### PR TITLE
chore: gitignore Claude Code local tooling dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,5 +38,8 @@ graphify-out/.graphify_*.json
 raw/**/*.mp3
 raw/**/*.wav
 
+# Claude Code local tooling state (worktrees, local settings)
+.claude/
+
 # OS
 .DS_Store


### PR DESCRIPTION
## Summary
- `.claude/` holds Claude Code per-checkout tooling state (session worktrees, local settings) and should never be committed.
- Added `.claude/` to `.gitignore` to silence `git status` noise and prevent accidental commits.

## Follow-up (not this PR)
- One outlier Claude worktree lives at `.claude/worktrees/graphify-improvement-codex-review` inside this repo, while convention puts all other worktrees at `../_worktrees/gov-*/`. Worth relocating in a separate cleanup.

## Test plan
- [ ] `git status` no longer shows `.claude/` as untracked

🤖 Generated with [Claude Code](https://claude.com/claude-code)