### PR TITLE
fix: remove Dependabot skip from governance check

### DIFF
--- a/.github/workflows/governance-check.yml
+++ b/.github/workflows/governance-check.yml
@@ -10,7 +10,6 @@ on:
 
 jobs:
   governance-check:
-    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- Removes `if: github.actor != 'dependabot[bot]'` from the reusable governance-check workflow
- The skip condition caused the status check to never report for Dependabot PRs, blocking merges since the MAIN ruleset requires `governance-check / governance-check`
- The governance check already handles deps-only PRs gracefully (no code file changes detected = all checks pass)

## Test plan
- [ ] Merge this PR
- [ ] Retrigger CI on AIS Dependabot PRs (#609, #613, #614)
- [ ] Verify governance-check reports success

🤖 Generated with [Claude Code](https://claude.com/claude-code)