### PR TITLE
fix: skip infra doc check for Dependabot PRs

### DIFF
--- a/.github/workflows/governance-check.yml
+++ b/.github/workflows/governance-check.yml
@@ -178,7 +178,7 @@ jobs:
 
       # ── 7. Infrastructure changes → PROGRESS ──
       - name: Check infrastructure changes documented
-        if: steps.changed.outputs.has_infra == 'true'
+        if: steps.changed.outputs.has_infra == 'true' && github.actor != 'dependabot[bot]'
         run: |
           if [ "${{ steps.changed.outputs.has_progress }}" != "true" ]; then
             echo "::error::GOVERNANCE GATE FAILED: Infrastructure files changed but docs/PROGRESS.md was not updated."


### PR DESCRIPTION
## Summary
- Skip the infrastructure→PROGRESS.md co-staging check when `github.actor == 'dependabot[bot]'`
- Dependabot bumps GitHub Actions versions which changes `.github/workflows/` files, triggering the infra check
- Dependabot can't add PROGRESS.md entries, so the check always fails

## Test plan
- [ ] Merge, then retrigger AIS PR #613 (GitHub Actions bumps)
- [ ] Verify governance passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)