### PR TITLE
fix(ci): extract Python heredocs from require-cross-review.yml

### DIFF
--- a/.github/scripts/check_som_exception.py
+++ b/.github/scripts/check_som_exception.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+"""Check if SOM-BOOTSTRAP-001 exception is active in docs/exception-register.md."""
+import datetime
+import re
+import sys
+
+path = "docs/exception-register.md"
+try:
+    text = open(path, "r", encoding="utf-8", errors="replace").read()
+except FileNotFoundError:
+    print("inactive")
+    sys.exit(0)
+
+pattern = re.compile(
+    r"SOM-BOOTSTRAP-001[\s\S]*?expiry_date:\**\s*([0-9]{4}-[0-9]{2}-[0-9]{2})", re.I
+)
+match = pattern.search(text)
+if not match:
+    print("inactive")
+    sys.exit(0)
+
+expiry = datetime.date.fromisoformat(match.group(1))
+today = datetime.date.today()
+print("active" if expiry > today else "inactive")

--- a/.github/scripts/get_pr_labels.py
+++ b/.github/scripts/get_pr_labels.py
@@ -1,0 +1,11 @@
+#!/usr/bin/env python3
+"""Print space-separated list of labels on the current pull request."""
+import json
+import os
+
+event = os.environ["GITHUB_EVENT_PATH"]
+with open(event, "r", encoding="utf-8") as f:
+    payload = json.load(f)
+pull = payload.get("pull_request") or {}
+labels = [l.get("name", "") for l in pull.get("labels", [])]
+print(" ".join(filter(None, labels)))

--- a/.github/workflows/require-cross-review.yml
+++ b/.github/workflows/require-cross-review.yml
@@ -33,18 +33,7 @@ jobs:
 
           TOUCH=0
           printf '%s\n' "${DIFF_FILES}" | grep -Eq '^STANDARDS\.md$|^docs/.*/[^/]*charter[^/]*\.md$|^docs/[^/]*charter[^/]*\.md$' && TOUCH=1 || true
-          LABELS="$(python3 - <<'PY'
-import json
-import os
-
-event = os.environ["GITHUB_EVENT_PATH"]
-with open(event, "r", encoding="utf-8") as f:
-    payload = json.load(f)
-pull = payload.get("pull_request") or {}
-labels = [l.get("name", "") for l in pull.get("labels", [])]
-print(" ".join(filter(None, labels)))
-PY
-)"
+          LABELS="$(python3 .github/scripts/get_pr_labels.py)"
 
           case " $LABELS " in
             *" architecture "*|*" standards "*)
@@ -69,23 +58,7 @@ PY
 
           if [ "${CROSS_FILE}" = "${BOOTSTRAP_FILE}" ]; then
             if [ -f "docs/exception-register.md" ]; then
-              EXCEPTION_ACTIVE="$(python3 - <<'PY'
-import datetime
-import os
-import re
-
-path = "docs/exception-register.md"
-text = open(path, "r", encoding="utf-8", errors="replace").read()
-pattern = re.compile(r"SOM-BOOTSTRAP-001[\\s\\S]*?expiry_date:\\**\\s*([0-9]{4}-[0-9]{2}-[0-9]{2})", re.I)
-match = pattern.search(text)
-if not match:
-    print("inactive")
-    raise SystemExit
-expiry = datetime.date.fromisoformat(match.group(1))
-today = datetime.date.today()
-print("active" if expiry > today else "inactive")
-PY
-)"
+              EXCEPTION_ACTIVE="$(python3 .github/scripts/check_som_exception.py)"
               if [ "${EXCEPTION_ACTIVE}" = "active" ]; then
                 APPLY_EXCEPTION=true
               fi


### PR DESCRIPTION
## Summary
- Extracts two inline Python scripts from `run: |` blocks into `.github/scripts/get_pr_labels.py` and `.github/scripts/check_som_exception.py`
- Replaces `<<'PY'` / `<<'PYEOF'` heredocs with `python3 .github/scripts/<name>.py` calls
- GitHub Actions YAML parser chokes on `<<` inside `run: |` blocks when the workflow is used as a `workflow_call` reusable workflow (error: "yaml syntax on line 37")

## No behavior change
Same logic in both scripts. The `check_som_exception.py` also adds a `FileNotFoundError` guard (previously would fail if `exception-register.md` didn't exist).

## Unblocks
NIBARGERB-HLDPRO/local-ai-machine#441 — the LAM pre-session hook PR that was failing because it calls this workflow via `workflow_call`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)