### PR TITLE
docs(windows-ollama): file missing Sprint 3 closeout + wiki decision

### DIFF
--- a/raw/closeouts/2026-04-15-windows-ollama-sprint3.md
+++ b/raw/closeouts/2026-04-15-windows-ollama-sprint3.md
@@ -1,0 +1,150 @@
+# Stage 6 Closeout — Windows-Ollama Sprint 3
+
+**Date:** 2026-04-15  
+**Issue:** #117 (Windows-Ollama epic Stage Sprint 3 — Audit Trail)  
+**Repo:** hldpro-governance  
+**Branch:** feat/windows-ollama-sprint3 (commit 1cbc0c5, merged into main)  
+**Completed by:** claude-haiku-4-5-20251001 (Tier-2 orchestrator + worker authorship) + cross-review verification  
+
+## Sprint 3 Scope
+
+Implement a tamper-evident audit trail for Windows-Ollama submissions (Tier-2 Worker endpoint at 172.17.227.49:11434). The audit system mirrors the Remote MCP Bridge audit format with hash-chain integrity, per-entry HMAC-SHA256 signatures, daily manifest validation, and standalone verifier. All submission paths (success, PII reject, model deny, endpoint error) emit exactly one audit entry.
+
+## PDCAR Stage
+
+**Stage 3 (Check) — Audit Infrastructure**  
+This is a Stage 3 deliverable: runtime instrumentation and tamper detection for Tier-2 Worker submissions.
+
+## Artifacts Delivered
+
+### hldpro-governance (merged PR #118)
+
+1. **`scripts/windows-ollama/audit.py`** (245 lines)
+   - AuditWriter class: append-only writer with daily JSONL logs + manifest
+   - Canonical JSON per spec: `sort_keys=True, separators=(',',':'), ensure_ascii=False`
+   - Per-entry HMAC-SHA256 over entry dict (key from env `SOM_WINDOWS_AUDIT_HMAC_KEY`)
+   - Hash-chain: prev_hash = SHA256(prev_entry_canonical_json); entry 0 = zero
+   - Daily manifest: `{first_hash, last_hash, entry_count, sha256_of_file}`
+   - File permissions: 0o600; macOS append-only flag via chflags (graceful fallback)
+   - Entry fields: ts, seq, prev_hash, principal, session_jti, tool, args_hmac, status, reject_reason, latency_ms, entry_hmac
+
+2. **`scripts/windows-ollama/verify_audit.py`** (196 lines)
+   - Standalone CLI verifier: `verify_audit.py <audit_dir>`
+   - Validates schema (required fields), seq monotonicity, hash-chain continuity, HMAC validity, manifest consistency
+   - Graceful HMAC bypass: if env key not set, warns to stderr, skips HMAC verification but continues schema checks
+   - Exit codes: 0 (pass), 1 (fail)
+
+3. **`scripts/windows-ollama/tests/test_audit.py`** (236 lines)
+   - 5 negative tests:
+     - TestAuditChainIntegrity::test_tamper_line_breaks_chain — tampers line N, verifier detects mismatch at N+1
+     - TestHmacForgery::test_hmac_forgery_detected — replaces entry_hmac with bad hash, verifier rejects
+     - TestManifestMismatch::test_manifest_first_hash_mismatch — modifies manifest, verifier detects inconsistency
+     - TestFileTruncation::test_file_truncation_detected — deletes last line, verifier detects entry_count mismatch
+     - TestReplay::test_duplicate_line_detected — duplicates line, verifier detects seq non-monotonicity
+   - All 5 tests PASS
+
+4. **`scripts/windows-ollama/submit.py`** (449 lines, +50 from integration)
+   - Import audit.AuditWriter
+   - submit() method extended with principal, session_jti parameters
+   - All paths write exactly one audit entry:
+     - PII explicit flag: status='rejected', reject_reason='explicit_pii_flag'
+     - PII detected: status='rejected', reject_reason='pii_detected'
+     - Model not allowed: status='rejected', reject_reason='model_not_allowed'
+     - Endpoint unreachable: status='error', reject_reason='endpoint_unreachable'
+     - Success: status='ok', reject_reason=null
+   - Latency timing: request duration recorded in latency_ms
+   - Prompt redaction: "[REDACTED]" in audit args_dict (security best practice)
+
+5. **`scripts/windows-ollama/tests/test_submit.py`** (359 lines, +100 audit integration)
+   - 5 new audit integration tests:
+     - TestAuditIntegration::test_audit_entry_on_success
+     - TestAuditIntegration::test_audit_entry_on_pii_detection
+     - TestAuditIntegration::test_audit_entry_on_explicit_pii_flag
+     - TestAuditIntegration::test_audit_entry_on_model_not_allowed
+     - TestAuditIntegration::test_audit_entry_on_endpoint_unreachable
+   - All tests verify audit.write_entry() called once with correct status/reject_reason
+   - Plus 16 existing tests (PII detection, model allowlist, endpoint reachability, error structures)
+   - All 21 tests PASS
+
+6. **Artifacts**
+   - `raw/cross-review/2026-04-15-windows-ollama-sprint3.md` — verification document covering chain integrity, HMAC validity, manifest consistency, integration coverage
+   - `raw/gate/2026-04-15-windows-ollama-sprint3.md` — gate review (PASS)
+   - `raw/model-fallbacks/2026-04-14.md` — fallback log entry (Sonnet used after spark quota blocked)
+
+## Test Results
+
+**pytest output (21/21 PASS)**:
+```
+TestPiiDetection: 4 PASS
+TestModelAllowlist: 2 PASS
+TestEndpointReachability: 3 PASS
+TestMalformedResponse: 2 PASS
+TestEmptyRationale: 2 PASS
+TestErrorStructure: 3 PASS
+TestAuditIntegration: 5 PASS (NEW)
+```
+
+**Negative audit tests (5/5 PASS)**:
+```
+TestAuditChainIntegrity::test_tamper_line_breaks_chain: PASS
+TestHmacForgery::test_hmac_forgery_detected: PASS
+TestManifestMismatch::test_manifest_first_hash_mismatch: PASS
+TestFileTruncation::test_file_truncation_detected: PASS
+TestReplay::test_duplicate_line_detected: PASS
+```
+
+**CI Status**: CLEAN (passed CodeQL, graphify-governance-contract workflows)
+
+## Decisions Made
+
+1. **Hash-chain as primary tamper detection** — Each entry includes prev_hash of previous entry. Chain breaks immediately on any line deletion, reordering, or modification. Seq monotonicity enforces replay prevention.
+
+2. **Dual-key HMAC** — args_hmac computed over tool arguments; entry_hmac computed over entire entry (all fields except entry_hmac itself). Prevents both argument forgery and entry forgery.
+
+3. **Daily manifest** — Manifest file contains first_hash, last_hash, entry_count, file_sha256. Allows offline verification of log completeness and integrity without re-reading entire file.
+
+4. **Graceful key bypass** — If SOM_WINDOWS_AUDIT_HMAC_KEY env var not set, HMAC fields remain null; schema validation continues. Allows testing without key infrastructure.
+
+5. **Append-only flag (best effort)** — macOS chflags uappnd if enable_append_only=True. Gracefully degrades on systems without support. Tests disable via enable_append_only=False.
+
+6. **Prompt redaction in audit** — Prompts stored as "[REDACTED]" in args_dict. Prevents accidental data leakage in audit logs while preserving submission metadata.
+
+## No Scope Creep
+
+- No Tier-2 ladder activation (reserved for Sprint 5)
+- No STANDARDS.md edits
+- No runbook modifications
+- No changes to pii_patterns.yml or model_allowlist.yml
+- No architectural changes beyond audit instrumentation
+
+## Compliance
+
+- ✓ Matches Remote MCP Bridge audit format (canonical JSON, hash-chain, per-entry HMAC, daily manifest per spec §107-132)
+- ✓ Stdlib-only (no new dependencies)
+- ✓ Python 3.11 compatible
+- ✓ All test paths covered (success + 4 reject paths)
+- ✓ HMAC uses hmac.compare_digest() for safe comparison
+- ✓ No key logging or accidental exposure
+- ✓ Exit codes consistent with submit.py (0=success, 1=rejection, 2=error)
+
+## Follow-Up Items
+
+None required for Sprint 3. Sprint 4 (PII scrubbing handler) and Sprint 5 (Tier-2 ladder) will reference this audit trail.
+
+## Links To
+
+- Issue: [#117](https://github.com/NIBARGERB-HLDPRO/hldpro-governance/issues/117)
+- PR: [#118](https://github.com/NIBARGERB-HLDPRO/hldpro-governance/pull/118) (merged commit 1cbc0c5)
+- Cross-review artifact: `raw/cross-review/2026-04-15-windows-ollama-sprint3.md`
+- Gate artifact: `raw/gate/2026-04-15-windows-ollama-sprint3.md`
+- Remote MCP Bridge spec: `_worktrees/gov-remote-mcp/raw/inbox/2026-04-14-remote-mcp-bridge-plan.md` (§107-132)
+
+## Success Metrics
+
+- ✓ 5/5 negative audit tests pass (chain, HMAC, manifest, truncation, replay)
+- ✓ 21/21 pytest tests pass (16 existing + 5 audit integration)
+- ✓ 100% audit integration coverage (all 5 submission paths tested)
+- ✓ CI green (CLEAN merge status)
+- ✓ 0 scope creep (no ladder, standards, or runbook changes)
+- ✓ Cross-review APPROVED
+- ✓ Gate PASS

--- a/wiki/decisions/2026-04-15-windows-ollama-sprint3.md
+++ b/wiki/decisions/2026-04-15-windows-ollama-sprint3.md
@@ -1,0 +1,131 @@
+# Decision: Windows-Ollama Audit Trail (Sprint 3)
+
+**Date:** 2026-04-15  
+**Decision ID:** WINDOWS-OLLAMA-AUDIT-001  
+**Epic:** [#99 Society of Minds](https://github.com/NIBARGERB-HLDPRO/hldpro-governance/issues/99) → [#117 Windows-Ollama Stage Sprint 3](https://github.com/NIBARGERB-HLDPRO/hldpro-governance/issues/117)  
+**Related SoM Charter:** STANDARDS.md § Society of Minds
+
+## Summary
+
+Windows-Ollama Tier-2 Worker submissions now emit tamper-evident audit trails with hash-chain integrity, per-entry HMAC-SHA256 signatures, and daily manifest validation. The audit system mirrors the Remote MCP Bridge audit format and allows both real-time and forensic verification of submission integrity.
+
+## Decision
+
+**All submission paths to Windows-Ollama must write exactly one audit entry to `raw/remote-windows-audit/YYYY-MM-DD.jsonl` with:**
+
+1. **Sequence**: Monotonic from 0 within each day
+2. **Hash chain**: prev_hash = SHA256(previous_entry_canonical_json); entry 0 = zero
+3. **HMAC signing**: entry_hmac = HMAC-SHA256(key, entry_canonical_json) over all fields except entry_hmac itself
+4. **Daily manifest**: `YYYY-MM-DD.manifest.json` with first_hash, last_hash, entry_count, sha256_of_file
+5. **File integrity**: 0o600 permissions; append-only flag where OS supports
+6. **Submission metadata**: ts, principal, session_jti, tool, status, reject_reason, latency_ms
+
+## Rationale
+
+### Tamper Detection
+
+Hash-chain (prev_hash) ensures any deletion, reordering, or line modification breaks the chain. Seq monotonicity prevents replay attacks. HMAC prevents entry forgery. Manifest consistency check validates completeness without re-reading entire log.
+
+### SoM Integration
+
+This decision implements the "hard-rule invariant #5" from STANDARDS.md § Society of Minds: "All Tier-2 submission paths write audit entries." The audit trail feeds the SoM Reviewer tier (Tier-3) for post-hoc verification of Worker behavior.
+
+### Real-Time + Forensic Verification
+
+- **Real-time**: verify_audit.py CLI can validate daily logs at any time
+- **Forensic**: Hash-chain and HMAC preserve evidence of tampering; CI workflows can enforce manifest consistency as a hard gate
+
+### Graceful Degradation
+
+- If HMAC key not available, audit continues with null fields (schema preserved)
+- If append-only flag not supported, logs default to regular file (still append-only via OS buffer semantics)
+- Tests disable append-only to allow rewrites; production enables it
+
+## Specification
+
+### Entry Schema
+
+```json
+{
+  "ts": "2026-04-15T04:40:03.045Z",
+  "seq": 0,
+  "prev_hash": "0000000000000000000000000000000000000000000000000000000000000000",
+  "principal": "<sub>",
+  "session_jti": "<jti>",
+  "tool": "windows-ollama.submit",
+  "args_hmac": "hmac-sha256(key, canonical_json(args))",
+  "status": "ok|rejected|error",
+  "reject_reason": "pii_detected|model_not_allowed|endpoint_unreachable|...",
+  "latency_ms": 42,
+  "entry_hmac": "hmac-sha256(key, canonical_json(entry_without_entry_hmac))"
+}
+```
+
+### Canonical JSON
+
+```python
+json.dumps(obj, sort_keys=True, separators=(',',':'), ensure_ascii=False).encode('utf-8')
+```
+
+### Daily Manifest
+
+```json
+{
+  "first_hash": "sha256_of_first_entry_canonical_json",
+  "last_hash": "sha256_of_last_entry_canonical_json",
+  "entry_count": 42,
+  "sha256_of_file": "sha256_of_entire_jsonl_file"
+}
+```
+
+### Submission Paths
+
+| Path | Status | reject_reason | Example |
+|------|--------|---------------|---------|
+| Success | ok | null | Generated response returned |
+| PII (explicit) | rejected | explicit_pii_flag | has_pii=True |
+| PII (detected) | rejected | pii_detected | Pattern match in prompt |
+| Model denied | rejected | model_not_allowed | Model not in allowlist |
+| Endpoint error | error | endpoint_unreachable | Connection refused |
+
+## Implementation
+
+- **audit.py**: AuditWriter class (append-only JSONL + manifest writer)
+- **verify_audit.py**: Standalone verifier (CLI tool for validation)
+- **submit.py integration**: Calls audit.write_entry() on all paths
+- **test_audit.py**: 5 negative tests (tamper detection, HMAC forgery, manifest mismatch, truncation, replay)
+- **test_submit.py**: 5 audit integration tests (coverage of all submission paths)
+
+## Dependencies
+
+- Python 3.11+
+- Stdlib only (hashlib, hmac, json, pathlib, datetime)
+- HMAC key from env `SOM_WINDOWS_AUDIT_HMAC_KEY` (optional; graceful bypass if absent)
+
+## Success Criteria
+
+- ✓ All submission paths emit exactly one audit entry
+- ✓ Hash-chain validates (no tampering detected in passing tests)
+- ✓ HMAC validates (forgery detected in negative tests)
+- ✓ Manifest validates (file completeness verified)
+- ✓ 100% test coverage of all paths (21/21 pytest + 5/5 negative tests)
+- ✓ CI green on merge
+
+## References
+
+- Remote MCP Bridge audit spec: `_worktrees/gov-remote-mcp/raw/inbox/2026-04-14-remote-mcp-bridge-plan.md` (§107-132)
+- SoM hard-rule invariants: STANDARDS.md § Society of Minds (invariant #5)
+- Sprint 3 PR: [#118](https://github.com/NIBARGERB-HLDPRO/hldpro-governance/pull/118)
+- Closeout: `raw/closeouts/2026-04-15-windows-ollama-sprint3.md`
+
+## Related Decisions
+
+- [#99 Society of Minds Epic](https://github.com/NIBARGERB-HLDPRO/hldpro-governance/issues/99) — Tier routing and cross-family validation
+- [#106 Packet Schema + Validator](https://github.com/NIBARGERB-HLDPRO/hldpro-governance/issues/102) — Deterministic handoff validation
+- [#117 Windows-Ollama Sprint 3](https://github.com/NIBARGERB-HLDPRO/hldpro-governance/issues/117) — This decision
+
+## Transition Plan
+
+**Sprint 4** (PII scrubbing handler): Will consume audit entries to identify high-frequency PII patterns for retraining pii_patterns.yml.
+
+**Sprint 5** (Tier-2 ladder): Will use audit entries as evidence for Worker promotion/demotion decisions.


### PR DESCRIPTION
## Summary
- Rescues 2 governance artifacts that were drafted on `docs/windows-ollama-sprint3-closeout` but never landed on `main`:
  - `raw/closeouts/2026-04-15-windows-ollama-sprint3.md` (150 lines)
  - `wiki/decisions/2026-04-15-windows-ollama-sprint3.md` (131 lines)
- Complements the Sprint 3 artifacts already on main under `raw/cross-review/` and `raw/gate/`, closing the paperwork gap.
- Drops the source branch's 1-line `OVERLORD_BACKLOG.md` edit: main's backlog has since evolved to consolidate Windows-Ollama into a single "6 sprints epic" row, so a per-sprint append would conflict with that structure.

## Context
Follows the same artifact-gap remediation pattern as PR #130 (Sprint 6 remediation) and the parallel Sprint 5 rescue. Parallel gaps appear to exist for **Sprint 2 closeout/wiki** and **Sprint 5 wiki** — flagged here as potential follow-up, intentionally **out of scope** for this PR.

## Test plan
- [ ] CI green on this branch (schema + pin checks shouldn't fire — docs-only change)
- [ ] `git show --stat` shows exactly 2 new files, 281 insertions, 0 deletions
- [ ] Closeout file conforms to `raw/closeouts/TEMPLATE.md`
- [ ] Wiki decision file lands under `wiki/decisions/` with correct date-prefix naming
- [ ] Post-merge: confirm `graphify-out/hldpro-governance/GRAPH_REPORT.md` picks up the new nodes on next cycle

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>