### PR TITLE
docs: close codex ingestion operationalization

### DIFF
--- a/OVERLORD_BACKLOG.md
+++ b/OVERLORD_BACKLOG.md
@@ -20,7 +20,6 @@
 
 | Item | Priority | Notes |
 |------|----------|-------|
-| Operationalize Codex ingestion review flow | HIGH | Issue [#46](https://github.com/NIBARGERB-HLDPRO/hldpro-governance/issues/46). Shared helper exists on `main`; current work is bounded-timeout hardening plus one more real governed-repo validation before enabling production sweep invocation. |
 | Governance doc consistency rollout — Sprint 1 | HIGH | Issue [#45](https://github.com/NIBARGERB-HLDPRO/hldpro-governance/issues/45). Shared standards + reusable governance checker. Define minimum contracts, enforce section presence, and codify AIS/HP exceptions before repo-local rewrites. |
 
 ### Sprint Breakdown — Governance Doc Consistency Rollout
@@ -74,6 +73,7 @@
 | Nightly overlord cleanup workflow | 2026-04-07 | Merged in PRs #13 and #15. Added nightly artifact cleanup + stale merged branch reporting. Validation issue: [#14](https://github.com/NIBARGERB-HLDPRO/hldpro-governance/issues/14). |
 | Codex subagent/persona routing baseline | 2026-04-07 | Updated shared standards and overlord docs so repo-required specialists can be satisfied with spawned Codex subagents/personas mapped from repo-local definitions. |
 | GitHub Actions Node 20 deprecation cleanup | 2026-04-07 | Merged in PR #18. Upgraded governance workflows from `actions/checkout@v4` to `actions/checkout@v6`; production sweep run `24059154210` completed without the prior Node 20 deprecation annotation. |
+| Operationalize Codex ingestion review flow | 2026-04-09 | Shared helper, auth probe, canary gate, bounded timeout, and stdin/schema review path were already live; a fresh governed-repo validation against `knocktracker` completed successfully and wrote `review-2026-04-09.json`, `qualified-2026-04-09.json`, and `backlog-2026-04-09.md` under a bounded temporary ingestion root. |
 | Living Knowledge Base — Phase 1 bootstrap | 2026-04-09 | graphify installed via Python 3.11, CLAUDE/settings pointers added in AIS, git hooks installed in the main AIS checkout, initial AIS code graph built (1883 nodes / 2533 edges / 111 communities), and graph artifacts synced into governance `graphify-out/` + `wiki/hldpro/`. |
 | Living Knowledge Base — Phase 2 dispatcher + wiki write-back | 2026-04-09 | `CLAUDE.md` now dispatches instead of answering directly, `wiki/index.md` is the pre-session entrypoint, and overlord agents/sweep are wired for governance-hosted graph/wiki reads and write-back. |
 | Living Knowledge Base — Phase 3 Karpathy Loop + closeout hook | 2026-04-09 | `raw/`, `wiki/`, closeout template, `closeout-hook.sh`, raw-feed sync, and weekly graph refresh/write-back are now implemented in governance. |

--- a/docs/FEATURE_REGISTRY.md
+++ b/docs/FEATURE_REGISTRY.md
@@ -36,6 +36,7 @@
 | GOV-009 | CLOSEOUT | Stage 6 closeout hook and template | COMPLETE | OPS_READY |
 | GOV-010 | RAW_FEEDS | Nightly GitHub issue feed sync via GitHub Actions | COMPLETE | INTERNAL_ONLY |
 | GOV-011 | ISSUE_BACKLOG_ALIGNMENT | Governance backlog must remain GitHub-issue-backed | COMPLETE | REQUIRED |
+| GOV-012 | CODEX_INGESTION | Codex second-opinion ingestion and backlog surfacing loop | COMPLETE | OPS_READY |
 
 ---
 
@@ -76,3 +77,4 @@
 | GOV-008 | `CLAUDE.md` rewritten as pure dispatcher — routes to overlord agents, never answers directly. Pre-session reads: `wiki/index.md` + `GRAPH_REPORT.md`. |
 | GOV-009 | `hooks/closeout-hook.sh` validates Stage 6 closeout template, triggers repo-local graph rebuild logic, and prompts for `operator_context` write-back. Template at `raw/closeouts/TEMPLATE.md`. |
 | GOV-010 | `raw-feed-sync.yml` fetches open GitHub issues from all governed repos daily, writes markdown summaries to `raw/github-issues/`. Initial snapshot files have been seeded locally for the bootstrap loop. |
+| GOV-012 | `scripts/overlord/codex_ingestion.py` now supports real governed-repo `generate`, `qualify`, `status`, and `promote` flows with bounded timeouts, precomputed diff context, CI auth/canary support, and session-start backlog surfacing. |

--- a/docs/plans/issue-46-codex-ingestion-pdcar.md
+++ b/docs/plans/issue-46-codex-ingestion-pdcar.md
@@ -1,0 +1,40 @@
+# Issue 46 — Codex Ingestion Operationalization PDCA/R
+
+Date: 2026-04-09
+Issue: `#46`
+Repo: `hldpro-governance`
+
+## Plan
+
+Verify whether the Codex ingestion helper and weekly sweep path still have a real production-readiness gap, or whether the remaining backlog item is now stale and only needs closeout.
+
+Success criteria:
+- prove a real governed-repo `generate -> qualify -> status` cycle completes under the current helper/runtime
+- confirm the weekly sweep already contains the canary/auth/timeout protections captured in fail-fast history
+- close the stale backlog note if no new code change is required
+
+## Do
+
+- inspect `scripts/overlord/codex_ingestion.py`, `scripts/overlord/README.md`, and `.github/workflows/overlord-sweep.yml`
+- run a real Codex review cycle against `knocktracker`
+- verify `review-*.json`, `qualified-*.json`, and `backlog-*.md` are written successfully
+- re-run `status` to confirm backlog surfacing works on the generated artifact set
+
+## Check
+
+- `python3 scripts/overlord/codex_ingestion.py generate --repo knocktracker ...`
+- `python3 scripts/overlord/codex_ingestion.py qualify --repo knocktracker ...`
+- `python3 scripts/overlord/codex_ingestion.py status --repo knocktracker ... --latest-only`
+- inspect the generated JSON/markdown artifacts under a bounded temporary ingestion root
+
+## Adjust
+
+- if validation succeeds, treat the remaining backlog note as stale and move the item to `Done`
+- if validation fails, log the exact new blocker in `docs/FAIL_FAST_LOG.md` and keep the issue open with the new root cause
+
+## Review
+
+Observed result:
+- the current helper completed a real `knocktracker` review cycle and wrote `review-2026-04-09.json`, `qualified-2026-04-09.json`, and `backlog-2026-04-09.md`
+- `status --latest-only` correctly surfaced the generated backlog file
+- no new runtime/auth blocker was discovered beyond the already-documented fail-fast history


### PR DESCRIPTION
## Summary
- add a PDCA/R closeout for governance issue #46
- move the stale Codex ingestion backlog note from `In Progress` to `Done`
- record the current Codex ingestion loop as an operational governance capability in the feature registry

## Validation
- real governed-repo validation completed against `knocktracker`
- generated `review-2026-04-09.json`, `qualified-2026-04-09.json`, and `backlog-2026-04-09.md`
- `status --latest-only` surfaced the generated backlog file correctly

## Issue
- Closes #46