### PR TITLE
fix(ci): resolve cross-repo script paths for SoM reusable workflow callees

### DIFF
--- a/.github/workflows/check-agent-model-pins.yml
+++ b/.github/workflows/check-agent-model-pins.yml
@@ -12,8 +12,20 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Checkout governance scripts
+        if: github.repository != 'NIBARGERB-HLDPRO/hldpro-governance'
+        uses: actions/checkout@v6
+        with:
+          repository: NIBARGERB-HLDPRO/hldpro-governance
+          path: .governance
+          fetch-depth: 1
+
       - name: Validate agent model pins
         run: |
           set -euo pipefail
+          SCRIPTS_DIR="${GITHUB_WORKSPACE}/.github/scripts"
+          if [ -d "${GITHUB_WORKSPACE}/.governance" ]; then
+            SCRIPTS_DIR="${GITHUB_WORKSPACE}/.governance/.github/scripts"
+          fi
           python3 -m pip install --quiet pyyaml
-          python3 .github/scripts/check_agent_model_pins.py
+          python3 "${SCRIPTS_DIR}/check_agent_model_pins.py"

--- a/.github/workflows/check-codex-model-pins.yml
+++ b/.github/workflows/check-codex-model-pins.yml
@@ -12,7 +12,19 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Checkout governance scripts
+        if: github.repository != 'NIBARGERB-HLDPRO/hldpro-governance'
+        uses: actions/checkout@v6
+        with:
+          repository: NIBARGERB-HLDPRO/hldpro-governance
+          path: .governance
+          fetch-depth: 1
+
       - name: Validate codex exec model pinning
         run: |
           set -euo pipefail
-          python3 .github/scripts/check_codex_model_pins.py
+          SCRIPTS_DIR="${GITHUB_WORKSPACE}/.github/scripts"
+          if [ -d "${GITHUB_WORKSPACE}/.governance" ]; then
+            SCRIPTS_DIR="${GITHUB_WORKSPACE}/.governance/.github/scripts"
+          fi
+          python3 "${SCRIPTS_DIR}/check_codex_model_pins.py"

--- a/.github/workflows/check-fallback-log-schema.yml
+++ b/.github/workflows/check-fallback-log-schema.yml
@@ -12,11 +12,23 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Checkout governance scripts
+        if: github.repository != 'NIBARGERB-HLDPRO/hldpro-governance'
+        uses: actions/checkout@v6
+        with:
+          repository: NIBARGERB-HLDPRO/hldpro-governance
+          path: .governance
+          fetch-depth: 1
+
       - name: Validate model fallback log schema
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           set -euo pipefail
+          SCRIPTS_DIR="${GITHUB_WORKSPACE}/.github/scripts"
+          if [ -d "${GITHUB_WORKSPACE}/.governance" ]; then
+            SCRIPTS_DIR="${GITHUB_WORKSPACE}/.governance/.github/scripts"
+          fi
           python3 -m pip install --quiet pyyaml
-          python3 .github/scripts/check_fallback_log_schema.py
+          python3 "${SCRIPTS_DIR}/check_fallback_log_schema.py"

--- a/.github/workflows/check-no-self-approval.yml
+++ b/.github/workflows/check-no-self-approval.yml
@@ -12,11 +12,23 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Checkout governance scripts
+        if: github.repository != 'NIBARGERB-HLDPRO/hldpro-governance'
+        uses: actions/checkout@v6
+        with:
+          repository: NIBARGERB-HLDPRO/hldpro-governance
+          path: .governance
+          fetch-depth: 1
+
       - name: Validate cross-review model separation
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           set -euo pipefail
+          SCRIPTS_DIR="${GITHUB_WORKSPACE}/.github/scripts"
+          if [ -d "${GITHUB_WORKSPACE}/.governance" ]; then
+            SCRIPTS_DIR="${GITHUB_WORKSPACE}/.governance/.github/scripts"
+          fi
           python3 -m pip install --quiet pyyaml
-          python3 .github/scripts/check_no_self_approval.py
+          python3 "${SCRIPTS_DIR}/check_no_self_approval.py"

--- a/.github/workflows/check-pii-routing.yml
+++ b/.github/workflows/check-pii-routing.yml
@@ -13,11 +13,23 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Checkout governance scripts
+        if: github.repository != 'NIBARGERB-HLDPRO/hldpro-governance'
+        uses: actions/checkout@v6
+        with:
+          repository: NIBARGERB-HLDPRO/hldpro-governance
+          path: .governance
+          fetch-depth: 1
+
       - name: Validate PII routing and audit evidence
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           set -euo pipefail
+          SCRIPTS_DIR="${GITHUB_WORKSPACE}/.github/scripts"
+          if [ -d "${GITHUB_WORKSPACE}/.governance" ]; then
+            SCRIPTS_DIR="${GITHUB_WORKSPACE}/.governance/.github/scripts"
+          fi
           python3 -m pip install --quiet pyyaml
-          python3 .github/scripts/check_pii_routing.py
+          python3 "${SCRIPTS_DIR}/check_pii_routing.py"

--- a/.github/workflows/require-cross-review.yml
+++ b/.github/workflows/require-cross-review.yml
@@ -13,9 +13,24 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Checkout governance scripts
+        if: github.repository != 'NIBARGERB-HLDPRO/hldpro-governance'
+        uses: actions/checkout@v6
+        with:
+          repository: NIBARGERB-HLDPRO/hldpro-governance
+          path: .governance
+          fetch-depth: 1
+
       - name: Require cross-review artifact
         run: |
           set -euo pipefail
+
+          SCRIPTS_DIR="${GITHUB_WORKSPACE}/.github/scripts"
+          GOV_ROOT="${GITHUB_WORKSPACE}"
+          if [ -d "${GITHUB_WORKSPACE}/.governance" ]; then
+            SCRIPTS_DIR="${GITHUB_WORKSPACE}/.governance/.github/scripts"
+            GOV_ROOT="${GITHUB_WORKSPACE}/.governance"
+          fi
 
           BASE_SHA="${{ github.event.pull_request.base.sha }}"
           HEAD_SHA="${{ github.event.pull_request.head.sha }}"
@@ -33,7 +48,7 @@ jobs:
 
           TOUCH=0
           printf '%s\n' "${DIFF_FILES}" | grep -Eq '^STANDARDS\.md$|^docs/.*/[^/]*charter[^/]*\.md$|^docs/[^/]*charter[^/]*\.md$' && TOUCH=1 || true
-          LABELS="$(python3 .github/scripts/get_pr_labels.py)"
+          LABELS="$(python3 "${SCRIPTS_DIR}/get_pr_labels.py")"
 
           case " $LABELS " in
             *" architecture "*|*" standards "*)
@@ -58,7 +73,7 @@ jobs:
 
           if [ "${CROSS_FILE}" = "${BOOTSTRAP_FILE}" ]; then
             if [ -f "docs/exception-register.md" ]; then
-              EXCEPTION_ACTIVE="$(python3 .github/scripts/check_som_exception.py)"
+              EXCEPTION_ACTIVE="$(python3 "${SCRIPTS_DIR}/check_som_exception.py")"
               if [ "${EXCEPTION_ACTIVE}" = "active" ]; then
                 APPLY_EXCEPTION=true
               fi
@@ -70,4 +85,4 @@ jobs:
             exit 0
           fi
 
-          bash scripts/cross-review/require-dual-signature.sh "${CROSS_FILE}"
+          bash "${GOV_ROOT}/scripts/cross-review/require-dual-signature.sh" "${CROSS_FILE}"

--- a/raw/packets/2026-04-16-som-callee-cross-repo-t2-brief.yml
+++ b/raw/packets/2026-04-16-som-callee-cross-repo-t2-brief.yml
@@ -1,0 +1,48 @@
+packet_id: som-callee-cross-repo-t2-brief
+created_at: "2026-04-16T00:00:00Z"
+prior:
+  tier: 1
+  role: dual-planner
+  drafter_model_id: claude-opus-4-6
+  drafter_model_family: anthropic
+  reviewer_model_id: claude-sonnet-4-6
+  reviewer_model_family: anthropic
+  verdict: APPROVED_WITH_CORRECTION
+next_tier: 2
+tier_2_model: claude-sonnet-4-6
+correction_applied: >
+  Opus plan placed permissions at top-level (regresses PR #203 fix).
+  Corrected to job-level before implementation.
+branch: fix/som-callee-cross-repo-scripts-20260416
+target: main
+
+---
+# Tier 2 Brief — SoM Callee Cross-Repo Script Resolution Fix
+
+## Problem
+
+Seven reusable workflow callees in hldpro-governance run
+`python3 .github/scripts/check_*.py` but `actions/checkout` puts the
+CALLER's workspace on-disk. When called from HealthcarePlatform, those
+scripts don't exist and jobs fail with "No such file or directory".
+
+## Reference pattern (governance-check.yml)
+
+Add a conditional secondary checkout to `.governance/` then resolve
+SCRIPTS_DIR dynamically.
+
+## Files to modify (6 of 7 — check-claude-md-pointer.yml unchanged)
+
+1. check-agent-model-pins.yml
+2. check-codex-model-pins.yml
+3. check-no-self-approval.yml
+4. check-pii-routing.yml
+5. check-fallback-log-schema.yml
+6. require-cross-review.yml (most complex — uses GOV_ROOT for bash script)
+
+## Constraints
+
+- permissions: MUST stay at JOB level (not top-level) — top-level causes startup_failure
+- check-claude-md-pointer.yml: NO changes — it correctly checks the caller's CLAUDE.md
+- YAML validation required after each file write
+- pip install pyyaml preserved only where it existed before


### PR DESCRIPTION
## Summary

- Adds conditional secondary checkout of hldpro-governance into `.governance/` for the 6 SoM reusable callee workflows
- Dynamically resolves `SCRIPTS_DIR` (and `GOV_ROOT` for `require-cross-review`) based on whether `.governance/` is present
- Mirrors the pattern already used in `governance-check.yml`

## Root Cause

When called from HealthcarePlatform, `actions/checkout` puts HP's workspace on disk. Python scripts (`check_agent_model_pins.py`, etc.) live in governance's `.github/scripts/` — not HP's — so the jobs fail with "No such file or directory".

## Files Changed

| File | Change |
|---|---|
| `check-agent-model-pins.yml` | Secondary checkout + SCRIPTS_DIR |
| `check-codex-model-pins.yml` | Secondary checkout + SCRIPTS_DIR |
| `check-no-self-approval.yml` | Secondary checkout + SCRIPTS_DIR |
| `check-pii-routing.yml` | Secondary checkout + SCRIPTS_DIR |
| `check-fallback-log-schema.yml` | Secondary checkout + SCRIPTS_DIR |
| `require-cross-review.yml` | Secondary checkout + SCRIPTS_DIR + GOV_ROOT for bash script |
| `check-claude-md-pointer.yml` | **Unchanged** — checks caller's own CLAUDE.md, no governance scripts needed |

## Test plan
- [ ] Merge HP PR #1349 first (startup_failure fix — explicit caller permissions)
- [ ] Merge this PR into governance main
- [ ] HP PR #1349's SHA (or next HP PR) should trigger all 8 Governance Gate jobs — expect `claude-md-pointer` to pass, `agent-model-pins` / `codex-model-pins` / `no-self-approval` to pass or warn, `cross-review` / `pii-routing` / `fallback-log-schema` to pass or warn

## Related
- HP PR #1349: startup_failure fix (explicit caller `permissions:` blocks)
- Governance PR #203: permissions at job-level fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)