### PR TITLE
[Issue #164] Fix hardcoded username typo in hooks

### DIFF
--- a/hooks/pre-session-context.sh
+++ b/hooks/pre-session-context.sh
@@ -4,7 +4,7 @@
 # Fires on every user prompt. Injects wiki/index.md + GRAPH_REPORT.md into context
 # so agents that call Read with the wrong env-injected path still get the content.
 #
-# Root cause this works around: Claude Code session env injects "/Users/bennibarker/"
+# Root cause this works around: Claude Code session env injects "/Users/bennibarger/"
 # (wrong username, 'k') but real username is "bennibarger" ('g'). Read tool fails
 # on the injected path; this hook uses shell $HOME which resolves correctly.
 #


### PR DESCRIPTION
## Summary
- Corrects `bennibarker` → `bennibarger` in `hooks/pre-session-context.sh` comment (line 7)
- Root cause: macOS username was misspelled when the hook was first authored

## Test plan
- [ ] Verify `grep bennibarker hooks/pre-session-context.sh` returns no matches
- [ ] Confirm hook still executes correctly on session start

Closes #164

🤖 Generated with [Claude Code](https://claude.com/claude-code)