### PR TITLE
feat(ci): consolidate SoM checks into governance-check.yml as inline steps

### DIFF
--- a/.github/workflows/governance-check.yml
+++ b/.github/workflows/governance-check.yml
@@ -15,6 +15,7 @@ on:
 permissions:
   contents: read
   issues: read
+  pull-requests: read
 
 jobs:
   governance-check:
@@ -425,6 +426,194 @@ jobs:
           else
             echo "✓ PROGRESS.md row count: $OLD_COUNT → $NEW_COUNT"
           fi
+
+
+      # -- SoM / Society-of-Minds governance checks --
+      - name: Install Python deps for SoM checks
+        run: python3 -m pip install --quiet pyyaml
+
+      - name: Validate CLAUDE.md SoM pointer
+        run: |
+          set -euo pipefail
+          if [ ! -f CLAUDE.md ]; then
+            echo "::error file=CLAUDE.md,line=1::[check-claude-md-pointer] CLAUDE.md not found"
+            exit 1
+          fi
+          if grep -Fq "STANDARDS.md" CLAUDE.md && grep -Fq "Society of Minds" CLAUDE.md; then
+            exit 0
+          fi
+          if grep -Eq "NIBARGERB-HLDPRO/hldpro-governance/blob/main/STANDARDS\.md" CLAUDE.md; then
+            exit 0
+          fi
+          echo "::error file=CLAUDE.md,line=1::[check-claude-md-pointer] CLAUDE.md must reference STANDARDS.md Society of Minds section or link to NIBARGERB-HLDPRO/hldpro-governance/blob/main/STANDARDS.md"
+          exit 1
+
+      - name: Validate agent model pins
+        run: |
+          set -euo pipefail
+          GOVSCRIPTS=".governance/.github/scripts"
+          [ -d "$GOVSCRIPTS" ] || GOVSCRIPTS=".github/scripts"
+          python3 "$GOVSCRIPTS/check_agent_model_pins.py"
+
+      - name: Validate codex exec model pinning
+        run: |
+          set -euo pipefail
+          GOVSCRIPTS=".governance/.github/scripts"
+          [ -d "$GOVSCRIPTS" ] || GOVSCRIPTS=".github/scripts"
+          python3 "$GOVSCRIPTS/check_codex_model_pins.py"
+
+      - name: Validate model fallback log schema
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          GOVSCRIPTS=".governance/.github/scripts"
+          [ -d "$GOVSCRIPTS" ] || GOVSCRIPTS=".github/scripts"
+          python3 "$GOVSCRIPTS/check_fallback_log_schema.py"
+
+      - name: Validate cross-review model separation
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          GOVSCRIPTS=".governance/.github/scripts"
+          [ -d "$GOVSCRIPTS" ] || GOVSCRIPTS=".github/scripts"
+          python3 "$GOVSCRIPTS/check_no_self_approval.py"
+
+      - name: Validate PII routing and audit evidence
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          GOVSCRIPTS=".governance/.github/scripts"
+          [ -d "$GOVSCRIPTS" ] || GOVSCRIPTS=".github/scripts"
+          python3 "$GOVSCRIPTS/check_pii_routing.py"
+
+      - name: Validate LAM reviewer/worker family diversity
+        run: |
+          set -euo pipefail
+          GOVSCRIPTS=".governance/.github/scripts"
+          [ -d "$GOVSCRIPTS" ] || GOVSCRIPTS=".github/scripts"
+          python3 "$GOVSCRIPTS/check_lam_family_diversity.py"
+
+      - name: Validate LAM health endpoint when required
+        env:
+          LAM_PROBE_URL: "http://host.docker.internal:8080/health"
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          GOVSCRIPTS=".governance/.github/scripts"
+          [ -d "$GOVSCRIPTS" ] || GOVSCRIPTS=".github/scripts"
+
+          if [ -z "${BASE_SHA}" ] || [ -z "${HEAD_SHA}" ]; then
+            echo "::warning::[check-lam-availability] Missing pull request context; skipping."
+            exit 0
+          fi
+
+          DIFF_FILES="$(git diff --name-only "${BASE_SHA}...${HEAD_SHA}")"
+          if [ -z "${DIFF_FILES}" ]; then
+            echo "No diff files found."
+            exit 0
+          fi
+
+          PII_LABEL=false
+          SAFE_LABEL=false
+          LABELS="$(python3 "$GOVSCRIPTS/check_lam_availability_labels.py")"
+
+          case " $LABELS " in
+            *" pii "*) PII_LABEL=true ;;
+            *" pii-safe "*) SAFE_LABEL=true ;;
+          esac
+
+          TOUCH=false
+          printf '%s\n' "${DIFF_FILES}" | grep -Eq '^scripts/lam/' && TOUCH=true || true
+          if [ "${PII_LABEL}" = true ]; then
+            TOUCH=true
+          fi
+
+          if [ "${TOUCH}" != true ]; then
+            echo "[check-lam-availability] LAM not required for this PR."
+            exit 0
+          fi
+
+          if [ "${SAFE_LABEL}" = true ]; then
+            echo "[check-lam-availability] pii-safe label present; skipping hard fail on non-200."
+            exit 0
+          fi
+
+          STATUS="$(curl -sS -o /tmp/lam-health.txt -w "%{http_code}" "${LAM_PROBE_URL}" || true)"
+          if [ "${STATUS}" != "200" ]; then
+            echo "::error file=.github/workflows/governance-check.yml::[check-lam-availability] LAM probe failed with HTTP ${STATUS} at ${LAM_PROBE_URL}"
+            exit 1
+          fi
+          echo "[check-lam-availability] LAM probe OK (HTTP 200)."
+
+      - name: Require cross-review artifact
+        run: |
+          set -euo pipefail
+          GOVSCRIPTS=".governance/.github/scripts"
+          [ -d "$GOVSCRIPTS" ] || GOVSCRIPTS=".github/scripts"
+          GOVROOT=".governance"
+          [ -d "$GOVROOT" ] || GOVROOT="."
+
+          BASE_SHA="${{ github.event.pull_request.base.sha }}"
+          HEAD_SHA="${{ github.event.pull_request.head.sha }}"
+
+          if [ -z "${BASE_SHA}" ] || [ -z "${HEAD_SHA}" ]; then
+            echo "::warning::[require-cross-review] Missing pull request context; skipping."
+            exit 0
+          fi
+
+          DIFF_FILES="$(git diff --name-only "${BASE_SHA}...${HEAD_SHA}")"
+          if [ -z "${DIFF_FILES}" ]; then
+            echo "No diff files found."
+            exit 0
+          fi
+
+          TOUCH=0
+          printf '%s\n' "${DIFF_FILES}" | grep -Eq '^STANDARDS\.md$|^docs/.*/[^/]*charter[^/]*\.md$|^docs/[^/]*charter[^/]*\.md$' && TOUCH=1 || true
+          LABELS="$(python3 "$GOVSCRIPTS/get_pr_labels.py")"
+
+          case " $LABELS " in
+            *" architecture "*|*" standards "*)
+              TOUCH=1
+              ;;
+          esac
+
+          if [ "${TOUCH}" -ne 1 ]; then
+            echo "Cross-review trigger not hit. Skipping."
+            exit 0
+          fi
+
+          RAW_CROSS_REVIEW="$(printf '%s\n' "${DIFF_FILES}" | grep -E '^raw/cross-review/.*\.md$' | sort -u || true)"
+          if [ -z "${RAW_CROSS_REVIEW}" ]; then
+            echo "::error file=raw/cross-review/::[require-cross-review] Missing raw/cross-review/*.md file in PR diff."
+            exit 1
+          fi
+
+          CROSS_FILE="$(printf '%s\n' "${RAW_CROSS_REVIEW}" | head -n 1)"
+          BOOTSTRAP_FILE="raw/cross-review/2026-04-14-society-of-minds-charter.md"
+          APPLY_EXCEPTION=false
+
+          if [ "${CROSS_FILE}" = "${BOOTSTRAP_FILE}" ]; then
+            if [ -f "docs/exception-register.md" ]; then
+              EXCEPTION_ACTIVE="$(python3 "$GOVSCRIPTS/check_som_exception.py")"
+              if [ "${EXCEPTION_ACTIVE}" = "active" ]; then
+                APPLY_EXCEPTION=true
+              fi
+            fi
+          fi
+
+          if [ "${APPLY_EXCEPTION}" = "true" ]; then
+            echo "::warning file=${BOOTSTRAP_FILE}::[require-cross-review] SOM-BOOTSTRAP-001 active; skipping REJECTED-blocks-merge check."
+            exit 0
+          fi
+
+          bash "$GOVROOT/scripts/cross-review/require-dual-signature.sh" "${CROSS_FILE}"
 
       # ── Summary ──
       - name: Governance summary

--- a/.github/workflows/governance-check.yml
+++ b/.github/workflows/governance-check.yml
@@ -12,14 +12,13 @@ on:
       SUPABASE_SERVICE_ROLE_KEY:
         required: false
 
-permissions:
-  contents: read
-  issues: read
-  pull-requests: read
-
 jobs:
   governance-check:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: read
+      pull-requests: read
     steps:
       - uses: actions/checkout@v6
         with:


### PR DESCRIPTION
## Summary
- Inlines 9 separate reusable workflow calls as steps inside governance-check.yml, eliminating the startup_failure that occurs when calling multiple external reusable workflows simultaneously
- Uses a GOVSCRIPTS path resolver so steps work whether running in an external product repo or running inside hldpro-governance itself
- Adds pull-requests: read permission to support label-reading steps

## Checks inlined
1. check-claude-md-pointer
2. check-agent-model-pins
3. check-codex-model-pins
4. check-fallback-log-schema
5. check-no-self-approval
6. check-pii-routing
7. check-lam-family-diversity
8. check-lam-availability
9. require-cross-review

## Test plan
- [ ] CI passes on this PR
- [ ] After merge, revert local-ai-machine governance.yml to single-job and verify PRs go green

🤖 Generated with [Claude Code](https://claude.com/claude-code)