### PR TITLE
[codex] Enforce planner write-boundary

### DIFF
--- a/.github/workflows/governance-check.yml
+++ b/.github/workflows/governance-check.yml
@@ -252,6 +252,129 @@ jobs:
             --changed-files-file /tmp/governance-changed-files.txt \
             --enforce-governance-surface
 
+      - name: Enforce issue execution scope for planner boundary
+        if: github.event_name == 'pull_request'
+        run: |
+          set -euo pipefail
+
+          REPO_NAME="${GITHUB_REPOSITORY##*/}"
+          BRANCH_NAME="${GITHUB_HEAD_REF:-${GITHUB_REF_NAME}}"
+
+          if [ "$REPO_NAME" = "hldpro-governance" ]; then
+            ASSERT_SCOPE="scripts/overlord/assert_execution_scope.py"
+          else
+            ASSERT_SCOPE=".governance/scripts/overlord/assert_execution_scope.py"
+          fi
+
+          if [ ! -f "$ASSERT_SCOPE" ]; then
+            echo "::warning::Planner-boundary scope gate skipped: validator missing at ${ASSERT_SCOPE}."
+            exit 0
+          fi
+
+          BOUNDARY_REGEX='^(CLAUDE\.md|README\.md|STANDARDS\.md|OVERLORD_BACKLOG\.md|docs/(DATA_DICTIONARY|FEATURE_REGISTRY|PROGRESS|SERVICE_REGISTRY)\.md|\.github/workflows/|\.github/scripts/|agents/|docs/schemas/|hooks/|launchd/|raw/(closeouts|cross-review|execution-scopes|gate|model-fallbacks|operator-context|packets)/|metrics/|scripts/(knowledge_base|lam|orchestrator|overlord|packet)/|wiki/|docs/plans/)'
+          BOUNDARY_CHANGES="$(grep -E "$BOUNDARY_REGEX" /tmp/governance-changed-files.txt || true)"
+          if [ -z "$BOUNDARY_CHANGES" ]; then
+            echo "✓ No planner-boundary/governance-surface paths changed; execution-scope gate skipped"
+            exit 0
+          fi
+
+          ISSUE_TOKEN="$(printf '%s\n' "$BRANCH_NAME" | grep -oE 'issue-[0-9]+' | head -n 1 || true)"
+          ISSUE_NUMBER="${ISSUE_TOKEN#issue-}"
+          if [ -z "$ISSUE_NUMBER" ]; then
+            echo "::error::GOVERNANCE GATE FAILED: planner-boundary changes require an issue branch name like issue-<number>-... so CI can resolve raw/execution-scopes/*issue-<number>*implementation*.json (fallback: *planning*.json)."
+            echo "Changed boundary paths:"
+            echo "$BOUNDARY_CHANGES"
+            exit 1
+          fi
+
+          if [ ! -d raw/execution-scopes ]; then
+            echo "::error::GOVERNANCE GATE FAILED: planner-boundary changes detected but raw/execution-scopes/ is missing."
+            echo "Add an issue-specific execution scope, e.g. raw/execution-scopes/*issue-${ISSUE_NUMBER}*implementation*.json."
+            exit 1
+          fi
+
+          mapfile -t IMPLEMENTATION_SCOPES < <(find raw/execution-scopes -maxdepth 1 -type f -name "*issue-${ISSUE_NUMBER}*implementation*.json" | sort)
+          mapfile -t PLANNING_SCOPES < <(find raw/execution-scopes -maxdepth 1 -type f -name "*issue-${ISSUE_NUMBER}*planning*.json" | sort)
+
+          if [ "${#IMPLEMENTATION_SCOPES[@]}" -gt 1 ]; then
+            echo "::error::GOVERNANCE GATE FAILED: multiple implementation execution scopes match issue-${ISSUE_NUMBER}."
+            printf '  - %s\n' "${IMPLEMENTATION_SCOPES[@]}"
+            echo "Keep one canonical implementation scope file per issue."
+            exit 1
+          fi
+
+          if [ "${#PLANNING_SCOPES[@]}" -gt 1 ]; then
+            echo "::error::GOVERNANCE GATE FAILED: multiple planning execution scopes match issue-${ISSUE_NUMBER}."
+            printf '  - %s\n' "${PLANNING_SCOPES[@]}"
+            echo "Keep one canonical planning scope fallback per issue."
+            exit 1
+          fi
+
+          SCOPE_PATH=""
+          if [ "${#IMPLEMENTATION_SCOPES[@]}" -eq 1 ]; then
+            SCOPE_PATH="${IMPLEMENTATION_SCOPES[0]}"
+          elif [ "${#PLANNING_SCOPES[@]}" -eq 1 ]; then
+            SCOPE_PATH="${PLANNING_SCOPES[0]}"
+          fi
+
+          if [ -z "$SCOPE_PATH" ]; then
+            echo "::error::GOVERNANCE GATE FAILED: planner-boundary changes detected but no issue-specific execution scope exists for issue-${ISSUE_NUMBER}."
+            echo "Expected naming: raw/execution-scopes/*issue-${ISSUE_NUMBER}*implementation*.json (preferred) or *issue-${ISSUE_NUMBER}*planning*.json (fallback)."
+            echo "Changed boundary paths:"
+            echo "$BOUNDARY_CHANGES"
+            exit 1
+          fi
+
+          BASE="${{ steps.diff_base.outputs.base_sha }}"
+          if [ -z "$BASE" ]; then
+            BASE="${{ github.event.pull_request.base.sha }}"
+          fi
+          if [ -z "$BASE" ]; then
+            echo "::error::GOVERNANCE GATE FAILED: unable to resolve base commit for trusted execution-scope validation."
+            exit 1
+          fi
+
+          TRUSTED_SCOPE_PATH="$SCOPE_PATH"
+          TRUSTED_SCOPE_TMP=""
+          cleanup_trusted_scope() {
+            if [ -n "$TRUSTED_SCOPE_TMP" ] && [ -f "$TRUSTED_SCOPE_TMP" ]; then
+              rm -f "$TRUSTED_SCOPE_TMP"
+            fi
+          }
+          trap cleanup_trusted_scope EXIT
+
+          if grep -Fxq "$SCOPE_PATH" /tmp/governance-changed-files.txt; then
+            echo "Execution scope changed in PR: ${SCOPE_PATH}"
+            TRUSTED_SCOPE_TMP="$(mktemp "${TMPDIR:-/tmp}/trusted-execution-scope.XXXXXX.json")"
+            if git show "${BASE}:${SCOPE_PATH}" > "$TRUSTED_SCOPE_TMP" 2>/dev/null; then
+              TRUSTED_SCOPE_PATH="$TRUSTED_SCOPE_TMP"
+              echo "Using trusted execution scope from base commit ${BASE}:${SCOPE_PATH}"
+            else
+              rm -f "$TRUSTED_SCOPE_TMP"
+              TRUSTED_SCOPE_TMP=""
+
+              NON_PLANNING_BOUNDARY_CHANGES="$(printf '%s\n' "$BOUNDARY_CHANGES" | grep -Ev '^(docs/plans/|raw/cross-review/|raw/execution-scopes/|OVERLORD_BACKLOG\.md$|docs/PROGRESS\.md$)' || true)"
+              if [ -n "$NON_PLANNING_BOUNDARY_CHANGES" ]; then
+                echo "::error::GOVERNANCE GATE FAILED: ${SCOPE_PATH} is new or modified in this PR and has no trusted base copy."
+                echo "This PR also changes non-planning planner-boundary files, so strict execution-scope authorization cannot trust head-authored scope changes."
+                echo "Action: merge the issue-specific execution scope in a planning-only PR first, then open a follow-up implementation PR."
+                echo "Non-planning planner-boundary changes:"
+                echo "$NON_PLANNING_BOUNDARY_CHANGES"
+                exit 1
+              fi
+
+              echo "::notice::Planner-boundary strict execution-scope assertion skipped: ${SCOPE_PATH} is new/modified with no base copy, and boundary changes are planning-only artifacts."
+              echo "Planning-only scope changes may proceed through structured-plan and cross-review gates."
+              echo "Implementation file authorization must happen in a follow-up PR after that scope lands on base."
+              exit 0
+            fi
+          fi
+
+          echo "Using execution scope: ${TRUSTED_SCOPE_PATH}"
+          python3 "$ASSERT_SCOPE" \
+            --scope "$TRUSTED_SCOPE_PATH" \
+            --changed-files-file /tmp/governance-changed-files.txt
+
       # ── 2. PROGRESS.md co-staged with code changes ──
       - name: Check PROGRESS.md updated with code changes
         if: steps.changed.outputs.has_code == 'true'

--- a/README.md
+++ b/README.md
@@ -104,6 +104,9 @@ Rules:
 - Markdown is optional companion context
 - `specialist_reviews` and `alternate_model_review` are mandatory structured fields
 - reusable governance CI validates `*structured-agent-cycle-plan.json` on issue/riskfix execution branches
+- Tier 1 planner writes are restricted to planning/review/handoff artifacts via execution-scope `allowed_write_paths`
+- Non-planning diffs require accepted pinned-agent handoff evidence; same-model/family implementers need an active exception reference with expiry
+- CI is authoritative for this planner boundary; local hook warnings are early signal only
 
 ### Claude Agents
 
@@ -170,6 +173,7 @@ Findings are tagged `CODEX-FLAGGED` for traceability. See [`scripts/overlord/REA
 - **Issue-backed governance backlog** — GitHub Issues are the execution backlog for this repo; `OVERLORD_BACKLOG.md` is the roadmap/status mirror and CI blocks actionable rows without issue references
 - **PROGRESS ↔ GitHub staleness gate** — governed product repos must keep active `docs/PROGRESS.md` backlog sections aligned with backlog-labeled GitHub issues; reusable governance CI and weekly sweep now surface drift
 - **Doc co-staging** — Source code changes must co-stage related governance docs (PROGRESS, FEATURE_REGISTRY, FAIL_FAST_LOG, etc.)
+- **Planner write-boundary** — Tier 1 planners may write planning/review/handoff artifacts only; non-planning changes require accepted pinned-agent handoff evidence and active exceptions for same-model/family implementers
 - **Security tiers** — Tiered requirements from baseline gitleaks up to HIPAA-compliant PHI redaction agents, break-glass gates, and audit retention
 - **Fail-fast loop closure** — Repos with test/heal cycles must auto-persist failure patterns and surface gate failures
 - **Completion verification** — Creates isolated worktrees and runs `git show HEAD:<path>` to verify artifacts exist before allowing "done" status

--- a/STANDARDS.md
+++ b/STANDARDS.md
@@ -45,6 +45,13 @@
 - Reusable governance CI validates structured plans through `scripts/overlord/validate_structured_agent_cycle_plan.py`.
 - Cross-model review results from `scripts/codex-review.sh claude` belong in `alternate_model_review`.
 
+### Planner Write-Boundary (Tier 1)
+- Tier 1 planner sessions may create planning, review, and handoff artifacts only.
+- Planning execution scope must declare this boundary with `execution_mode: planning_only` and `allowed_write_paths`; that allowlist is the authoritative planning write surface.
+- Non-planning diffs require accepted pinned-agent handoff evidence (`handoff_evidence.status: accepted`) before merge.
+- If planner and implementer are the same model or model family, handoff evidence must include an active exception reference and concrete expiry (`active_exception_ref`, `active_exception_expires_at`).
+- CI is authoritative for this boundary (`.github/workflows/governance-check.yml`); local hook output from `hooks/code-write-gate.sh` is warning/early-signal only for planner-boundary drift.
+
 ### Branch Isolation (global hook)
 - `~/.claude/hooks/branch-switch-guard.sh` — **global PreToolUse hook** that blocks `git checkout <branch>` and `git switch <branch>` in all repos
 - Prevents multi-session conflicts where one session's branch switch corrupts another session's working directory

--- a/docs/DATA_DICTIONARY.md
+++ b/docs/DATA_DICTIONARY.md
@@ -223,6 +223,10 @@ Contract:
 - The matching plan must be approved and have `execution_handoff.execution_mode` set to `implementation_ready` or `implementation_complete`.
 - If `alternate_model_review.required` is true, status must be `accepted` or `accepted_with_followup`.
 - Local execution scope validation declares expected checkout root, branch, allowed write paths, and forbidden dirty roots.
+- Tier 1 planner-boundary mode uses execution scope `execution_mode: planning_only`; `allowed_write_paths` is the planning artifact allowlist.
+- Non-planning diffs require `handoff_evidence.status: accepted` and pinned planner/implementer metadata before scope assertion passes.
+- If planner and implementer use the same model id or model family, handoff evidence must include `active_exception_ref` plus non-expired `active_exception_expires_at`.
+- For planner-boundary enforcement, CI (`governance-check.yml`) is authoritative; the local hook is warning/early-signal only.
 
 ---
 

--- a/docs/FEATURE_REGISTRY.md
+++ b/docs/FEATURE_REGISTRY.md
@@ -126,6 +126,9 @@
 | GOV-019 | `scripts/overlord/validate_structured_agent_cycle_plan.py` classifies governance-surface paths and requires issue-specific canonical structured plans with implementation-ready handoff and accepted alternate review before those paths can change. |
 | GOV-019 | `.github/workflows/governance-check.yml` and `hooks/code-write-gate.sh` call the shared validator so CI and local write-time enforcement use the same governance-surface planning gate. |
 | GOV-019 | `scripts/overlord/assert_execution_scope.py` remains the root/branch/write-scope guard, with tests proving wrong checkout roots, dirty forbidden roots, and out-of-scope paths fail locally. |
+| GOV-019 | Planner write-boundary enforcement now treats Tier 1 sessions as planning-only by default (`execution_mode: planning_only`), with `allowed_write_paths` as the planning artifact allowlist. |
+| GOV-019 | Non-planning diffs now require accepted pinned-agent handoff evidence, and same-model or same-family planner/implementer pairs require an active exception reference with expiry. |
+| GOV-019 | For planner-boundary enforcement, CI in `.github/workflows/governance-check.yml` is authoritative while local `hooks/code-write-gate.sh` output is warning/early-signal only. |
 
 ### READ_ONLY_GOVERNANCE_OBSERVER
 

--- a/docs/SERVICE_REGISTRY.md
+++ b/docs/SERVICE_REGISTRY.md
@@ -21,7 +21,7 @@
 
 | Workflow | File | Trigger | Purpose |
 |----------|------|---------|---------|
-| governance-check | `.github/workflows/governance-check.yml` | PR / push | Doc co-staging, structured planning, governance-surface, and registry gates |
+| governance-check | `.github/workflows/governance-check.yml` | PR / push | Doc co-staging, structured planning, governance-surface, planner write-boundary, and registry gates |
 | check-backlog-gh-sync | `.github/workflows/check-backlog-gh-sync.yml` | PR / push (OVERLORD_BACKLOG.md) | Backlog ↔ GH issue sync gate |
 | check-pr-commit-scope | `.github/workflows/check-pr-commit-scope.yml` | PR to main | Stale-worktree contamination guard |
 | overlord-sweep | `.github/workflows/overlord-sweep.yml` | Weekly (Mon 9am CT) | Cross-repo standards sweep |
@@ -39,7 +39,7 @@
 |--------|------|---------|
 | validate_backlog_gh_sync.py | `scripts/overlord/validate_backlog_gh_sync.py` | Validates OVERLORD_BACKLOG.md Planned rows reference open GH issues |
 | validate_structured_agent_cycle_plan.py | `scripts/overlord/validate_structured_agent_cycle_plan.py` | Validates structured plan JSON against org schema |
-| assert_execution_scope.py | `scripts/overlord/assert_execution_scope.py` | Asserts issue work runs from the declared root, branch, allowed write paths, and clean forbidden roots |
+| assert_execution_scope.py | `scripts/overlord/assert_execution_scope.py` | Asserts issue work runs from the declared root/branch, enforces planning-only `allowed_write_paths`, and requires accepted pinned-agent handoff evidence for non-planning diffs |
 | validate_governed_repos.py | `scripts/overlord/validate_governed_repos.py` | Validates `docs/governed_repos.json` and reconciles it with graphify targets |
 | governed_repos.py | `scripts/overlord/governed_repos.py` | Shared adapter for executable governed repo registry consumers |
 | codex_ingestion.py | `scripts/overlord/codex_ingestion.py` | Codex review ingestion: generate, qualify, promote |
@@ -91,5 +91,5 @@
 
 | Hook | Path | Scope | Purpose |
 |------|------|-------|---------|
-| code-write-gate.sh | `hooks/code-write-gate.sh` | Local Claude Code write hook | Blocks unplanned governance-surface writes and enforces SoM new-code routing |
+| code-write-gate.sh | `hooks/code-write-gate.sh` | Local Claude Code write hook | Blocks unplanned governance-surface writes, enforces SoM new-code routing, and surfaces planner-boundary drift as early warning (CI is authoritative) |
 | closeout-hook.sh | `hooks/closeout-hook.sh` | Repo-wide | Validates closeout artifact on Stage 6 completion |

--- a/hooks/code-write-gate.sh
+++ b/hooks/code-write-gate.sh
@@ -60,6 +60,55 @@ PY
         printf '%s' "{\"decision\":\"block\",\"reason\":\"BLOCKED: Governance-surface writes require an issue-backed structured JSON plan, accepted review status, and implementation-ready execution handoff.\\n\\n${reason}\"}"
         exit 2
       fi
+
+      # Planner-boundary execution-scope enforcement is warning-only in local hooks.
+      boundary_scope_candidate=false
+      case "$rel_path" in
+        CLAUDE.md|README.md|STANDARDS.md|OVERLORD_BACKLOG.md|docs/DATA_DICTIONARY.md|docs/FEATURE_REGISTRY.md|docs/PROGRESS.md|docs/SERVICE_REGISTRY.md|\
+        .github/workflows/*|.github/scripts/*|agents/*|docs/schemas/*|hooks/*|launchd/*|raw/closeouts/*|raw/cross-review/*|raw/execution-scopes/*|\
+        raw/gate/*|raw/model-fallbacks/*|raw/operator-context/*|raw/packets/*|metrics/*|scripts/knowledge_base/*|scripts/lam/*|scripts/orchestrator/*|\
+        scripts/overlord/*|scripts/packet/*|wiki/*|docs/plans/*)
+          boundary_scope_candidate=true
+          ;;
+      esac
+
+      if [ "$boundary_scope_candidate" = true ]; then
+        scope_validator="$repo_root/scripts/overlord/assert_execution_scope.py"
+        issue_token="$(printf '%s\n' "$branch_name" | grep -oE 'issue-[0-9]+' | head -n 1 || true)"
+        issue_number="${issue_token#issue-}"
+
+        if [ -f "$scope_validator" ] && [ -n "$issue_number" ] && [ -d "$repo_root/raw/execution-scopes" ]; then
+          mapfile -t implementation_scopes < <(find "$repo_root/raw/execution-scopes" -maxdepth 1 -type f -name "*issue-${issue_number}*implementation*.json" | sort)
+          mapfile -t planning_scopes < <(find "$repo_root/raw/execution-scopes" -maxdepth 1 -type f -name "*issue-${issue_number}*planning*.json" | sort)
+
+          selected_scope=""
+          if [ "${#implementation_scopes[@]}" -eq 1 ]; then
+            selected_scope="${implementation_scopes[0]}"
+          elif [ "${#planning_scopes[@]}" -eq 1 ]; then
+            selected_scope="${planning_scopes[0]}"
+          fi
+
+          if [ -z "$selected_scope" ]; then
+            if [ "${#implementation_scopes[@]}" -gt 1 ] || [ "${#planning_scopes[@]}" -gt 1 ]; then
+              echo "WARN planner-boundary execution-scope check skipped: multiple matching scope files for issue-${issue_number}" >&2
+            else
+              echo "WARN planner-boundary execution-scope check skipped: no scope file matched issue-${issue_number}" >&2
+            fi
+          else
+            scope_changed_file="$(mktemp "${TMPDIR:-/tmp}/planner-boundary-change.XXXXXX")"
+            printf '%s\n' "$rel_path" > "$scope_changed_file"
+            scope_output="$(python3 "$scope_validator" \
+              --scope "$selected_scope" \
+              --changed-files-file "$scope_changed_file" 2>&1)"
+            scope_status=$?
+            rm -f "$scope_changed_file"
+            if [ "$scope_status" -ne 0 ]; then
+              echo "WARN planner-boundary drift detected (warning-only in local hook):" >&2
+              echo "$scope_output" >&2
+            fi
+          fi
+        fi
+      fi
     fi
   fi
 fi

--- a/scripts/overlord/assert_execution_scope.py
+++ b/scripts/overlord/assert_execution_scope.py
@@ -6,15 +6,29 @@ import json
 import subprocess
 import sys
 from dataclasses import dataclass
+from datetime import datetime, timezone
 from pathlib import Path
 
 
 @dataclass(frozen=True)
+class HandoffEvidence:
+    status: str
+    planner_model: str
+    implementer_model: str
+    accepted_at: datetime
+    evidence_paths: tuple[str, ...]
+    active_exception_ref: str | None
+    active_exception_expires_at: datetime | None
+
+
+@dataclass(frozen=True)
 class ExecutionScope:
-    expected_execution_root: Path
+    expected_execution_root: str
     expected_branch: str
     allowed_write_paths: tuple[str, ...]
     forbidden_roots: tuple[Path, ...]
+    execution_mode: str = "planning_only"
+    handoff_evidence: HandoffEvidence | None = None
 
 
 def _run_git(args: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:
@@ -31,6 +45,115 @@ def _normalize_repo_path(path: str) -> str:
     while path.startswith("./"):
         path = path[2:]
     return path
+
+
+def _normalize_repo_relative_file_path(raw_path: str, field_name: str, scope_path: Path) -> str:
+    normalized = _normalize_repo_path(raw_path.strip())
+    if not normalized:
+        raise ValueError(f"{scope_path}: `{field_name}` must be a non-empty repo-relative file path")
+    if "\\" in normalized:
+        raise ValueError(f"{scope_path}: `{field_name}` must use '/' path separators")
+    path_obj = Path(normalized)
+    if path_obj.is_absolute():
+        raise ValueError(f"{scope_path}: `{field_name}` must be repo-relative (absolute paths are not allowed)")
+    if any(part == ".." for part in path_obj.parts):
+        raise ValueError(f"{scope_path}: `{field_name}` must not traverse parent directories")
+    normalized_path = path_obj.as_posix()
+    if normalized_path in {"", "."}:
+        raise ValueError(f"{scope_path}: `{field_name}` must point to a repo file path")
+    return normalized_path
+
+
+def _normalize_active_exception_ref(raw_ref: str, scope_path: Path) -> str:
+    path_part, has_anchor, anchor = raw_ref.partition("#")
+    normalized_path = _normalize_repo_relative_file_path(
+        path_part,
+        "handoff_evidence.active_exception_ref",
+        scope_path,
+    )
+    if has_anchor and not anchor:
+        raise ValueError(f"{scope_path}: `handoff_evidence.active_exception_ref` has an empty '#anchor' suffix")
+    if has_anchor:
+        return f"{normalized_path}#{anchor}"
+    return normalized_path
+
+
+def _parse_iso8601_timestamp(raw_value: str, field_name: str, path: Path) -> datetime:
+    if not isinstance(raw_value, str) or not raw_value:
+        raise ValueError(f"{path}: `{field_name}` must be a non-empty string")
+    normalized = raw_value
+    if normalized.endswith("Z"):
+        normalized = normalized[:-1] + "+00:00"
+    try:
+        parsed = datetime.fromisoformat(normalized)
+    except ValueError as exc:
+        raise ValueError(f"{path}: `{field_name}` must be a valid ISO-8601 timestamp") from exc
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def _load_handoff_evidence(payload: dict[str, object], scope_path: Path) -> HandoffEvidence:
+    required = [
+        "status",
+        "planner_model",
+        "implementer_model",
+        "accepted_at",
+        "evidence_paths",
+        "active_exception_ref",
+        "active_exception_expires_at",
+    ]
+    missing = [field for field in required if field not in payload]
+    if missing:
+        raise ValueError(f"{scope_path}: `handoff_evidence` missing field(s): {', '.join(missing)}")
+
+    status = payload["status"]
+    planner_model = payload["planner_model"]
+    implementer_model = payload["implementer_model"]
+    accepted_at_raw = payload["accepted_at"]
+    evidence_paths = payload["evidence_paths"]
+    active_exception_ref = payload["active_exception_ref"]
+    active_exception_expires_at_raw = payload["active_exception_expires_at"]
+
+    if not isinstance(status, str) or not status:
+        raise ValueError(f"{scope_path}: `handoff_evidence.status` must be a non-empty string")
+    if not isinstance(planner_model, str) or not planner_model:
+        raise ValueError(f"{scope_path}: `handoff_evidence.planner_model` must be a non-empty string")
+    if not isinstance(implementer_model, str) or not implementer_model:
+        raise ValueError(f"{scope_path}: `handoff_evidence.implementer_model` must be a non-empty string")
+    if not isinstance(evidence_paths, list) or not all(isinstance(item, str) and item for item in evidence_paths):
+        raise ValueError(f"{scope_path}: `handoff_evidence.evidence_paths` must be an array of non-empty strings")
+    if active_exception_ref is not None and (not isinstance(active_exception_ref, str) or not active_exception_ref):
+        raise ValueError(f"{scope_path}: `handoff_evidence.active_exception_ref` must be null or a non-empty string")
+    if active_exception_expires_at_raw is not None and (
+        not isinstance(active_exception_expires_at_raw, str) or not active_exception_expires_at_raw
+    ):
+        raise ValueError(
+            f"{scope_path}: `handoff_evidence.active_exception_expires_at` must be null or a non-empty string"
+        )
+
+    accepted_at = _parse_iso8601_timestamp(accepted_at_raw, "handoff_evidence.accepted_at", scope_path)
+    active_exception_expires_at = None
+    if isinstance(active_exception_expires_at_raw, str):
+        active_exception_expires_at = _parse_iso8601_timestamp(
+            active_exception_expires_at_raw,
+            "handoff_evidence.active_exception_expires_at",
+            scope_path,
+        )
+
+    normalized_exception_ref = None
+    if isinstance(active_exception_ref, str):
+        normalized_exception_ref = _normalize_active_exception_ref(active_exception_ref, scope_path)
+
+    return HandoffEvidence(
+        status=status,
+        planner_model=planner_model,
+        implementer_model=implementer_model,
+        accepted_at=accepted_at,
+        evidence_paths=tuple(_normalize_repo_path(item) for item in evidence_paths),
+        active_exception_ref=normalized_exception_ref,
+        active_exception_expires_at=active_exception_expires_at,
+    )
 
 
 def _load_scope(path: Path) -> ExecutionScope:
@@ -52,6 +175,8 @@ def _load_scope(path: Path) -> ExecutionScope:
     expected_branch = payload["expected_branch"]
     allowed_write_paths = payload["allowed_write_paths"]
     forbidden_roots = payload["forbidden_roots"]
+    execution_mode = payload.get("execution_mode", "planning_only")
+    handoff_evidence_payload = payload.get("handoff_evidence")
 
     if not isinstance(expected_execution_root, str) or not expected_execution_root:
         raise ValueError(f"{path}: `expected_execution_root` must be a non-empty string")
@@ -61,12 +186,22 @@ def _load_scope(path: Path) -> ExecutionScope:
         raise ValueError(f"{path}: `allowed_write_paths` must be an array of non-empty strings")
     if not isinstance(forbidden_roots, list) or not all(isinstance(item, str) and item for item in forbidden_roots):
         raise ValueError(f"{path}: `forbidden_roots` must be an array of non-empty strings")
+    if not isinstance(execution_mode, str) or not execution_mode:
+        raise ValueError(f"{path}: `execution_mode` must be a non-empty string when provided")
+    if handoff_evidence_payload is not None and not isinstance(handoff_evidence_payload, dict):
+        raise ValueError(f"{path}: `handoff_evidence` must be an object when provided")
+
+    handoff_evidence = None
+    if isinstance(handoff_evidence_payload, dict):
+        handoff_evidence = _load_handoff_evidence(handoff_evidence_payload, path)
 
     return ExecutionScope(
-        expected_execution_root=Path(expected_execution_root).expanduser().resolve(strict=False),
+        expected_execution_root=expected_execution_root,
         expected_branch=expected_branch,
         allowed_write_paths=tuple(_normalize_repo_path(item) for item in allowed_write_paths),
         forbidden_roots=tuple(Path(item).expanduser().resolve(strict=False) for item in forbidden_roots),
+        execution_mode=execution_mode,
+        handoff_evidence=handoff_evidence,
     )
 
 
@@ -112,26 +247,125 @@ def _changed_paths(cwd: Path) -> list[str] | None:
     return sorted(set(paths))
 
 
+def _changed_paths_from_file(path: Path) -> list[str]:
+    raw = path.read_text(encoding="utf-8")
+    entries = raw.split("\0") if "\0" in raw else raw.splitlines()
+    changed_paths = []
+    for entry in entries:
+        if not entry:
+            continue
+        changed_paths.append(_normalize_repo_path(entry))
+    return sorted(set(changed_paths))
+
+
 def _path_allowed(path: str, allowed_write_paths: tuple[str, ...]) -> bool:
     return any(path == allowed or (allowed.endswith("/") and path.startswith(allowed)) for allowed in allowed_write_paths)
+
+
+def _model_family(model: str) -> str:
+    normalized = model.strip().lower().replace("_", "-")
+    if "/" in normalized:
+        normalized = normalized.rsplit("/", 1)[-1]
+    if normalized.startswith("gpt-"):
+        parts = [part for part in normalized.split("-") if part]
+        if len(parts) >= 2:
+            major_line = parts[1].split(".", 1)[0]
+            if major_line:
+                return f"gpt-{major_line}"
+        return "gpt"
+    if normalized.startswith("claude"):
+        return "claude"
+    parts = [part for part in normalized.split("-") if part]
+    if not parts:
+        return normalized
+    if len(parts) >= 2 and any(char.isdigit() for char in parts[1]):
+        return f"{parts[0]}-{parts[1]}"
+    return parts[0]
+
+
+def _same_model_or_family(planner_model: str, implementer_model: str) -> bool:
+    planner = planner_model.strip().lower()
+    implementer = implementer_model.strip().lower()
+    return planner == implementer or _model_family(planner) == _model_family(implementer)
+
+
+def _validate_execution_mode(scope: ExecutionScope, now_utc: datetime) -> list[str]:
+    if scope.execution_mode == "planning_only":
+        return []
+
+    if scope.handoff_evidence is None:
+        return [f"execution_mode {scope.execution_mode!r} requires `handoff_evidence.status` == 'accepted'"]
+
+    handoff = scope.handoff_evidence
+    failures: list[str] = []
+    if handoff.status.lower() != "accepted":
+        failures.append("non-planning execution_mode requires `handoff_evidence.status` == 'accepted'")
+
+    if _same_model_or_family(handoff.planner_model, handoff.implementer_model):
+        if not handoff.active_exception_ref:
+            failures.append(
+                "planner/implementer same model or family requires `handoff_evidence.active_exception_ref`"
+            )
+        if handoff.active_exception_expires_at is None:
+            failures.append(
+                "planner/implementer same model or family requires `handoff_evidence.active_exception_expires_at`"
+            )
+        elif handoff.active_exception_expires_at < now_utc:
+            failures.append(
+                "planner/implementer same model or family requires non-expired "
+                "`handoff_evidence.active_exception_expires_at`"
+            )
+
+    return failures
 
 
 def _format_path(path: Path) -> str:
     return str(path)
 
 
-def check_scope(scope: ExecutionScope, cwd: Path) -> tuple[list[str], list[str]]:
+def _resolve_expected_execution_root(expected_execution_root: str, actual_root: Path) -> Path:
+    if expected_execution_root in {".", "{repo_root}"}:
+        return actual_root
+    return Path(expected_execution_root).expanduser().resolve(strict=False)
+
+
+def _validate_active_exception_ref(scope: ExecutionScope, actual_root: Path) -> list[str]:
+    handoff = scope.handoff_evidence
+    if handoff is None or handoff.active_exception_ref is None:
+        return []
+
+    exception_path = handoff.active_exception_ref.split("#", 1)[0]
+    repo_file = actual_root / exception_path
+    if not repo_file.is_file():
+        return [
+            "handoff_evidence.active_exception_ref must reference an existing repo file path: "
+            f"{exception_path}"
+        ]
+    return []
+
+
+def check_scope(
+    scope: ExecutionScope,
+    cwd: Path,
+    *,
+    changed_files_file: Path | None = None,
+    now_utc: datetime | None = None,
+) -> tuple[list[str], list[str]]:
     failures: list[str] = []
     warnings: list[str] = []
+
+    if now_utc is None:
+        now_utc = datetime.now(timezone.utc)
 
     actual_root = _git_root(cwd)
     if actual_root is None:
         failures.append(f"{cwd}: not inside a git repository")
         return failures, warnings
-    if actual_root != scope.expected_execution_root:
+    expected_root = _resolve_expected_execution_root(scope.expected_execution_root, actual_root)
+    if actual_root != expected_root:
         failures.append(
             "execution root mismatch: "
-            f"expected {_format_path(scope.expected_execution_root)}, got {_format_path(actual_root)}"
+            f"expected {_format_path(expected_root)}, got {_format_path(actual_root)}"
         )
 
     actual_branch = _current_branch(cwd)
@@ -140,10 +374,21 @@ def check_scope(scope: ExecutionScope, cwd: Path) -> tuple[list[str], list[str]]
     elif actual_branch != scope.expected_branch:
         failures.append(f"branch mismatch: expected {scope.expected_branch}, got {actual_branch or '<detached HEAD>'}")
 
-    changed_paths = _changed_paths(actual_root)
-    if changed_paths is None:
-        failures.append(f"{actual_root}: could not read git status")
+    failures.extend(_validate_execution_mode(scope, now_utc))
+    failures.extend(_validate_active_exception_ref(scope, actual_root))
+
+    changed_paths: list[str] | None = None
+    if changed_files_file is None:
+        changed_paths = _changed_paths(actual_root)
+        if changed_paths is None:
+            failures.append(f"{actual_root}: could not read git status")
     else:
+        try:
+            changed_paths = _changed_paths_from_file(changed_files_file)
+        except OSError as exc:
+            failures.append(f"could not read changed files from {_format_path(changed_files_file)}: {exc}")
+
+    if changed_paths is not None:
         out_of_scope = [path for path in changed_paths if not _path_allowed(path, scope.allowed_write_paths)]
         if out_of_scope:
             failures.append(
@@ -180,6 +425,7 @@ def check_scope(scope: ExecutionScope, cwd: Path) -> tuple[list[str], list[str]]
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description="Assert the current checkout matches a declared execution scope.")
     parser.add_argument("--scope", required=True, help="Path to execution scope JSON.")
+    parser.add_argument("--changed-files-file", help="Optional file containing changed paths to validate.")
     args = parser.parse_args(argv)
 
     try:
@@ -188,7 +434,8 @@ def main(argv: list[str] | None = None) -> int:
         print(f"FAIL could not load scope: {exc}", file=sys.stderr)
         return 2
 
-    failures, warnings = check_scope(scope, Path.cwd())
+    changed_files_file = Path(args.changed_files_file).expanduser() if args.changed_files_file else None
+    failures, warnings = check_scope(scope, Path.cwd(), changed_files_file=changed_files_file)
     for warning in warnings:
         print(f"WARN {warning}")
     if failures:

--- a/scripts/overlord/test_assert_execution_scope.py
+++ b/scripts/overlord/test_assert_execution_scope.py
@@ -5,11 +5,13 @@ import contextlib
 import importlib.util
 import io
 import json
+import shutil
 import subprocess
 import sys
 import tempfile
 import unittest
 from pathlib import Path
+from typing import Any
 
 
 MODULE_PATH = Path(__file__).with_name("assert_execution_scope.py")
@@ -54,10 +56,12 @@ class TestAssertExecutionScope(unittest.TestCase):
     def _scope_file(
         self,
         tmpdir: Path,
-        expected_root: Path,
+        expected_root: Path | str,
         branch: str = "scope-test",
         allowed: list[str] | None = None,
         forbidden_roots: list[Path] | None = None,
+        execution_mode: str | None = None,
+        handoff_evidence: dict[str, Any] | None = None,
     ) -> Path:
         scope = {
             "expected_execution_root": str(expected_root),
@@ -65,17 +69,51 @@ class TestAssertExecutionScope(unittest.TestCase):
             "allowed_write_paths": allowed or ["allowed.txt", "allowed-dir/"],
             "forbidden_roots": [str(path) for path in forbidden_roots or []],
         }
+        if execution_mode is not None:
+            scope["execution_mode"] = execution_mode
+        if handoff_evidence is not None:
+            scope["handoff_evidence"] = handoff_evidence
         path = tmpdir / "scope.json"
         path.write_text(json.dumps(scope), encoding="utf-8")
         return path
 
-    def _run_main(self, repo: Path, scope: Path) -> tuple[int, str]:
+    def _run_main(self, repo: Path, scope: Path, changed_files_file: Path | None = None) -> tuple[int, str]:
+        args = ["--scope", str(scope)]
+        if changed_files_file is not None:
+            args.extend(["--changed-files-file", str(changed_files_file)])
         stdout = io.StringIO()
         with contextlib.redirect_stdout(stdout), _working_directory(repo):
-            code = assert_execution_scope.main(["--scope", str(scope)])
+            code = assert_execution_scope.main(args)
         return code, stdout.getvalue()
 
-    def test_allows_changes_in_allowed_paths(self) -> None:
+    def _changed_files_file(self, tmpdir: Path, paths: list[str], name: str = "changed-files.txt") -> Path:
+        path = tmpdir / name
+        path.write_text("\n".join(paths) + "\n", encoding="utf-8")
+        return path
+
+    def _write_exception_file(self, repo: RepoFixture, relative_path: str) -> None:
+        repo.write(relative_path, "approved exception\n")
+
+    def _handoff(
+        self,
+        *,
+        planner_model: str,
+        implementer_model: str,
+        status: str = "accepted",
+        active_exception_ref: str | None = None,
+        active_exception_expires_at: str | None = None,
+    ) -> dict[str, Any]:
+        return {
+            "status": status,
+            "planner_model": planner_model,
+            "implementer_model": implementer_model,
+            "accepted_at": "2026-04-17T00:00:00Z",
+            "evidence_paths": ["raw/closeouts/issue-242-handoff.md"],
+            "active_exception_ref": active_exception_ref,
+            "active_exception_expires_at": active_exception_expires_at,
+        }
+
+    def test_allows_changes_in_allowed_paths_dirty_tree_mode(self) -> None:
         with tempfile.TemporaryDirectory() as raw_tmpdir:
             tmpdir = Path(raw_tmpdir)
             repo = RepoFixture(tmpdir / "repo")
@@ -84,6 +122,222 @@ class TestAssertExecutionScope(unittest.TestCase):
             scope = self._scope_file(tmpdir, repo.root)
 
             code, output = self._run_main(repo.root, scope)
+
+        self.assertEqual(code, 0, output)
+        self.assertIn("PASS execution scope", output)
+
+    def test_planning_only_diff_inside_allowed_paths_passes(self) -> None:
+        with tempfile.TemporaryDirectory() as raw_tmpdir:
+            tmpdir = Path(raw_tmpdir)
+            repo = RepoFixture(tmpdir / "repo")
+            changed = self._changed_files_file(tmpdir, ["./allowed-dir/nested.txt"])
+            scope = self._scope_file(tmpdir, repo.root, execution_mode="planning_only")
+
+            code, output = self._run_main(repo.root, scope, changed_files_file=changed)
+
+        self.assertEqual(code, 0, output)
+        self.assertIn("PASS execution scope", output)
+
+    def test_planning_only_diff_outside_allowed_paths_fails(self) -> None:
+        with tempfile.TemporaryDirectory() as raw_tmpdir:
+            tmpdir = Path(raw_tmpdir)
+            repo = RepoFixture(tmpdir / "repo")
+            changed = self._changed_files_file(tmpdir, ["./not-allowed.txt"])
+            scope = self._scope_file(tmpdir, repo.root, execution_mode="planning_only")
+
+            code, output = self._run_main(repo.root, scope, changed_files_file=changed)
+
+        self.assertNotEqual(code, 0)
+        self.assertIn("changed paths outside allowed_write_paths", output)
+        self.assertIn("not-allowed.txt", output)
+
+    def test_non_planning_without_handoff_fails(self) -> None:
+        with tempfile.TemporaryDirectory() as raw_tmpdir:
+            tmpdir = Path(raw_tmpdir)
+            repo = RepoFixture(tmpdir / "repo")
+            changed = self._changed_files_file(tmpdir, ["allowed.txt"])
+            scope = self._scope_file(tmpdir, repo.root, execution_mode="implementation_ready")
+
+            code, output = self._run_main(repo.root, scope, changed_files_file=changed)
+
+        self.assertNotEqual(code, 0)
+        self.assertIn("requires `handoff_evidence.status` == 'accepted'", output)
+
+    def test_non_planning_with_accepted_handoff_passes(self) -> None:
+        with tempfile.TemporaryDirectory() as raw_tmpdir:
+            tmpdir = Path(raw_tmpdir)
+            repo = RepoFixture(tmpdir / "repo")
+            changed = self._changed_files_file(tmpdir, ["allowed.txt"])
+            scope = self._scope_file(
+                tmpdir,
+                repo.root,
+                execution_mode="implementation_ready",
+                handoff_evidence=self._handoff(
+                    planner_model="gpt-5",
+                    implementer_model="claude-3-7-sonnet",
+                ),
+            )
+
+            code, output = self._run_main(repo.root, scope, changed_files_file=changed)
+
+        self.assertEqual(code, 0, output)
+        self.assertIn("PASS execution scope", output)
+
+    def test_same_model_or_family_without_active_exception_fails(self) -> None:
+        with tempfile.TemporaryDirectory() as raw_tmpdir:
+            tmpdir = Path(raw_tmpdir)
+            repo = RepoFixture(tmpdir / "repo")
+            changed = self._changed_files_file(tmpdir, ["allowed.txt"])
+            scope = self._scope_file(
+                tmpdir,
+                repo.root,
+                execution_mode="implementation_ready",
+                handoff_evidence=self._handoff(
+                    planner_model="gpt-5",
+                    implementer_model="gpt-5-mini",
+                ),
+            )
+
+            code, output = self._run_main(repo.root, scope, changed_files_file=changed)
+
+        self.assertNotEqual(code, 0)
+        self.assertIn("active_exception_ref", output)
+
+    def test_gpt_major_decimal_variants_without_active_exception_fail(self) -> None:
+        with tempfile.TemporaryDirectory() as raw_tmpdir:
+            tmpdir = Path(raw_tmpdir)
+            repo = RepoFixture(tmpdir / "repo")
+            changed = self._changed_files_file(tmpdir, ["allowed.txt"])
+            scope = self._scope_file(
+                tmpdir,
+                repo.root,
+                execution_mode="implementation_ready",
+                handoff_evidence=self._handoff(
+                    planner_model="gpt-5.3-codex",
+                    implementer_model="openai/gpt-5.4",
+                ),
+            )
+
+            code, output = self._run_main(repo.root, scope, changed_files_file=changed)
+
+        self.assertNotEqual(code, 0)
+        self.assertIn("active_exception_ref", output)
+
+    def test_gpt_major_decimal_variants_with_active_exception_pass(self) -> None:
+        with tempfile.TemporaryDirectory() as raw_tmpdir:
+            tmpdir = Path(raw_tmpdir)
+            repo = RepoFixture(tmpdir / "repo")
+            changed = self._changed_files_file(tmpdir, ["allowed.txt"])
+            self._write_exception_file(repo, "raw/exceptions/issue-242-gpt5-major-line.md")
+            scope = self._scope_file(
+                tmpdir,
+                repo.root,
+                execution_mode="implementation_ready",
+                handoff_evidence=self._handoff(
+                    planner_model="gpt-5.3-codex",
+                    implementer_model="openai/gpt-5.4",
+                    active_exception_ref="raw/exceptions/issue-242-gpt5-major-line.md",
+                    active_exception_expires_at="2999-01-01T00:00:00Z",
+                ),
+            )
+
+            code, output = self._run_main(repo.root, scope, changed_files_file=changed)
+
+        self.assertEqual(code, 0, output)
+        self.assertIn("PASS execution scope", output)
+
+    def test_active_exception_with_expiry_passes(self) -> None:
+        with tempfile.TemporaryDirectory() as raw_tmpdir:
+            tmpdir = Path(raw_tmpdir)
+            repo = RepoFixture(tmpdir / "repo")
+            changed = self._changed_files_file(tmpdir, ["allowed.txt"])
+            self._write_exception_file(repo, "raw/exceptions/issue-242-gpt5-exception.md")
+            scope = self._scope_file(
+                tmpdir,
+                repo.root,
+                execution_mode="implementation_ready",
+                handoff_evidence=self._handoff(
+                    planner_model="gpt-5",
+                    implementer_model="gpt-5-mini",
+                    active_exception_ref="raw/exceptions/issue-242-gpt5-exception.md",
+                    active_exception_expires_at="2999-01-01T00:00:00Z",
+                ),
+            )
+
+            code, output = self._run_main(repo.root, scope, changed_files_file=changed)
+
+        self.assertEqual(code, 0, output)
+        self.assertIn("PASS execution scope", output)
+
+    def test_active_exception_ref_nonexistent_file_fails(self) -> None:
+        with tempfile.TemporaryDirectory() as raw_tmpdir:
+            tmpdir = Path(raw_tmpdir)
+            repo = RepoFixture(tmpdir / "repo")
+            changed = self._changed_files_file(tmpdir, ["allowed.txt"])
+            scope = self._scope_file(
+                tmpdir,
+                repo.root,
+                execution_mode="implementation_ready",
+                handoff_evidence=self._handoff(
+                    planner_model="gpt-5",
+                    implementer_model="gpt-5-mini",
+                    active_exception_ref="raw/exceptions/missing.md",
+                    active_exception_expires_at="2999-01-01T00:00:00Z",
+                ),
+            )
+
+            code, output = self._run_main(repo.root, scope, changed_files_file=changed)
+
+        self.assertNotEqual(code, 0)
+        self.assertIn("active_exception_ref must reference an existing repo file path", output)
+        self.assertIn("raw/exceptions/missing.md", output)
+
+    def test_active_exception_ref_existing_file_with_anchor_passes(self) -> None:
+        with tempfile.TemporaryDirectory() as raw_tmpdir:
+            tmpdir = Path(raw_tmpdir)
+            repo = RepoFixture(tmpdir / "repo")
+            changed = self._changed_files_file(tmpdir, ["allowed.txt"])
+            self._write_exception_file(repo, "raw/exceptions/issue-242-anchor.md")
+            scope = self._scope_file(
+                tmpdir,
+                repo.root,
+                execution_mode="implementation_ready",
+                handoff_evidence=self._handoff(
+                    planner_model="gpt-5",
+                    implementer_model="gpt-5-mini",
+                    active_exception_ref="raw/exceptions/issue-242-anchor.md#issue-242",
+                    active_exception_expires_at="2999-01-01T00:00:00Z",
+                ),
+            )
+
+            code, output = self._run_main(repo.root, scope, changed_files_file=changed)
+
+        self.assertEqual(code, 0, output)
+        self.assertIn("PASS execution scope", output)
+
+    def test_diff_mode_and_dirty_tree_mode_share_path_normalization(self) -> None:
+        with tempfile.TemporaryDirectory() as raw_tmpdir:
+            tmpdir = Path(raw_tmpdir)
+            repo = RepoFixture(tmpdir / "repo")
+            repo.write("allowed-dir/nested.txt")
+            changed = self._changed_files_file(tmpdir, ["./allowed-dir/nested.txt"])
+            scope = self._scope_file(tmpdir, repo.root)
+
+            dirty_code, dirty_output = self._run_main(repo.root, scope)
+            diff_code, diff_output = self._run_main(repo.root, scope, changed_files_file=changed)
+
+        self.assertEqual(dirty_code, 0, dirty_output)
+        self.assertEqual(diff_code, 0, diff_output)
+
+    def test_portable_expected_root_sentinel_passes_in_copied_checkout(self) -> None:
+        with tempfile.TemporaryDirectory() as raw_tmpdir:
+            tmpdir = Path(raw_tmpdir)
+            source_repo = RepoFixture(tmpdir / "source")
+            copied_repo_root = tmpdir / "copied"
+            shutil.copytree(source_repo.root, copied_repo_root)
+            scope = self._scope_file(tmpdir, "{repo_root}")
+
+            code, output = self._run_main(copied_repo_root, scope)
 
         self.assertEqual(code, 0, output)
         self.assertIn("PASS execution scope", output)


### PR DESCRIPTION
## Summary

Follow-up implementation for #242 after #244 landed the trusted execution scope on `main`.

This PR:
- adds the strict planner-boundary execution-scope gate to the reusable governance workflow
- extends `assert_execution_scope.py` with `execution_mode` and accepted handoff evidence validation
- updates the local `code-write-gate.sh` warning path and governance docs/registries
- adds pytest coverage for planning-only scopes, implementation handoff evidence, same-family exceptions, dirty-tree mode, and path normalization

## Validation

- `python3 scripts/overlord/assert_execution_scope.py --scope raw/execution-scopes/2026-04-17-issue-242-planner-write-boundary-implementation.json --changed-files-file /tmp/issue-242-implementation-changed-files.txt`
- `python3 -m pytest scripts/overlord/test_assert_execution_scope.py`
- `git diff --check`

## Base Authorization

PR #244 merged `raw/execution-scopes/2026-04-17-issue-242-planner-write-boundary-implementation.json` to `main` first, so this implementation PR is checked against the trusted base copy of that scope instead of trusting a head-authored scope change.