### PR TITLE
fix(ci): PR commit-scope lint — prevent stale-worktree base contamination (#174)

### DIFF
--- a/.github/scripts/check_pr_commit_scope.sh
+++ b/.github/scripts/check_pr_commit_scope.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# Checks that a PR does not contain more commits than MAX_COMMITS (default 10).
+# Large commit counts are a signal of stale-worktree base contamination.
+# Set MAX_COMMITS env var to override the threshold.
+
+MAX_COMMITS="${MAX_COMMITS:-10}"
+
+if [[ -n "${PR_BASE:-}" ]]; then
+  base="$PR_BASE"
+else
+  base="$(git merge-base HEAD origin/main)"
+fi
+
+commit_count="$(git rev-list --count "$base..HEAD")"
+changed_files="$(git diff --name-only "$base..HEAD")"
+file_count="$(echo "$changed_files" | grep -c . || true)"
+
+if [[ "$commit_count" -gt "$MAX_COMMITS" ]]; then
+  echo "ERROR: PR contains $commit_count commits (max $MAX_COMMITS)."
+  echo ""
+  echo "Commits in this PR:"
+  git log --oneline "$base..HEAD"
+  echo ""
+  echo "Changed files:"
+  echo "$changed_files"
+  echo ""
+  echo "If this branch was created from a stale local origin/main, re-create the worktree from a fresh fetch:"
+  echo "  git fetch origin main && git worktree add -b <branch> <path> origin/main"
+  exit 1
+fi
+
+echo "Commits in this PR:"
+git log --oneline "$base..HEAD"
+echo ""
+echo "Changed files ($file_count):"
+echo "$changed_files"
+echo ""
+echo "Scope check passed: $commit_count commits, $file_count files changed."

--- a/.github/workflows/check-pr-commit-scope.yml
+++ b/.github/workflows/check-pr-commit-scope.yml
@@ -1,0 +1,16 @@
+name: check-pr-commit-scope
+on:
+  pull_request:
+    branches: [main]
+jobs:
+  commit-scope:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Check PR commit scope
+        env:
+          MAX_COMMITS: "10"
+          PR_BASE: ${{ github.event.pull_request.base.sha }}
+        run: bash .github/scripts/check_pr_commit_scope.sh

--- a/STANDARDS.md
+++ b/STANDARDS.md
@@ -17,6 +17,7 @@
 - `.claude/hooks/backlog-check.sh` — **hard gate**: blocks branch creation unless a matching `PLANNED` or `IN_PROGRESS` entry exists in `docs/PROGRESS.md` Plans table. Enforces backlog-first workflow (plan with AC before code).
 - `.claude/hooks/check-errors.sh` — PostToolUse hard gate: auto-grep FAIL_FAST_LOG on errors, 3-attempt max, then STOP and ask user
 - `check-backlog-gh-sync.yml` — **hard gate**: every `OVERLORD_BACKLOG.md` Planned entry must reference an open GitHub issue (`#NNN` in the `Issue` column). GitHub is canonical — create the issue before adding to Planned. CI validates all refs are open on every push.
+- `check-pr-commit-scope.yml` — **scope guard**: PRs to main must contain ≤ 10 commits. Excess commits indicate stale-worktree base contamination (2026-04-15 incident). Threshold configurable via `MAX_COMMITS` env var.
 - `.claude/settings.json` PostToolUse matcher must be `"*"` (all tools), NOT `"Bash"` — errors from MCP, Agent, Read, etc. must also trigger the 3-attempt gate
 - **Hook commands in `.claude/settings.json` must use absolute paths** (e.g. `bash $HOME/Developer/HLDPRO/<repo>/.claude/hooks/<hook>.sh`) — relative paths break silently when the session CWD shifts to a subdirectory, causing the hook to no-op without a hard error
 - Session start must check `~/Developer/hldpro/.codex-ingestion/{repo}/backlog-*.md` for pending Codex findings — surface to user if any exist


### PR DESCRIPTION
## Summary

Closes acceptance criterion (c) of #174.

- Adds `.github/scripts/check_pr_commit_scope.sh` — counts commits between PR base and HEAD; fails if > `MAX_COMMITS` (default 10) with full commit list, changed files, and remediation instructions pointing to the stale-worktree root cause
- Adds `.github/workflows/check-pr-commit-scope.yml` — triggers on every PR to main; no heredocs, calls the script wrapper
- Updates `STANDARDS.md` — documents the scope-guard rule under `## Required Governance`

## Why 10 commits

The 2026-04-15 incident had PRs with 15–100 unrelated WIP commits from stale local `origin/main` bases. Normal governance slices are 1–5 commits. 10 gives comfortable headroom for multi-sprint PRs while catching contaminated worktrees reliably.

The threshold is overridable via the `MAX_COMMITS` env var in the workflow for intentional exceptions.

## Context

- (a) verify-completion remote-read fix — already on main (audit_remote.sh)
- (b) codex brief worktree discipline — already on main (docs/templates/codex-spark-dispatch-brief.md)
- (c) this PR

Closes #174

🤖 Generated with [Claude Code](https://claude.com/claude-code)