### PR TITLE
chore(governance): tighten .gitignore and commit UserPromptSubmit settings

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash $HOME/Developer/HLDPRO/hldpro-governance/hooks/pre-session-context.sh",
+            "timeout": 5000
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -13,9 +13,9 @@ downloads/
 backups/
 
 # Sensitive
-settings.json
-settings.local.json
-scheduled_tasks.lock
+.claude/worktrees/
+.claude/scheduled_tasks.lock
+.claude/settings.local.json
 
 # Per-project memory (conversation-specific, managed by auto-memory)
 projects/


### PR DESCRIPTION
Part of #154 (Sprint 1).

## Summary
- Tightens `.gitignore` in the Sensitive section: drops blanket `settings.json` / `settings.local.json` / `scheduled_tasks.lock` entries in favor of three `.claude/`-path-scoped entries (`.claude/worktrees/`, `.claude/scheduled_tasks.lock`, `.claude/settings.local.json`).
- Commits `.claude/settings.json` wiring `UserPromptSubmit → hooks/pre-session-context.sh`. Existing hook script unchanged.

## Why
The broad `settings.json` rule was swallowing `.claude/settings.json`, preventing the pre-session-context wiring from propagating to fresh clones.

## Scope
2 files. No behavior change to `hooks/pre-session-context.sh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)