### PR TITLE
fix(security): add .gitleaks.toml — baseline security tier compliance

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,40 @@
+[extend]
+useDefault = true
+
+[[rules]]
+id = "anthropic-api-key"
+description = "Anthropic API Key"
+regex = '''sk-ant-[a-zA-Z0-9-]{20,}'''
+tags = ["anthropic", "api-key"]
+
+[[rules]]
+id = "openai-api-key"
+description = "OpenAI API Key"
+regex = '''sk-[a-zA-Z0-9]{20,}'''
+tags = ["openai", "api-key"]
+
+[[rules]]
+id = "github-pat"
+description = "GitHub Personal Access Token"
+regex = '''ghp_[a-zA-Z0-9]{36}'''
+tags = ["github", "pat"]
+
+[[rules]]
+id = "github-oauth"
+description = "GitHub OAuth Token"
+regex = '''gho_[a-zA-Z0-9]{36}'''
+tags = ["github", "oauth"]
+
+[[rules]]
+id = "supabase-service-role"
+description = "Supabase Service Role Key"
+regex = '''sbp_[a-zA-Z0-9]{40,}'''
+tags = ["supabase", "service-key"]
+
+[allowlist]
+description = "Governance repo allowlist"
+paths = [
+  '''graphify-out/''',
+  '''\.claude/worktrees/''',
+  '''_worktrees/''',
+]


### PR DESCRIPTION
## Summary
- Adds `.gitleaks.toml` at repo root, satisfying the Baseline security tier requirement in STANDARDS.md
- Extends gitleaks defaults with rules for Anthropic, OpenAI, GitHub PAT/OAuth, and Supabase service-role keys
- Allowlist excludes `graphify-out/` and worktree paths to prevent false positives on generated content

## Why these rules
hldpro-governance holds governance scripts, CI workflows, and agent configs — the realistic secret exposure is API keys in scripts or accidentally committed `.env` fragments. No app-specific secrets (Stripe, Resend, etc.) are in scope here.

## Test plan
- [ ] CI passes
- [ ] `gitleaks detect --config .gitleaks.toml --source .` passes locally (no false positives)
- [ ] Overlord next session no longer flags missing `.gitleaks.toml`

Closes #184

🤖 Generated with [Claude Code](https://claude.com/claude-code)