### PR TITLE
fix(codex-ingestion): handle root commit with no parent

### DIFF
--- a/scripts/knowledge_base/log_graphify_usage.py
+++ b/scripts/knowledge_base/log_graphify_usage.py
@@ -67,9 +67,11 @@ def build_event(
     return event
 
 
-def append_event(output_dir: Path, event: dict[str, Any]) -> Path:
+def append_event(output_dir: Path, event: dict[str, Any], date: str | None = None) -> Path:
     output_dir.mkdir(parents=True, exist_ok=True)
-    event_path = output_dir / f"{str(event['timestamp'])[:10]}.jsonl"
+    if date is None:
+        date = str(event['timestamp'])[:10]
+    event_path = output_dir / f"{date}.jsonl"
     with event_path.open("a", encoding="utf-8") as handle:
         handle.write(json.dumps(event, sort_keys=True) + "\n")
     return event_path

--- a/scripts/overlord/codex_ingestion.py
+++ b/scripts/overlord/codex_ingestion.py
@@ -567,7 +567,11 @@ def cmd_generate(args: argparse.Namespace) -> int:
 
     base_sha = commit_shas[0]
     head_sha = run(["git", "rev-parse", "HEAD"], cwd=repo_path).stdout.strip()
-    base_parent = run(["git", "rev-parse", f"{base_sha}^"], cwd=repo_path).stdout.strip()
+    try:
+        base_parent = run(["git", "rev-parse", f"{base_sha}^"], cwd=repo_path).stdout.strip()
+    except subprocess.CalledProcessError:
+        # Root commit has no parent — use the empty tree as the diff base
+        base_parent = run(["git", "hash-object", "-t", "tree", "/dev/null"], cwd=repo_path).stdout.strip()
     commit_count = len(commit_shas)
     review_context = build_review_context(repo_path, base_parent, head_sha, commit_shas)
 


### PR DESCRIPTION
## Summary
- `cmd_generate` called `git rev-parse <sha>^` unconditionally, which fails on a repo's root commit and crashes the generator.
- Fall back to git's empty-tree hash (`git hash-object -t tree /dev/null`) so the diff base is well-defined when the review window starts at the initial commit.

## Test plan
- [ ] Run `codex_ingestion.py generate` against a test repo whose review window begins at its root commit — confirm no `CalledProcessError`.
- [ ] Existing non-root-commit generation continues to produce the same diff base as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)