### PR TITLE
docs: create PROGRESS.md, DATA_DICTIONARY.md, SERVICE_REGISTRY.md (#171 #172 #173)

### DIFF
--- a/docs/DATA_DICTIONARY.md
+++ b/docs/DATA_DICTIONARY.md
@@ -1,0 +1,74 @@
+# Data Dictionary
+
+**Last Updated:** 2026-04-16
+**Scope:** hldpro-governance — meta-governance repo
+**Source of truth:** This file documents the canonical schemas, file formats, and data contracts owned or enforced by hldpro-governance. Schema JSON/YAML source files live in `docs/schemas/`.
+
+---
+
+## Schemas
+
+### Structured Agent Cycle Plan
+**File:** `docs/schemas/structured-agent-cycle-plan.schema.json`
+**Used by:** All governed repos — issue-driven execution branches must have a valid plan before execution is governance-ready.
+**Validator:** `scripts/overlord/validate_structured_agent_cycle_plan.py`
+
+Key fields:
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `sprint` | string | yes | Sprint identifier |
+| `task` | string | yes | Task description |
+| `acceptance` | array | yes | Acceptance criteria list |
+| `specialist_reviews` | array | yes | Required reviewer roles |
+| `alternate_model_review` | object | yes | Cross-model review result |
+| `execution_handoff` | object | yes | Handoff chain record |
+| `material_deviation_rules` | array | yes | Allowed deviation conditions |
+
+---
+
+### SoM Packet
+**File:** `docs/schemas/som-packet.schema.yml`
+**Used by:** MCP daemon (local-ai-machine), all tier handoffs in the Society of Minds routing chain.
+
+Key fields: `tier`, `model_id`, `model_family`, `payload`, `pii_cleared`, `audit_ref`
+
+---
+
+### Graphify Usage Event
+**File:** `docs/schemas/graphify-usage-event.schema.json`
+**Used by:** `scripts/knowledge_base/log_graphify_usage.py`, `scripts/knowledge_base/measure_graphify_usage.py`
+**Storage:** `metrics/graphify-usage/events/YYYY-MM-DD.jsonl` (append-only)
+
+Key fields:
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `timestamp` | string (ISO 8601) | yes | Event time |
+| `repo` | string | yes | Target repo |
+| `task_id` | string | yes | Issue or task identifier |
+| `task_type` | string | yes | e.g. `architecture_retrieval`, `workflow_bug` |
+| `strategy` | string | yes | `graphify`, `repo-search`, or `hybrid` |
+| `artifacts` | array | yes | Files/paths used as context |
+| `estimated_tokens` | integer | yes | Token footprint estimate |
+| `experiment_id` | string | no | A/B experiment grouping |
+| `session_id` | string | no | Session identifier |
+| `prompt` | string | no | Query prompt text |
+| `query_terms` | array | no | Search terms used |
+| `top_candidates` | array | no | Top-ranked files returned |
+
+---
+
+### OVERLORD_BACKLOG.md Planned Table
+**Owner:** hldpro-governance root
+**Enforced by:** `check-backlog-gh-sync.yml`
+
+Required columns: `Item`, `Issue`, `Priority`, `Est. Hours`, `Notes`
+
+Contract: Every Planned row must reference an open GitHub issue (`#NNN`). GH is canonical — create the issue before adding to Planned.
+
+---
+
+### FAIL_FAST_LOG / Error Patterns
+**File:** `docs/FAIL_FAST_LOG.md`, `docs/ERROR_PATTERNS.md`
+**Schema:** `docs/schemas/fail-fast-log.schema.md`, `docs/schemas/error-patterns.schema.md`
+
+Standard columns: `Date`, `Repo`, `Error`, `Root Cause`, `Fix`, `Prevention`

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -1,0 +1,42 @@
+# hldpro-governance — Progress & Backlog
+
+**Last Updated:** 2026-04-16
+**Scope:** Cross-repo governance standards, CI enforcement, audit agents, and knowledge base infrastructure.
+
+> This file is the single source of truth for planned work, open bugs, feature requests, and operational items in hldpro-governance.
+> The `OVERLORD_BACKLOG.md` at repo root is the cross-repo roadmap mirror; this file is the per-repo execution tracker.
+
+## Plans
+
+| Plan | Issue | Status | Priority | Est. Hours | Deliverables | Notes |
+|------|-------|--------|----------|------------|--------------|-------|
+| Harden verify-completion + codex-spark dispatch briefs against stale-checkout contamination | #174 | IN PROGRESS | HIGH | 2-3 | `check-pr-commit-scope.yml`, `check_pr_commit_scope.sh`, STANDARDS.md update | 2026-04-15 incident; (a)+(b) already on main; (c) PR #182 |
+| Reconcile SoM branch naming vs local-ai-machine riskfix/* convention | #175 | PLANNED | MEDIUM | 1-2 | STANDARDS.md update, exception register update | Exception SOM-LAM-BRANCH-001 defers enforcement |
+| Stage 5+ som-worker launchd boot-start integration | #104 | PLANNED | MEDIUM | 2-3 | launchd plist, service docs | Gate: local-ai-machine #431, #432 adopt |
+| Codex-spark refinement pass on Stage 3b MCP tools + Stage 4 validator | #177 | PLANNED | LOW-MEDIUM | 2-3 | Codex review findings, follow-up issues | Gate: live-fallback rate < 2% confirmed |
+| Qwen-Coder MLX driver stub-emission bug | #105 | PLANNED | LOW | 1-2 | MLX driver patch or workaround | Workarounds in docs/runbooks/qwen-coder-driver.md |
+| SoM Stage 5: som-worker daemon | #178 | PLANNED | LOW | 6-8 | Daemon implementation, queue wiring | Follow-on to Stage 3b/4 |
+| Reconcile ASC-Evaluator exemption with governance.yml | #176 | PLANNED | LOW | 0.5 | Exemption register update or governance.yml fix | Exception SOM-ASC-CI-001 |
+| Living Knowledge Base — Phase 8: Qwen3-32B fine-tune | #49 | PLANNED | LOW | TBD | Fine-tuned model, eval results | Gate: 6+ months of wiki data |
+
+## Known Bugs
+
+| Bug | Issue | Priority | Status | Notes |
+|-----|-------|----------|--------|-------|
+| Qwen-Coder MLX driver emits incomplete stubs on full-file rewrites (>200 lines) | #105 | LOW | OPEN | Workarounds documented in docs/runbooks/qwen-coder-driver.md |
+
+## Feature Requests
+
+| Feature | Issue | Priority | Notes |
+|---------|-------|----------|-------|
+| Cloud → Local MCP Bridge (remote CLI access to SoM daemon) | #109 | MEDIUM | Deferred; depends on SoM Stage 5 |
+| SoM Slice A: codex flag remediation across AIS / HP / LAM / KT | #139 | MEDIUM | Epic: model-pin compliance across governed repos |
+| SoM Slice B: AGENTS.md → agents/*.md migration + model pins | #140 | MEDIUM | Follow-on to Slice A |
+
+## Operational Items
+
+| Item | Issue | Status | Notes |
+|------|-------|--------|-------|
+| hldpro-governance missing docs: SERVICE_REGISTRY.md, DATA_DICTIONARY.md | #172 #173 | IN PROGRESS | Being created in this PR |
+| Weekly overlord sweep write-back to wiki/index.md | — | PENDING | Last sweep was 2026-04-09; needs live GH Actions run |
+| LAM env-var-docs contract debt: SOM_* variables unclassified | #145 | OPEN | local-ai-machine env vars need classification |

--- a/docs/SERVICE_REGISTRY.md
+++ b/docs/SERVICE_REGISTRY.md
@@ -1,0 +1,65 @@
+# Service Registry
+
+**Last Updated:** 2026-04-16
+**Scope:** hldpro-governance — meta-governance repo
+**Source of truth:** This file inventories the scripts, agents, CI workflows, and hooks that constitute the active "services" enforced or provided by hldpro-governance across the governed org.
+
+---
+
+## Agents
+
+| Agent | File | Model | Role |
+|-------|------|-------|------|
+| overlord | `agents/overlord.md` | claude-sonnet-4-6 | Session-start standards drift check |
+| overlord-sweep | `agents/overlord-sweep.md` | claude-sonnet-4-6 | Weekly cross-repo audit + metrics |
+| overlord-audit | `agents/overlord-audit.md` | claude-sonnet-4-6 | Deep cross-repo pattern analysis |
+| verify-completion | `agents/verify-completion.md` | claude-haiku-4-5-20251001 | Hard-gate artifact verification |
+
+---
+
+## CI Workflows (Reusable / Governance)
+
+| Workflow | File | Trigger | Purpose |
+|----------|------|---------|---------|
+| governance-check | `.github/workflows/governance-check.yml` | PR / push | Doc co-staging gate |
+| check-backlog-gh-sync | `.github/workflows/check-backlog-gh-sync.yml` | PR / push (OVERLORD_BACKLOG.md) | Backlog ↔ GH issue sync gate |
+| check-pr-commit-scope | `.github/workflows/check-pr-commit-scope.yml` | PR to main | Stale-worktree contamination guard |
+| overlord-sweep | `.github/workflows/overlord-sweep.yml` | Weekly (Mon 9am CT) | Cross-repo standards sweep |
+| overlord-nightly-cleanup | `.github/workflows/overlord-nightly-cleanup.yml` | Nightly | Stale branch cleanup |
+| graphify-governance-contract | `.github/workflows/graphify-governance-contract.yml` | PR / push | Graphify usage logging contract tests |
+| require-cross-review | `.github/workflows/require-cross-review.yml` | PR | Dual-planner cross-review artifact gate |
+| check-agent-model-pins | `.github/workflows/check-agent-model-pins.yml` | PR | SoM Tier enforcement: agent model pins |
+| check-no-self-approval | `.github/workflows/check-no-self-approval.yml` | PR | SoM invariant #1: no self-approval |
+
+---
+
+## Overlord Scripts
+
+| Script | Path | Purpose |
+|--------|------|---------|
+| validate_backlog_gh_sync.py | `scripts/overlord/validate_backlog_gh_sync.py` | Validates OVERLORD_BACKLOG.md Planned rows reference open GH issues |
+| validate_structured_agent_cycle_plan.py | `scripts/overlord/validate_structured_agent_cycle_plan.py` | Validates structured plan JSON against org schema |
+| codex_ingestion.py | `scripts/overlord/codex_ingestion.py` | Codex review ingestion: generate, qualify, promote |
+| build_effectiveness_metrics.py | `scripts/overlord/build_effectiveness_metrics.py` | Weekly effectiveness baseline snapshots |
+| worktree_shared_dependencies.sh | `scripts/overlord/worktree_shared_dependencies.sh` | Approved dependency symlink helper for worktrees |
+| audit_remote.sh | `scripts/overlord/audit_remote.sh` | Reads a file from any repo's remote HEAD via GH API |
+
+---
+
+## Knowledge Base Scripts
+
+| Script | Path | Purpose |
+|--------|------|---------|
+| build_graph.py | `scripts/knowledge_base/build_graph.py` | Builds graphify knowledge graph for a repo |
+| log_graphify_usage.py | `scripts/knowledge_base/log_graphify_usage.py` | Appends graphify usage events to JSONL log |
+| measure_graphify_usage.py | `scripts/knowledge_base/measure_graphify_usage.py` | A/B comparison: graphify vs repo-search retrieval |
+| update_knowledge_index.py | `scripts/knowledge_base/update_knowledge_index.py` | Regenerates wiki/index.md from graph summaries |
+
+---
+
+## Hooks
+
+| Hook | Path | Scope | Purpose |
+|------|------|-------|---------|
+| governance-check.sh | `hooks/governance-check.sh` | Repo-wide (pre-commit) | Blocks commits missing doc co-staging |
+| closeout-hook.sh | `hooks/closeout-hook.sh` | Repo-wide | Validates closeout artifact on Stage 6 completion |


### PR DESCRIPTION
## Summary

Creates the three required governance docs missing from hldpro-governance. All three satisfy the STANDARDS.md contract.

- **`docs/PROGRESS.md`** — Single source of truth for planned work, open bugs, feature requests, and operational items. Plans table references all 8 open backlog issues (#49, #104, #105, #174–#178). Closes #171.
- **`docs/DATA_DICTIONARY.md`** — Documents canonical schemas owned by this repo: structured agent cycle plan, SoM packet, graphify usage event, backlog table contract, fail-fast log. Closes #172.
- **`docs/SERVICE_REGISTRY.md`** — Inventories agents, CI workflows, overlord scripts, knowledge base scripts, and hooks. Closes #173.

## Test plan

- [ ] CI passes
- [ ] `overlord` agent no longer reports these files as missing on next session-start check

Closes #171, #172, #173

🤖 Generated with [Claude Code](https://claude.com/claude-code)