### PR TITLE
fix(standards): require absolute hook paths in settings.json

### DIFF
--- a/STANDARDS.md
+++ b/STANDARDS.md
@@ -17,6 +17,7 @@
 - `.claude/hooks/backlog-check.sh` — **hard gate**: blocks branch creation unless a matching `PLANNED` or `IN_PROGRESS` entry exists in `docs/PROGRESS.md` Plans table. Enforces backlog-first workflow (plan with AC before code).
 - `.claude/hooks/check-errors.sh` — PostToolUse hard gate: auto-grep FAIL_FAST_LOG on errors, 3-attempt max, then STOP and ask user
 - `.claude/settings.json` PostToolUse matcher must be `"*"` (all tools), NOT `"Bash"` — errors from MCP, Agent, Read, etc. must also trigger the 3-attempt gate
+- **Hook commands in `.claude/settings.json` must use absolute paths** (e.g. `bash $HOME/Developer/HLDPRO/<repo>/.claude/hooks/<hook>.sh`) — relative paths break silently when the session CWD shifts to a subdirectory, causing the hook to no-op without a hard error
 - Session start must check `~/Developer/hldpro/.codex-ingestion/{repo}/backlog-*.md` for pending Codex findings — surface to user if any exist
 - If repo governance requires specialist agents/subagents, the session must use them. Codex sessions may satisfy this by spawning equivalent Codex subagents and loading the repo's persona definitions from `CODEX.md`, `AGENTS.md`, `.agents/`, or repo-local standards instead of relying on Claude-only agent files.
 - Conventional commits: `feat/fix/docs/chore` with scope


### PR DESCRIPTION
## Summary
- Adds a rule to `STANDARDS.md §Required Governance` requiring that hook commands in `.claude/settings.json` use absolute paths
- Relative paths silently no-op when the session CWD shifts to a subdirectory (e.g. `frontend/`, a worktree subdirectory), causing all guards to stop firing without any blocking error

## Root cause observed
HealthcarePlatform sessions drifting into `frontend/` (via `npx --prefix ../frontend` commands) caused all 5 hooks to fail with non-blocking "No such file or directory". The schema guard, merge guardian, backlog check, governance check, and error gate all stopped running silently.

## Follow-up (blocked on clean HP branch)
- [ ] Fix HealthcarePlatform `.claude/settings.json` — all 5 hook commands need `$HOME/Developer/HLDPRO/HealthcarePlatform/` prefix (tracked file, needs branch+commit)

## Test plan
- [ ] Verify STANDARDS.md rule visible in `§Required Governance`
- [ ] Confirm CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)