### PR TITLE
fix(ci): move SoM workflow permissions to job scope — fixes HP startup_failure

### DIFF
--- a/.github/workflows/check-agent-model-pins.yml
+++ b/.github/workflows/check-agent-model-pins.yml
@@ -1,11 +1,11 @@
 name: check-agent-model-pins
 on:
   workflow_call:
-permissions:
-  contents: read
 
 jobs:
   check-agent-model-pins:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/check-claude-md-pointer.yml
+++ b/.github/workflows/check-claude-md-pointer.yml
@@ -1,11 +1,11 @@
 name: check-claude-md-pointer
 on:
   workflow_call:
-permissions:
-  contents: read
 
 jobs:
   check-claude-md-pointer:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/check-codex-model-pins.yml
+++ b/.github/workflows/check-codex-model-pins.yml
@@ -1,11 +1,11 @@
 name: check-codex-model-pins
 on:
   workflow_call:
-permissions:
-  contents: read
 
 jobs:
   check-codex-model-pins:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/check-fallback-log-schema.yml
+++ b/.github/workflows/check-fallback-log-schema.yml
@@ -1,11 +1,11 @@
 name: check-fallback-log-schema
 on:
   workflow_call:
-permissions:
-  contents: read
 
 jobs:
   check-fallback-log-schema:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/check-no-self-approval.yml
+++ b/.github/workflows/check-no-self-approval.yml
@@ -1,11 +1,11 @@
 name: check-no-self-approval
 on:
   workflow_call:
-permissions:
-  contents: read
 
 jobs:
   check-no-self-approval:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/check-pii-routing.yml
+++ b/.github/workflows/check-pii-routing.yml
@@ -1,12 +1,12 @@
 name: check-pii-routing
 on:
   workflow_call:
-permissions:
-  contents: read
-  pull-requests: read
 
 jobs:
   check-pii-routing:
+    permissions:
+      contents: read
+      pull-requests: read
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/overlord-sweep.yml
+++ b/.github/workflows/overlord-sweep.yml
@@ -622,11 +622,7 @@ jobs:
             PERSIST_STATUS="unknown"
             PERSIST_NOTE="Baseline refresh step did not report a status."
           fi
-          BODY="${BODY}
-
-## BASELINE REFRESH
-- Status: ${PERSIST_STATUS}
-- Detail: ${PERSIST_NOTE}"
+          BODY="${BODY}$(printf '\n\n## BASELINE REFRESH\n- Status: %s\n- Detail: %s' "${PERSIST_STATUS}" "${PERSIST_NOTE}")"
 
           if [ -n "$EXISTING" ]; then
             # Update existing issue

--- a/.github/workflows/require-cross-review.yml
+++ b/.github/workflows/require-cross-review.yml
@@ -1,12 +1,12 @@
 name: require-cross-review
 on:
   workflow_call:
-permissions:
-  contents: read
-  pull-requests: read
 
 jobs:
   require-cross-review:
+    permissions:
+      contents: read
+      pull-requests: read
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
## Problem

HP Governance Gate has had `startup_failure` on all PRs since ~18:27 UTC 2026-04-16. Root cause: all 7 SoM reusable workflows have top-level `permissions:` blocks. GitHub Actions raises `startup_failure` when a calling workflow invokes a reusable workflow that declares top-level permissions — the caller cannot honor them.

This is the same bug pattern as the prior `governance.yml` multi-job revert (tracked in LAM docs/PROGRESS.md: "Root cause: top-level permissions in reusable workflow caused startup_failure").

## Fix

Move `permissions:` from top level to job level in all 7 affected workflows:
- `check-agent-model-pins.yml`
- `check-codex-model-pins.yml`
- `require-cross-review.yml` (contents + pull-requests)
- `check-no-self-approval.yml`
- `check-pii-routing.yml` (contents + pull-requests)
- `check-claude-md-pointer.yml`
- `check-fallback-log-schema.yml`

Also fixes `overlord-sweep.yml` YAML parse error: bare `## BASELINE REFRESH` heading at column 0 inside `run: |` block was parsed as a YAML list item (same heredoc pattern from memory). Replaced with `printf` interpolation.

## Impact

Once merged to main: HP Governance Gate resumes for all open PRs. The 7 SoM workflows are called via `@main` from HP, AIS, and LAM governance.yml files — all three repos unblock simultaneously.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/overlord-sweep.yml'))"` → YAML VALID
- [x] All 7 fixed workflows: `permissions:` now at 4-space indent inside job, not top-level
- [ ] HP Governance Gate passes on next triggered run after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)