### PR TITLE
fix(governance-check): belt-and-suspenders exclusion for .claude/hooks/ and .claude/settings

### DIFF
--- a/.github/workflows/governance-check.yml
+++ b/.github/workflows/governance-check.yml
@@ -179,10 +179,12 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
           # Source code changes (broad: .ts .tsx .sql .html .css .js .svg .py .sh)
-          # Exclude: docs, .claude, .github, tests, configs, lock files
+          # Exclude: docs, .claude (hooks/settings/config), .github, tests, configs, lock files
           CODE_CHANGES=$(echo "$CHANGED" | grep -E '\.(ts|tsx|sql|html|css|js|svg|py|sh)$' \
             | grep -v '^docs/' \
             | grep -v '^\.claude/' \
+            | grep -v '^\.claude/hooks/' \
+            | grep -v '^\.claude/settings' \
             | grep -v '^\.github/' \
             | grep -v '\.spec\.' \
             | grep -v '\.test\.' \


### PR DESCRIPTION
## Summary
- Adds explicit `grep -v '^\.claude/hooks/'` and `grep -v '^\.claude/settings'` lines to the `CODE_CHANGES` filter
- The broad `grep -v '^\.claude/'` already covers these paths — these are defensive duplicates that survive future edits to the exclusion list
- Closes #199

## Root Cause
PRs that touch only `.claude/hooks/*.sh` or `.claude/settings.json` were failing the governance gate with "Source files changed but docs/PROGRESS.md was not updated." The `.sh` extension matches the `CODE_CHANGES` filter, and if the broad `.claude/` exclusion is ever accidentally dropped, these files become false-positive source changes.

## Why belt-and-suspenders
The existing `grep -v '^\.claude/'` is correct but a single line. Explicit sub-path exclusions make the intent self-documenting and prevent regression if someone narrows the `.claude/` rule.

## Propagation
This is the canonical workflow. All product repos consume it via `workflow_call` — no per-repo changes needed.

## Test plan
- [ ] PR touching only `.claude/hooks/*.sh` — governance gate passes
- [ ] PR touching only `.claude/settings.json` — governance gate passes  
- [ ] PR touching `functions/foo/index.ts` without docs — gate still blocks

🤖 Generated with [Claude Code](https://claude.com/claude-code)