### PR TITLE
feat(graphify): add governed hook helper

### DIFF
--- a/raw/cross-review/2026-04-17-issue-250-graphify-hook-helper.md
+++ b/raw/cross-review/2026-04-17-issue-250-graphify-hook-helper.md
@@ -1,0 +1,66 @@
+---
+schema_version: v2
+pr_number: 254
+pr_scope: architecture
+drafter:
+  role: architect-codex
+  model_id: gpt-5.3-codex-spark
+  model_family: openai
+  signature_date: 2026-04-17
+reviewer:
+  role: architect-claude
+  model_id: claude-opus-4-6
+  model_family: anthropic
+  signature_date: 2026-04-17
+  verdict: APPROVED
+gate_identity:
+  role: gate-claude
+  model_id: claude-sonnet-4-6
+  model_family: anthropic
+  signature_date: 2026-04-17
+invariants_checked:
+  dual_planner_pairing: true
+  no_self_approval: true
+  planning_floor: true
+  pii_floor: true
+  cross_family_independence: true
+  architecture_scope_declared: true
+  real_pr_number_present: true
+  unsafe_output_preflight_before_builder: true
+---
+
+# Issue #250 Graphify Hook Helper Cross-Review
+
+PR: [#254](https://github.com/NIBARGERB-HLDPRO/hldpro-governance/pull/254)
+Issue: [#250](https://github.com/NIBARGERB-HLDPRO/hldpro-governance/issues/250)
+Parent: [#248](https://github.com/NIBARGERB-HLDPRO/hldpro-governance/issues/248)
+
+## Scope Reviewed
+
+The MS2 PR adds the governance-owned graphify helper implementation and focused tests:
+
+- `scripts/knowledge_base/graphify_hook_helper.py`
+- `scripts/knowledge_base/test_graphify_hook_helper.py`
+
+## Reviewer Verdict
+
+Claude Opus 4.6 reviewed PR #254 on 2026-04-17 and returned `APPROVED` with no blocking findings.
+
+Acceptance criteria coverage from the review:
+
+- `resolve` and `dry-run` output include repo slug, governance root, source path, output path, wiki path, hook paths, and refresh command.
+- Manifest paths resolve through `docs/graphify_targets.json` relative to the governance root.
+- AIS and knocktracker are supported by inference or explicit `--repo-slug`.
+- Unsafe product-checkout graphify output paths are refused before `build_graph.py` is invoked.
+- The unsafe-output test patches `subprocess.run` and asserts the builder is not called.
+- Existing unmanaged hooks are not silently overwritten.
+- Managed hooks call the governance helper and do not contain raw `graphify.watch._rebuild_code(Path('.'))` or `graphify hook install` behavior.
+- Focused tests cover slug resolution, manifest resolution, safe output preflight, existing-hook handling, and generated hook body content.
+
+## Gate
+
+Claude Sonnet 4.6 gate review confirmed the branch preconditions and required this artifact before final pass. The gate identities are distinct, the reviewer verdict is approved, and the scope is architecture-labeled implementation for #250.
+
+## Required Follow-Through
+
+MS3 (#251) must document adoption commands and require AIS/knocktracker adoption PRs to prove raw graphify hooks are removed or absent before installing the managed helper.

--- a/scripts/knowledge_base/graphify_hook_helper.py
+++ b/scripts/knowledge_base/graphify_hook_helper.py
@@ -1,0 +1,255 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+
+GOVERNANCE_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_MANIFEST = GOVERNANCE_ROOT / "docs" / "graphify_targets.json"
+MANAGED_MARKER = "# hldpro-governance graphify hook helper managed"
+HOOK_NAMES = ("post-commit", "post-checkout")
+
+
+class HelperError(RuntimeError):
+    pass
+
+
+@dataclass(frozen=True)
+class HookPlan:
+    repo_slug: str
+    target_repo: Path
+    governance_root: Path
+    source_path: Path
+    output_path: Path
+    wiki_path: Path
+    hook_paths: dict[str, Path]
+
+    def to_json(self) -> dict[str, object]:
+        return {
+            "repo_slug": self.repo_slug,
+            "target_repo": str(self.target_repo),
+            "governance_root": str(self.governance_root),
+            "source_path": str(self.source_path),
+            "output_path": str(self.output_path),
+            "wiki_path": str(self.wiki_path),
+            "hook_paths": {name: str(path) for name, path in self.hook_paths.items()},
+        }
+
+
+def load_manifest(path: Path) -> dict[str, object]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise HelperError("manifest root must be an object")
+    targets = payload.get("targets")
+    if not isinstance(targets, list) or not targets:
+        raise HelperError("manifest must contain a non-empty targets array")
+    return payload
+
+
+def target_rows(manifest: dict[str, object]) -> list[dict[str, object]]:
+    rows = manifest.get("targets")
+    if not isinstance(rows, list):
+        raise HelperError("manifest targets must be an array")
+    return [row for row in rows if isinstance(row, dict)]
+
+
+def find_target(rows: list[dict[str, object]], repo_slug: str) -> dict[str, object]:
+    for row in rows:
+        if row.get("repo_slug") == repo_slug:
+            return row
+    raise HelperError(f"repo_slug not found in manifest: {repo_slug}")
+
+
+def infer_repo_slug(rows: list[dict[str, object]], target_repo: Path) -> str:
+    names = {target_repo.name, target_repo.resolve().name}
+    normalized_names = {name.lower() for name in names}
+    for row in rows:
+        repo_slug = str(row.get("repo_slug", ""))
+        display_name = str(row.get("display_name", ""))
+        candidates = {repo_slug.lower(), display_name.lower()}
+        if normalized_names & candidates:
+            return repo_slug
+    raise HelperError(f"unable to infer repo slug from target repo: {target_repo}")
+
+
+def resolve_under(root: Path, raw_path: object, field: str) -> Path:
+    if not isinstance(raw_path, str) or not raw_path.strip():
+        raise HelperError(f"manifest target missing {field}")
+    path = Path(raw_path)
+    if path.is_absolute():
+        raise HelperError(f"manifest {field} must be relative to governance root: {raw_path}")
+    return (root / path).resolve()
+
+
+def git_hook_paths(target_repo: Path) -> dict[str, Path]:
+    result = subprocess.run(
+        ["git", "-C", str(target_repo), "rev-parse", "--git-path", "hooks"],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        raise HelperError(result.stderr.strip() or f"not a git repository: {target_repo}")
+    hooks_root = Path(result.stdout.strip())
+    if not hooks_root.is_absolute():
+        hooks_root = (target_repo / hooks_root).resolve()
+    return {name: hooks_root / name for name in HOOK_NAMES}
+
+
+def build_plan(args: argparse.Namespace) -> HookPlan:
+    governance_root = Path(args.governance_root).resolve()
+    manifest_path = Path(args.manifest).resolve() if args.manifest else governance_root / "docs" / "graphify_targets.json"
+    target_repo = Path(args.target_repo).resolve()
+    manifest = load_manifest(manifest_path)
+    rows = target_rows(manifest)
+    repo_slug = args.repo_slug or infer_repo_slug(rows, target_repo)
+    target = find_target(rows, repo_slug)
+    return HookPlan(
+        repo_slug=repo_slug,
+        target_repo=target_repo,
+        governance_root=governance_root,
+        source_path=resolve_under(governance_root, target.get("source_path"), "source_path"),
+        output_path=resolve_under(governance_root, target.get("output_path"), "output_path"),
+        wiki_path=resolve_under(governance_root, target.get("wiki_path"), "wiki_path"),
+        hook_paths=git_hook_paths(target_repo),
+    )
+
+
+def is_relative_to(path: Path, root: Path) -> bool:
+    try:
+        path.resolve().relative_to(root.resolve())
+        return True
+    except ValueError:
+        return False
+
+
+def preflight_safe_output(plan: HookPlan) -> None:
+    if plan.repo_slug != "hldpro-governance" and is_relative_to(plan.output_path, plan.target_repo):
+        raise HelperError(f"refusing graphify output under product repo checkout: {plan.output_path}")
+    if not is_relative_to(plan.output_path, plan.governance_root):
+        raise HelperError(f"refusing graphify output outside governance root: {plan.output_path}")
+    if not is_relative_to(plan.wiki_path, plan.governance_root):
+        raise HelperError(f"refusing wiki output outside governance root: {plan.wiki_path}")
+
+
+def build_refresh_command(plan: HookPlan, no_html: bool) -> list[str]:
+    command = [
+        sys.executable,
+        str(plan.governance_root / "scripts" / "knowledge_base" / "build_graph.py"),
+        "--source",
+        str(plan.source_path),
+        "--output",
+        str(plan.output_path),
+        "--wiki-dir",
+        str(plan.wiki_path),
+        "--repo-slug",
+        plan.repo_slug,
+    ]
+    if no_html:
+        command.append("--no-html")
+    return command
+
+
+def managed_hook_body(governance_root: Path, target_repo: Path, repo_slug: str) -> str:
+    helper = governance_root / "scripts" / "knowledge_base" / "graphify_hook_helper.py"
+    return f"""#!/usr/bin/env bash
+{MANAGED_MARKER}
+set -euo pipefail
+
+python3 "{helper}" refresh \\
+  --governance-root "{governance_root}" \\
+  --target-repo "{target_repo}" \\
+  --repo-slug "{repo_slug}" \\
+  --no-html
+"""
+
+
+def install_hooks(plan: HookPlan, backup_existing: bool, force: bool) -> None:
+    body = managed_hook_body(plan.governance_root, plan.target_repo, plan.repo_slug)
+    for name, path in plan.hook_paths.items():
+        if path.exists():
+            current = path.read_text(encoding="utf-8", errors="replace")
+            if MANAGED_MARKER not in current and not (backup_existing or force):
+                raise HelperError(f"refusing to overwrite unmanaged hook {path}; use --backup-existing or --force")
+            if MANAGED_MARKER not in current and backup_existing:
+                backup = path.with_name(f"{path.name}.pre-governance-graphify")
+                path.replace(backup)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(body, encoding="utf-8")
+        path.chmod(0o755)
+        print(f"installed {name}: {path}")
+
+
+def execute_refresh(plan: HookPlan, no_html: bool) -> int:
+    preflight_safe_output(plan)
+    return subprocess.run(build_refresh_command(plan, no_html=no_html)).returncode
+
+
+def print_json(data: object) -> None:
+    json.dump(data, sys.stdout, indent=2)
+    sys.stdout.write("\n")
+
+
+def add_common_args(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--governance-root", default=str(GOVERNANCE_ROOT), help="hldpro-governance checkout root")
+    parser.add_argument("--manifest", help="Path to graphify_targets.json; defaults to <governance-root>/docs/graphify_targets.json")
+    parser.add_argument("--target-repo", default=".", help="Product/governed repo checkout root")
+    parser.add_argument("--repo-slug", help="Manifest repo_slug; inferred from --target-repo when omitted")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Install and run governance-managed graphify hooks.")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    resolve_parser = subparsers.add_parser("resolve", help="Print resolved helper paths as JSON")
+    add_common_args(resolve_parser)
+
+    dry_run_parser = subparsers.add_parser("dry-run", help="Resolve paths and print the refresh command without running it")
+    add_common_args(dry_run_parser)
+    dry_run_parser.add_argument("--no-html", action="store_true", help="Include --no-html in the refresh command")
+
+    refresh_parser = subparsers.add_parser("refresh", help="Run the governance graph builder for the resolved target")
+    add_common_args(refresh_parser)
+    refresh_parser.add_argument("--no-html", action="store_true", help="Skip graph.html generation")
+
+    install_parser = subparsers.add_parser("install", help="Install managed post-commit and post-checkout hooks")
+    add_common_args(install_parser)
+    install_parser.add_argument("--backup-existing", action="store_true", help="Rename unmanaged existing hooks before installing")
+    install_parser.add_argument("--force", action="store_true", help="Overwrite unmanaged existing hooks without backup")
+
+    args = parser.parse_args()
+    try:
+        plan = build_plan(args)
+        if args.command == "resolve":
+            preflight_safe_output(plan)
+            print_json(plan.to_json())
+            return 0
+
+        if args.command == "dry-run":
+            preflight_safe_output(plan)
+            payload = plan.to_json()
+            payload["refresh_command"] = build_refresh_command(plan, no_html=args.no_html)
+            print_json(payload)
+            return 0
+
+        if args.command == "refresh":
+            return execute_refresh(plan, no_html=args.no_html)
+
+        if args.command == "install":
+            preflight_safe_output(plan)
+            install_hooks(plan, backup_existing=args.backup_existing, force=args.force)
+            return 0
+
+        parser.error(f"unknown command: {args.command}")
+        return 2
+    except HelperError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/knowledge_base/test_graphify_hook_helper.py
+++ b/scripts/knowledge_base/test_graphify_hook_helper.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+import graphify_hook_helper as helper
+
+
+class TestGraphifyHookHelper(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmp = tempfile.TemporaryDirectory()
+        self.root = Path(self.tmp.name)
+        self.gov = self.root / "hldpro-governance"
+        self.gov.mkdir()
+        self.manifest = self.gov / "graphify_targets.json"
+        self.product = self.root / "ai-integration-services"
+        self.product.mkdir()
+        subprocess.run(["git", "init"], cwd=self.product, check=True, capture_output=True, text=True)
+        self.write_manifest(
+            {
+                "version": 1,
+                "targets": [
+                    {
+                        "repo_slug": "ai-integration-services",
+                        "display_name": "ai-integration-services",
+                        "source_path": "repos/ai-integration-services",
+                        "output_path": "graphify-out/ai-integration-services",
+                        "wiki_path": "wiki/ai-integration-services",
+                    },
+                    {
+                        "repo_slug": "knocktracker",
+                        "display_name": "knocktracker",
+                        "source_path": "repos/knocktracker",
+                        "output_path": "graphify-out/knocktracker",
+                        "wiki_path": "wiki/knocktracker",
+                    },
+                ],
+            }
+        )
+
+    def tearDown(self) -> None:
+        self.tmp.cleanup()
+
+    def write_manifest(self, payload: dict[str, object]) -> None:
+        self.manifest.write_text(json.dumps(payload), encoding="utf-8")
+
+    def args(self, **overrides: object) -> object:
+        values = {
+            "governance_root": str(self.gov),
+            "manifest": str(self.manifest),
+            "target_repo": str(self.product),
+            "repo_slug": None,
+        }
+        values.update(overrides)
+        return type("Args", (), values)()
+
+    def test_infers_repo_slug_and_resolves_manifest_paths_from_governance_root(self) -> None:
+        plan = helper.build_plan(self.args())
+
+        self.assertEqual(plan.repo_slug, "ai-integration-services")
+        self.assertEqual(plan.governance_root, self.gov.resolve())
+        self.assertEqual(plan.source_path, (self.gov / "repos/ai-integration-services").resolve())
+        self.assertEqual(plan.output_path, (self.gov / "graphify-out/ai-integration-services").resolve())
+        self.assertEqual(plan.wiki_path, (self.gov / "wiki/ai-integration-services").resolve())
+        self.assertIn("post-commit", plan.hook_paths)
+        self.assertIn("post-checkout", plan.hook_paths)
+
+    def test_accepts_explicit_knocktracker_slug(self) -> None:
+        knocktracker = self.root / "knocktracker"
+        knocktracker.mkdir()
+        subprocess.run(["git", "init"], cwd=knocktracker, check=True, capture_output=True, text=True)
+
+        plan = helper.build_plan(self.args(target_repo=str(knocktracker), repo_slug="knocktracker"))
+
+        self.assertEqual(plan.repo_slug, "knocktracker")
+        self.assertEqual(plan.output_path, (self.gov / "graphify-out/knocktracker").resolve())
+
+    def test_unsafe_product_repo_output_aborts_before_builder_call(self) -> None:
+        plan = helper.HookPlan(
+            repo_slug="ai-integration-services",
+            target_repo=self.product.resolve(),
+            governance_root=self.gov.resolve(),
+            source_path=(self.gov / "repos/ai-integration-services").resolve(),
+            output_path=(self.product / "graphify-out/ai-integration-services").resolve(),
+            wiki_path=(self.gov / "wiki/ai-integration-services").resolve(),
+            hook_paths={},
+        )
+
+        with mock.patch.object(helper.subprocess, "run") as run:
+            with self.assertRaises(helper.HelperError):
+                helper.execute_refresh(plan, no_html=True)
+            run.assert_not_called()
+
+    def test_install_refuses_unmanaged_existing_hooks(self) -> None:
+        plan = helper.build_plan(self.args(repo_slug="ai-integration-services"))
+        hook = plan.hook_paths["post-commit"]
+        hook.parent.mkdir(parents=True, exist_ok=True)
+        hook.write_text("#!/usr/bin/env bash\necho unmanaged\n", encoding="utf-8")
+
+        with self.assertRaises(helper.HelperError):
+            helper.install_hooks(plan, backup_existing=False, force=False)
+
+        self.assertEqual(hook.read_text(encoding="utf-8"), "#!/usr/bin/env bash\necho unmanaged\n")
+
+    def test_install_backs_up_unmanaged_hook_and_writes_managed_body(self) -> None:
+        plan = helper.build_plan(self.args(repo_slug="ai-integration-services"))
+        hook = plan.hook_paths["post-commit"]
+        hook.parent.mkdir(parents=True, exist_ok=True)
+        hook.write_text("#!/usr/bin/env bash\necho unmanaged\n", encoding="utf-8")
+
+        helper.install_hooks(plan, backup_existing=True, force=False)
+
+        body = hook.read_text(encoding="utf-8")
+        self.assertIn(helper.MANAGED_MARKER, body)
+        self.assertIn("graphify_hook_helper.py\" refresh", body)
+        self.assertNotIn("graphify.watch._rebuild_code", body)
+        self.assertNotIn("graphify hook install", body)
+        backup = hook.with_name("post-commit.pre-governance-graphify")
+        self.assertTrue(backup.exists())
+
+    def test_dry_run_payload_includes_command_and_hook_targets(self) -> None:
+        plan = helper.build_plan(self.args(repo_slug="ai-integration-services"))
+        helper.preflight_safe_output(plan)
+        payload = plan.to_json()
+        payload["refresh_command"] = helper.build_refresh_command(plan, no_html=True)
+
+        self.assertEqual(payload["repo_slug"], "ai-integration-services")
+        self.assertIn("hook_paths", payload)
+        self.assertIn("--output", payload["refresh_command"])
+        self.assertIn("--no-html", payload["refresh_command"])
+        self.assertEqual(
+            payload["refresh_command"][1],
+            str((self.gov / "scripts" / "knowledge_base" / "build_graph.py").resolve()),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Adds `scripts/knowledge_base/graphify_hook_helper.py` with `resolve`, `dry-run`, `refresh`, and `install` commands.
- Resolves manifest paths relative to the governance root and refuses product-checkout graph outputs before invoking `build_graph.py`.
- Installs managed post-commit/post-checkout hooks while refusing unmanaged hook overwrite unless `--backup-existing` or `--force` is explicit.
- Adds focused unit coverage for slug inference, manifest path resolution, unsafe-output preflight, existing-hook handling, and generated hook content.
- Adds PR-numbered architecture cross-review evidence.

## Microslice

Addresses #250.
Parent: #248.
Depends on merged #249 / PR #252.

## Validation

- `python3 scripts/knowledge_base/test_graphify_hook_helper.py`
- `python3 scripts/knowledge_base/test_graphify_governance_contract.py`
- `python3 scripts/overlord/validate_structured_agent_cycle_plan.py --root .`
- `python3 -m py_compile scripts/knowledge_base/graphify_hook_helper.py scripts/knowledge_base/test_graphify_hook_helper.py`
- `bash scripts/cross-review/require-dual-signature.sh raw/cross-review/2026-04-17-issue-250-graphify-hook-helper.md`
- `git diff --check`
- AIS dry-run: `python3 scripts/knowledge_base/graphify_hook_helper.py dry-run --target-repo /Users/bennibarger/Developer/HLDPRO/ai-integration-services --repo-slug ai-integration-services --no-html`
- knocktracker dry-run: `python3 scripts/knowledge_base/graphify_hook_helper.py dry-run --target-repo /Users/bennibarger/Developer/HLDPRO/knocktracker --repo-slug knocktracker --no-html`

## Cross-Review

- Claude Opus 4.6: `APPROVED`
- Claude Sonnet 4.6 gate: `GATE_PASSED`
- Artifact: `raw/cross-review/2026-04-17-issue-250-graphify-hook-helper.md`

## Local Hook Evidence

Creating and committing from isolated worktrees triggered the existing local raw graphify hook family and failed with `No module named 'graphify'`. No tracked graph artifacts were added. This PR implements the managed helper path but does not edit untracked local `.git/hooks` directly.
