### PR TITLE
docs(windows-ollama): Sprint 5 closeout + epic wiki decision (missing artifacts)

### DIFF
--- a/raw/closeouts/2026-04-15-windows-ollama-sprint5.md
+++ b/raw/closeouts/2026-04-15-windows-ollama-sprint5.md
@@ -1,0 +1,149 @@
+# Sprint 5 Closeout — Windows-Ollama Tier-2 Rung Activation
+
+**Date:** 2026-04-15  
+**Epic:** Windows-Ollama SoM Tier-2 Integration (Phase 2)  
+**Sprint:** 5 (Final / Activation)  
+**Status:** COMPLETE  
+**PR:** #123 (merged a3f2a4a)
+
+## Objective
+
+Activate the Windows-Ollama Tier-2 Worker fallback rung from documented/disabled to ACTIVE state. Deliver the routing decision tree (`decide.sh`), close all 3 blocking exceptions, and complete the epic.
+
+## Acceptance Criteria — All Met
+
+### 1. Decision routing script
+- [x] `scripts/windows-ollama/decide.sh` implemented (109 lines, bash + Python stdlib)
+- [x] Decision priority: PII halts → spark primary → local → windows → cloud fallback
+- [x] Inputs: pii-flag, prompt-text/file, daemon statuses (all flags supported)
+- [x] Output: single line to stdout (LOCAL | WINDOWS | CLOUD | HALT); exit codes correct
+- [x] Stderr logging implemented for observability
+
+### 2. Test suite — all 8 cases passing
+- [x] test_decide.sh covers all 8 decision paths
+  - PII-yes + any other state → HALT (2 cases)
+  - PII-no + spark-ok → CLOUD (primary)
+  - PII-no + spark-blocked + local-up → LOCAL
+  - PII-no + spark-blocked + local-down + windows-ok → WINDOWS
+  - PII-no + spark-blocked + local-down + windows-down → CLOUD (fallback)
+  - Empty pii-flag defaults to "no"
+  - Spark-unknown with windows-ok → WINDOWS
+- [x] test_integration.sh E2E smoke test (skip-on-unreachable convention)
+
+### 3. STANDARDS.md activation
+- [x] Tier-2 ladder cell updated: Qwen → **Windows Ollama** → Sonnet (now ACTIVE)
+- [x] Removed "Sprint 5 deferral" markers from cell
+- [x] Cites `scripts/windows-ollama/decide.sh` as routing entry point
+- [x] References invariants #8–#10 enforcement
+
+### 4. Exception register — all 3 closed
+- [x] SOM-WIN-OLLAMA-PII-001 → CLOSED (Sprint 2 submit.py + Sprint 5 decide.sh)
+- [x] SOM-WIN-OLLAMA-AUDIT-001 → CLOSED (Sprint 3 audit.py + Sprint 4 CI)
+- [x] SOM-WIN-OLLAMA-DISABLED-001 → CLOSED (rung now ACTIVE)
+- [x] All closures justified with live control references
+- [x] Entries kept in file for audit trail
+
+### 5. Runbook update
+- [x] Removed "not approved for SoM routing" language
+- [x] Updated to: "Windows Ollama is an ACTIVE SoM Tier-2 Worker fallback as of Sprint 5 merge"
+- [x] New §Decision entry point documents decide.sh flags and output
+- [x] Updated §Audit and §PII gate sections to reflect active state
+- [x] Changelog entry added
+
+### 6. Code quality
+- [x] Bash syntax clean (bash -n on all three scripts)
+- [x] No net-new dependencies
+- [x] Scripts idempotent and pure (no side effects)
+- [x] All files parse cleanly
+
+## Test Results
+
+```
+test_decide.sh: 8/8 PASS ✓
+test_integration.sh: SKIP (exit 77) — Windows endpoint unreachable in CI (expected) ✓
+Bash lint: ✓ Clean
+CI gates: ✓ All pass (5 checks)
+```
+
+## Deliverables Summary
+
+| File | Type | Lines | Change |
+|---|---|---|---|
+| scripts/windows-ollama/decide.sh | new | 109 | Routing decision tree |
+| scripts/windows-ollama/tests/test_decide.sh | new | 87 | 8 unit tests |
+| scripts/windows-ollama/tests/test_integration.sh | new | 23 | E2E smoke test |
+| STANDARDS.md | modified | 271 | Tier-2 cell activated |
+| docs/exception-register.md | modified | 117 | 3 exceptions closed |
+| docs/runbooks/windows-ollama-worker.md | modified | 127 | Updated for active state |
+
+**Total additions:** 269 insertions  
+**Commit:** a3f2a4a (squash merge of feat/windows-ollama-sprint5)
+
+## Invariant Enforcement Status
+
+| # | Invariant | Control | Status |
+|---|---|---|---|
+| 8 | PII floor (Windows-Ollama) | submit.py (Sprint 2) + decide.sh (Sprint 5) | LIVE ✓ |
+| 9 | Firewall binding | check-windows-ollama-exposure.yml (Sprint 4) | LIVE ✓ |
+| 10 | Audit trail | audit.py (Sprint 3) + verify_audit.py (Sprint 3) + check-windows-ollama-audit-schema.yml (Sprint 4) | LIVE ✓ |
+
+## Epic Complete — All 5 Sprints
+
+| Sprint | PR | SHA | Artifact |
+|---|---|---|---|
+| 1 (Stage A) | #112 | 52cee63 | Standards + runbook + 3 exceptions seeded |
+| 2 (PII) | #116 | 9d3061d | submit.py + pii_patterns.yml + tests |
+| 3 (Audit) | #118 | 1cbc0c5 | audit.py + verify_audit.py + tests |
+| 4 (CI) | #121 | 4799ada | exposure + audit-schema validators |
+| **5 (Activate)** | **#123** | **a3f2a4a** | **decide.sh + 3 exception closures + activation** |
+
+## Tier-2 Ladder State (Final)
+
+```
+Tier 2 (Worker): gpt-5.3-codex-spark (high) →[fallback 1]→ gpt-5.3-codex-spark (medium) →[fallback 2]→
+  mlx-community/Qwen2.5-Coder-7B-Instruct-4bit (local warm daemon) 
+  →[spark blocked & local down]→ Windows Ollama (http://172.17.227.49:11434, qwen2.5-coder:7b)
+  →[windows down]→ claude-sonnet-4-6 (cost-flagged)
+
+Routing via: scripts/windows-ollama/decide.sh
+Exceptions closed: ALL (3/3)
+Status: ACTIVE ✓
+```
+
+## Memory / Feedback Updates
+
+**Recommended update to memory:**
+
+> **Windows-Ollama Tier-2 ladder now active** (as of 2026-04-15 Sprint 5 merge).
+> 
+> Tier-2 Worker fallback chain:
+> 1. gpt-5.3-codex-spark (primary, high effort)
+> 2. gpt-5.3-codex-spark (medium effort if spark high is quota-blocked)
+> 3. mlx-community/Qwen2.5-Coder-7B-Instruct-4bit (local warm daemon on Mac)
+> 4. **Windows Ollama** (http://172.17.227.49:11434, qwen2.5-coder:7b, routed via scripts/windows-ollama/decide.sh, PII halts at entry point)
+> 5. claude-sonnet-4-6 (cost-flagged final fallback)
+>
+> PII invariant #8: All payloads validated against pii_patterns.yml. PII-flagged payloads halt, never route to Windows or cloud.
+> Audit invariant #10: All calls appended to raw/remote-windows-audit/YYYY-MM-DD.jsonl with hash-chain + HMAC + daily manifest.
+> Firewall invariant #9: LAN-only, sase-switch vEthernet adapter (172.17.0.0/16 subnet).
+
+## Phase 3 Future Epics (Queued)
+
+The following epics remain in backlog, queued for Phase 3 (post Sprint 5):
+
+- **Cloudflare Tunnel exposure** (Issue TBD) — Remote access via Cloudflare Access (out-of-band from SoM routing)
+- **Wake-on-LAN provisioning** (Issue TBD) — Auto-boot + magic-packet sender (ops convenience, not security-critical)
+- **Health-check workflow** (Issue TBD) — Periodic CI ping to flag endpoint outages (observability)
+
+These were planned in the original epic but deferred to Phase 3 per SoM charter. No blockers.
+
+## Sign-Off
+
+- **Orchestrator:** Haiku Orchestrator (Claude Haiku 4.5)
+- **Worker:** Claude Sonnet 4.6 (Tier-2 implementation per fallback #5)
+- **Reviewer:** gpt-5.4 (cross-review, Tier-3)
+- **Gate:** claude-haiku-4-5-20251001 (Tier-4 verification)
+
+**Status:** EPIC COMPLETE ✓
+
+All acceptance criteria met. All 3 exceptions closed. Windows-Ollama Tier-2 rung is now ACTIVE. Epic ready for wiki write-back and memory update.

--- a/raw/closeouts/2026-04-15-windows-ollama-sprint5.md
+++ b/raw/closeouts/2026-04-15-windows-ollama-sprint5.md
@@ -147,3 +147,5 @@ These were planned in the original epic but deferred to Phase 3 per SoM charter.
 **Status:** EPIC COMPLETE ✓
 
 All acceptance criteria met. All 3 exceptions closed. Windows-Ollama Tier-2 rung is now ACTIVE. Epic ready for wiki write-back and memory update.
+
+*Post-merge addendum: Sprint 6 (PR #129) remediated an invariant #8 PII regression introduced in Sprint 5. See `raw/closeouts/2026-04-15-windows-ollama-sprint6.md`.*

--- a/wiki/decisions/2026-04-15-windows-ollama-epic-complete.md
+++ b/wiki/decisions/2026-04-15-windows-ollama-epic-complete.md
@@ -95,3 +95,5 @@ These do not block the rung activation and are deferred per SoM charter Phase 3 
 ## Status
 
 **DECISION FINAL:** Epic complete. Windows-Ollama Tier-2 rung is ACTIVE. All invariants enforced. All tests passing. Ready for production routing.
+
+*Post-merge addendum: Sprint 6 (PR #129) remediated an invariant #8 PII regression introduced in Sprint 5. See `raw/closeouts/2026-04-15-windows-ollama-sprint6.md`.*

--- a/wiki/decisions/2026-04-15-windows-ollama-epic-complete.md
+++ b/wiki/decisions/2026-04-15-windows-ollama-epic-complete.md
@@ -1,0 +1,97 @@
+# Decision: Windows-Ollama Epic Complete — Tier-2 Rung Activated (2026-04-15)
+
+**Date:** 2026-04-15  
+**Authority:** Haiku Orchestrator + Tier-2 Worker (Sonnet 4.6) + Tier-3 Reviewer (gpt-5.4) + Tier-4 Gate (Haiku)  
+**Scope:** Governance — Society of Minds routing standard  
+**Epic:** Windows-Ollama SoM Tier-2 Integration (Phase 2)  
+
+## Context
+
+The Windows-Ollama Tier-2 Worker fallback underwent a 5-sprint integration phase to transition from documented/disabled to ACTIVE:
+
+1. **Sprint 1 (Stage A, PR #112):** Standards + runbook documentation + 3 blocking exceptions seeded
+2. **Sprint 2 (PR #116):** PII middleware (submit.py + pii_patterns.yml validation)
+3. **Sprint 3 (PR #118):** Audit trail (audit.py + verify_audit.py + hash-chain + HMAC + manifest)
+4. **Sprint 4 (PR #121):** CI validation workflows (exposure + audit-schema gates)
+5. **Sprint 5 (PR #123):** Routing decision tree (decide.sh) + all 3 exceptions closed + rung activation
+
+## Decision
+
+**The Windows-Ollama Tier-2 Worker fallback is now ACTIVE.**
+
+The rung transitions from documented/disabled to active status in the Society of Minds Tier-2 ladder. All three invariant controls (#8 PII floor, #9 firewall binding, #10 audit trail) are live end-to-end.
+
+### Rationale
+
+**Invariant #8 (PII floor):** PII-patterns.yml middleware active in submit.py (Sprint 2) + decide.sh routing gate (Sprint 5) enforces: PII-flagged payloads → HALT (never route to Windows or cloud).
+
+**Invariant #9 (firewall binding):** check-windows-ollama-exposure.yml CI gate (Sprint 4) enforces: endpoint bound to LAN-only via sase-switch vEthernet (172.17.0.0/16 subnet), no public bind, no port-forwarding.
+
+**Invariant #10 (audit trail):** audit.py (Sprint 3) + verify_audit.py (Sprint 3) + check-windows-ollama-audit-schema.yml (Sprint 4) enforce: all Windows-Ollama calls appended to raw/remote-windows-audit/YYYY-MM-DD.jsonl with hash-chain + HMAC + daily manifest. Broken chain → CI validator fails, endpoint disabled until chain rebuilt.
+
+### Decision Tree
+
+The `scripts/windows-ollama/decide.sh` routing script implements the Tier-2 ladder priority:
+
+```
+1. PII halts first (invariant #8)
+2. If spark-ok → CLOUD (spark is primary, skip ladder)
+3. Else if local-up → LOCAL (Qwen2.5 on Mac)
+4. Else if windows-ok → WINDOWS (this rung)
+5. Else → CLOUD (Sonnet cost-flagged fallback)
+```
+
+All 8 decision states tested + pass. Integration test skips (exit 77) if Windows unreachable (CI environment expected).
+
+### Exceptions Closed
+
+All 3 blocking exceptions now closed:
+
+- **SOM-WIN-OLLAMA-PII-001:** PII middleware fully enforced via Sprint 2 + 5 controls
+- **SOM-WIN-OLLAMA-AUDIT-001:** Audit trail fully enforced via Sprint 3 + 4 controls  
+- **SOM-WIN-OLLAMA-DISABLED-001:** Rung activation gate met; status changed from disabled to active
+
+Entries retained in exception-register.md for audit trail.
+
+## Tier-2 Ladder (Final)
+
+```
+Primary: gpt-5.3-codex-spark @ high
+├─ Fallback 1: gpt-5.3-codex-spark @ medium
+└─ Fallback 2: mlx-community/Qwen2.5-Coder-7B-Instruct-4bit (local warm daemon)
+   └─ [if spark blocked & local down]
+      └─ Windows Ollama (http://172.17.227.49:11434, qwen2.5-coder:7b)
+         └─ [if windows down]
+            └── claude-sonnet-4-6 (cost-flagged final fallback)
+```
+
+**Routing:** `scripts/windows-ollama/decide.sh` (CLI entry point)
+
+## Implications
+
+1. **Usage:** Tier-2 Worker jobs may now automatically route to Windows-Ollama if spark is blocked and local Mac is memory-tight.
+2. **Observability:** All Windows-Ollama calls audited in raw/remote-windows-audit/. Audit chain failures block CI.
+3. **PII Safety:** PII-flagged payloads halt at decide.sh entry point — never reach Windows endpoint or cloud.
+4. **Memory Update:** Feedback_codex_spark_specialist.md should note the 4-rung Tier-2 ladder (spark → local Qwen → Windows Ollama → Sonnet).
+
+## Cross-References
+
+- STANDARDS.md §Society of Minds §Tier 2 (Worker) — row updated to show ACTIVE rung
+- STANDARDS.md §Windows Host Inference — invariants #8–#10 live
+- docs/exception-register.md — 3 entries marked CLOSED
+- docs/runbooks/windows-ollama-worker.md — updated for active state + decide.sh interface
+- raw/closeouts/2026-04-15-windows-ollama-sprint5.md — detailed acceptance + test evidence
+
+## Phase 3 Future Work
+
+The following epics remain queued (no blockers):
+
+- **Cloudflare Tunnel exposure** — Remote access via Cloudflare Access
+- **Wake-on-LAN provisioning** — Auto-boot + magic-packet convenience
+- **Health-check workflow** — Periodic CI ping for observability
+
+These do not block the rung activation and are deferred per SoM charter Phase 3 sequencing.
+
+## Status
+
+**DECISION FINAL:** Epic complete. Windows-Ollama Tier-2 rung is ACTIVE. All invariants enforced. All tests passing. Ready for production routing.


### PR DESCRIPTION
## Summary

- Adds `raw/closeouts/2026-04-15-windows-ollama-sprint5.md` — Sprint 5 closeout (was missing from main; Sprint 6 closeout was present but Sprint 5's was not)
- Adds `wiki/decisions/2026-04-15-windows-ollama-epic-complete.md` — epic-complete wiki decision artifact
- Both artifacts include a one-line post-merge addendum pointing to the Sprint 6 PII remediation closeout

## Context

This branch originally tracked Windows-Ollama backlog updates across 4 commits, all of which were superseded by main's merged state. After rebasing onto origin/main, only these 2 artifacts carried forward as genuinely missing from main.

## Test plan

- [ ] CI passes (docs-only change, no code)
- [ ] `raw/closeouts/2026-04-15-windows-ollama-sprint5.md` present and references correct PRs/SHAs
- [ ] `wiki/decisions/2026-04-15-windows-ollama-epic-complete.md` present and consistent with closeout
- [ ] Sprint 6 addendum line present in both files

🤖 Generated with [Claude Code](https://claude.com/claude-code)