### PR TITLE
feat(overlord): audit_remote.sh helper + dispatch brief template + verify-completion patch (closes #160)

### DIFF
--- a/agents/verify-completion.md
+++ b/agents/verify-completion.md
@@ -81,6 +81,18 @@ Your job: check every repo against ~/.claude/STANDARDS.md and report PASS or FAI
 
 4. **Cross-reference with plan**: If a plan file exists in the conversation, verify every "create" or "add" line item has a corresponding artifact.
 
+## Remote-reading preferred
+
+When checking a single file on remote main, ALWAYS call the governance helper instead of reading local working tree:
+
+```bash
+bash scripts/overlord/audit_remote.sh <repo> <path>
+```
+
+**Why:** 2026-04-15 incident — verify-completion audit read stale local checkouts (AIS on dirty feature branch, knocktracker 29 behind origin/main, HP detached HEAD with 100 WIP commits) and reported phantom SoM-pointer gaps in 3 repos that already had the section. See feedback memories `feedback_audit_must_read_remote_head.md` and `feedback_codex_worktree_base_contamination.md`.
+
+**How to apply:** for every single-file compliance check (e.g., "does CLAUDE.md on repo X have section Y?"), use the helper. Keep the worktree-based pattern in `## Process` for multi-file structural audits only.
+
 ## Output Format
 
 ```

--- a/docs/templates/codex-spark-dispatch-brief.md
+++ b/docs/templates/codex-spark-dispatch-brief.md
@@ -1,0 +1,76 @@
+## Preflight
+
+Run this first and include the full command output in your session notes:
+
+```bash
+bash scripts/codex-preflight.sh --log
+```
+
+Do not start the issue slice until preflight completes with PASS.
+
+## Worktree discipline (HARD GATE)
+
+Create and verify worktrees exactly as below before any commit:
+
+```bash
+cd ~/Developer/HLDPRO/<repo>
+git fetch origin main
+git worktree add -b <branch-name> /tmp/<worktree-name> origin/main
+cd /tmp/<worktree-name>
+git log --oneline origin/main..HEAD   # HARD GATE: must be empty before first commit
+```
+
+If `git log --oneline origin/main..HEAD` shows any lines, HALT and re-create the worktree from a fresh `origin/main`.
+
+## Non-destructive editing
+
+For committed JSON settings (`.claude/settings.json`), use JSON-merge updates only; never overwrite the file wholesale.
+For `.gitignore`, apply minimal surgical patches that preserve existing generated lines.
+For CLAUDE.md-style docs, use append-only updates at the end of the file unless a full rewrite is explicitly requested.
+
+Use issue #154 as prior art for this exact edit discipline and audit trail.
+
+## Diff scope cap
+
+Per-sprint `file_paths` are enforced. Do not modify anything outside the current sprint’s declared files.
+If `git diff --name-only origin/main..HEAD` shows a fourth file, immediately HALT and report the violation.
+
+## No push / no gh
+
+Codex-spark is a local executor with no remote network operations in this environment.
+Do not run `git push`, do not call `gh` for remote ops, and do not open PRs.
+See `feedback_codex_spark_no_network.md`.
+
+## Report format
+
+At each handoff, include:
+
+- branch name
+- worktree path
+- `git log --oneline origin/main..HEAD`
+- `git diff --name-only origin/main..HEAD`
+- blockers (if any)
+
+## Example usage
+
+Issue #154 — Pre-session hook standardization
+
+- Branch: `issue-154-pre-session-hook`
+- Worktree: `/tmp/issue-154-pre-session-hook`
+- Start command:
+
+```bash
+cd ~/Developer/HLDPRO/hldpro-governance
+git fetch origin main
+git worktree add -b issue-154-pre-session-hook /tmp/issue-154-pre-session-hook origin/main
+cd /tmp/issue-154-pre-session-hook
+git log --oneline origin/main..HEAD
+```
+
+- Verified log: `<empty>`
+- H2 sections written: Preflight, Worktree discipline, Non-destructive editing, Diff scope cap, No push / no gh, Report format
+- 1st sprint files: `agents/pre-session.md`, `agents/pre-session-hook.md`
+- 2nd sprint file: `docs/templates/codex-spark-dispatch-brief.md`
+- 3rd sprint file: `docs/agents.md`
+- Reported blockers: none
+- Diff scope after completion: exactly the files declared by each sprint

--- a/scripts/overlord/audit_remote.sh
+++ b/scripts/overlord/audit_remote.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Usage: audit_remote.sh <repo> <path> [ref] (default ref=main)
+# Fetches repos/NIBARGERB-HLDPRO/<repo>/contents/<path>?ref=<ref> via gh api.
+# Decodes the `.content` field with base64 -d and prints to stdout.
+# Exit 1: repository/path/ref not found.
+# Exit 2: any other fetch/decode failure.
+set -eu -o pipefail
+
+repo=${1:?Usage: audit_remote.sh <repo> <path> [ref]}
+path=$2
+ref=${3:-main}
+
+if ! api_resp=$(gh api "repos/NIBARGERB-HLDPRO/${repo}/contents/${path}?ref=${ref}" 2>&1); then
+  if printf '%s' "$api_resp" | grep -qE '"status":\s*404|"Not Found"|404'; then
+    echo "{\"error\":\"not-found\",\"repo\":\"${repo}\",\"path\":\"${path}\",\"ref\":\"${ref}\"}" >&2
+    exit 1
+  fi
+  detail=$(printf '%s' "$api_resp" | tr '\n' ' ' | cut -c1-180)
+  echo "{\"error\":\"fetch-failed\",\"detail\":\"${detail}\"}" >&2
+  exit 2
+fi
+
+encoded=$(printf '%s' "$api_resp" | sed -n 's/.*"content":[[:space:]]*"\([^"]*\)".*/\1/p')
+if [ -z "$encoded" ]; then
+  echo '{"error":"fetch-failed","detail":"missing content field"}' >&2
+  exit 2
+fi
+printf '%b' "$encoded" | base64 -d


### PR DESCRIPTION
Closes #160.

## Summary
Three-sprint audit-hardening slice (see merged plan in PR #161):

1. **`scripts/overlord/audit_remote.sh`** — 28-line bash wrapper around `gh api repos/NIBARGERB-HLDPRO/<repo>/contents/<path>?ref=<ref>`. Decodes base64 content, prints to stdout. Exit 1 on 404 with structured JSON to stderr; exit 2 on other fetch failures.
2. **`docs/templates/codex-spark-dispatch-brief.md`** — reusable dispatch brief with 6 required H2 sections: Preflight, Worktree discipline (HARD GATE), Non-destructive editing, Diff scope cap, No push / no gh, Report format.
3. **`agents/verify-completion.md`** — surgical patch: new `## Remote-reading preferred` section inserted between `## Process` and `## Output Format`. No existing content modified.

## Tiered work
Tier 2 — mechanical rollout of today's 3 feedback memories (`feedback_audit_must_read_remote_head`, `feedback_codex_worktree_base_contamination`, `feedback_codex_spark_no_network`) into enforcement artifacts.

## Scope discipline
- Exactly 3 commits, 3 files.
- Non-destructive editing held (verify-completion.md sprint is insert-only).
- Helper script under 40-line cap (28 actual).

## Test plan
- [ ] CI green
- [ ] Smoke test helper: `bash scripts/overlord/audit_remote.sh hldpro-governance STANDARDS.md | head -1` returns first markdown heading (dispatcher will run; codex-spark sandbox had no network so couldn't smoke-test the success cases).
- [ ] 404 smoke: `bash scripts/overlord/audit_remote.sh hldpro-governance does-not-exist.xyz` exits 1 with `"error":"not-found"`.
- [ ] verify-completion.md diff shows only `+` lines outside insertion boundaries.

## Next (out of scope here)
- Closeout: move "Harden verify-completion audits..." Planned row → Done in OVERLORD_BACKLOG.md.
- Update 3 feedback memories to reference the new script + template as enforcement mechanism.

🤖 Generated with [Claude Code](https://claude.com/claude-code)