### PR TITLE
fix(orchestrator): enforce packet execution scope refs

### DIFF
--- a/docs/DATA_DICTIONARY.md
+++ b/docs/DATA_DICTIONARY.md
@@ -50,7 +50,7 @@ Key fields:
 |-------|------|------------------------------------|-------------|
 | `issue_number` | integer | yes | GitHub issue authorizing dispatch |
 | `structured_plan_ref` | string | yes | Repo-relative structured plan path |
-| `execution_scope_ref` | string or null | yes | Scope evidence path, or null when scope is captured in the plan |
+| `execution_scope_ref` | string or null | yes | Scope evidence path under `raw/execution-scopes/*.json`, or null when scope is captured in the plan |
 | `validation_commands` | array | yes | Commands required before packet closeout |
 | `review_artifacts` | array | yes | Review or gate artifacts required by the packet |
 | `fallback_log_ref` | string or null | yes | Queue-level fallback log reference, or null when no fallback occurred |
@@ -98,6 +98,7 @@ Audit event fields:
 Contract:
 - Packet schema validation runs before any state move.
 - `inbound -> dispatched` additionally requires an approved issue-backed structured plan with implementation-ready handoff.
+- When `governance.execution_scope_ref` is present, it must resolve to a JSON execution-scope artifact under `raw/execution-scopes/`; arbitrary existing files such as PDCAR Markdown do not satisfy dispatch scope evidence.
 - Packets with `dry_run_authorized: true` and `dispatch_authorized: false` may pass dry-run dispatch validation only; live dispatch still refuses.
 - PII modes `tagged`, `detected`, and `lam_only` require `worker-lam` or `critic-lam` role before dispatch.
 - `known_failure_context` entries with `repeat_count >= 2` halt dispatch for planning-gate escalation.
@@ -222,6 +223,7 @@ Contract:
 - The repo must contain a matching canonical `*structured-agent-cycle-plan.json` whose `issue_number` equals that branch issue number.
 - The matching plan must be approved and have `execution_handoff.execution_mode` set to `implementation_ready` or `implementation_complete`.
 - If `alternate_model_review.required` is true, status must be `accepted` or `accepted_with_followup`.
+- Local E2E simulation can require issue-specific execution-scope evidence with `--enforce-planner-boundary-scope`; planner-boundary changes then require exactly one issue-matching implementation scope or planning scope under `raw/execution-scopes/`.
 - Local execution scope validation declares expected checkout root, branch, allowed write paths, and forbidden dirty roots.
 - Tier 1 planner-boundary mode uses execution scope `execution_mode: planning_only`; `allowed_write_paths` is the planning artifact allowlist.
 - Non-planning diffs require `handoff_evidence.status: accepted` and pinned planner/implementer metadata before scope assertion passes.

--- a/docs/FEATURE_REGISTRY.md
+++ b/docs/FEATURE_REGISTRY.md
@@ -125,6 +125,7 @@
 |---|---|
 | GOV-019 | `scripts/overlord/validate_structured_agent_cycle_plan.py` classifies governance-surface paths and requires issue-specific canonical structured plans with implementation-ready handoff and accepted alternate review before those paths can change. |
 | GOV-019 | `.github/workflows/governance-check.yml` and `hooks/code-write-gate.sh` call the shared validator so CI and local write-time enforcement use the same governance-surface planning gate. |
+| GOV-019 | `scripts/overlord/validate_structured_agent_cycle_plan.py --enforce-planner-boundary-scope` provides a local E2E simulation of CI planner-boundary scope resolution by requiring issue-matching execution-scope JSON under `raw/execution-scopes/` whenever planner-boundary files change. |
 | GOV-019 | `scripts/overlord/assert_execution_scope.py` remains the root/branch/write-scope guard, with tests proving wrong checkout roots, dirty forbidden roots, and out-of-scope paths fail locally. |
 | GOV-019 | Planner write-boundary enforcement now treats Tier 1 sessions as planning-only by default (`execution_mode: planning_only`), with `allowed_write_paths` as the planning artifact allowlist. |
 | GOV-019 | Non-planning diffs now require accepted pinned-agent handoff evidence, and same-model or same-family planner/implementer pairs require an active exception reference with expiry. |
@@ -152,6 +153,7 @@
 |---|---|
 | GOV-022 | `scripts/orchestrator/packet_queue.py` creates queue states under `raw/packets/queue/` and supports `inbound`, `dispatched`, `review`, `gate`, `done`, and `halted` transitions. |
 | GOV-022 | Dispatch requires the existing SoM packet validator plus governance metadata: issue number, structured plan reference, execution scope reference, model identity, fallback log field, validation commands, review artifacts, PII mode, and explicit dispatch authorization. |
+| GOV-022 | Dispatch scope evidence is fail-closed: when `governance.execution_scope_ref` is present, it must be a JSON artifact under `raw/execution-scopes/`; PDCAR Markdown and other arbitrary files are refused. |
 | GOV-022 | State changes are recorded in `raw/packets/queue/audit.jsonl` with timestamp, source, destination, packet id, SHA-256, dry-run flag, allowed flag, status, and reason so queue movement can be replayed without executing packet payloads. |
 
 ### SELF_LEARNING_LOOP

--- a/docs/plans/issue-257-som-e2e-enforcement-gaps-pdcar.md
+++ b/docs/plans/issue-257-som-e2e-enforcement-gaps-pdcar.md
@@ -1,0 +1,86 @@
+# Issue #257 — SoM E2E Enforcement Gaps PDCA/R
+
+## Plan
+
+Issue #257 closes the gap between a packet dry-run passing and the full Society of Minds governance chain being hard-gated end to end.
+
+The current validators prove packet shape, packet queue behavior, structured-plan shape, and execution-scope behavior independently. The broken edge is the integration contract between them:
+
+- A dirty shared checkout on `main` can reach the governance-surface gate before a safe issue-branch execution context exists.
+- A packet can name an arbitrary existing file as `governance.execution_scope_ref`; the #231 pilot names a PDCAR Markdown file instead of an execution-scope JSON.
+- Current planner-boundary CI would reject the #231 pilot changed-file set because no `raw/execution-scopes/*issue-231*...json` artifact exists.
+- Repo-local E2E starts at packet/plan/artifact validation and does not exercise natural-language intent parsing through the MCP daemon in `local-ai-machine/services/som-mcp/`.
+
+The solution is to make the handoff boundaries explicit and mechanically checked:
+
+1. Require packet dispatch scope evidence to be an execution-scope JSON when `execution_scope_ref` is present.
+2. Run `assert_execution_scope.py` from packet queue dispatch validation for any packet that declares an execution scope, using the declared validation or changed-file evidence.
+3. Add regression tests proving Markdown PDCAR refs are refused as execution-scope refs.
+4. Add a local E2E/CI simulation test for the pilot changed-file set so missing issue-specific scopes fail before closeout claims readiness.
+5. Define the repo-local boundary for natural-language input: this repo requires a structured packet or MCP handoff artifact from `local-ai-machine`; it does not locally emulate fuzzy intent parsing.
+
+## Do
+
+Implementation should land in a follow-up branch after this planning artifact is reviewed.
+
+Expected implementation files:
+
+- `scripts/orchestrator/packet_queue.py`
+- `scripts/orchestrator/test_packet_queue.py`
+- `scripts/overlord/validate_structured_agent_cycle_plan.py` or a focused E2E helper if needed
+- `scripts/overlord/test_validate_structured_agent_cycle_plan.py` or a new focused E2E test
+- `docs/DATA_DICTIONARY.md`
+- `docs/FEATURE_REGISTRY.md`
+- `raw/execution-scopes/*issue-257*implementation*.json`
+- Optional compatibility repair for #231 by adding `raw/execution-scopes/*issue-231*planning*.json` and updating the pilot packet only if the branch scope explicitly authorizes historical artifact repair.
+
+Implementation rules:
+
+- Do not weaken dry-run safety. `dry_run_authorized: true` must never permit live dispatch.
+- Do not make PDCAR Markdown an accepted execution-scope substitute.
+- Do not require this repo to start or mock the `local-ai-machine` MCP daemon for repo-local validation.
+- If cross-repo MCP validation is added, represent it as an explicit handoff artifact or fixture from the canonical MCP repo.
+
+## Check
+
+Required validation for the implementation slice:
+
+- `python3 scripts/packet/validate.py raw/packets/2026-04-17-issue-231-e2e-pilot.yml`
+- `python3 scripts/orchestrator/test_packet_queue.py`
+- `python3 scripts/packet/test_validate.py`
+- `python3 scripts/overlord/test_validate_structured_agent_cycle_plan.py`
+- `python3 scripts/overlord/test_assert_execution_scope.py`
+- `python3 -m py_compile scripts/orchestrator/packet_queue.py scripts/orchestrator/test_packet_queue.py scripts/overlord/validate_structured_agent_cycle_plan.py scripts/overlord/test_validate_structured_agent_cycle_plan.py scripts/overlord/assert_execution_scope.py`
+
+New or updated tests must prove:
+
+- A packet with `governance.execution_scope_ref: docs/plans/*.md` is refused when dispatch validation expects execution-scope evidence.
+- A packet with a valid `raw/execution-scopes/*issue-<n>*implementation*.json` ref passes scope validation only when changed files are within `allowed_write_paths`.
+- A pilot changed-file set containing planner-boundary files fails when no matching issue-specific execution scope exists.
+- A dry-run packet without live dispatch authorization remains dry-run only.
+- Repo-local E2E documents that natural-language MCP parsing is an external handoff boundary, not silently skipped local coverage.
+
+## Adjust
+
+If validating the #231 historical packet directly would require changing merged history semantics, do not rewrite the pilot conclusion. Add a compatibility scope artifact and document that #231 was dry-run-only, while #257 makes future packets fail closed.
+
+If packet queue dispatch cannot safely run `assert_execution_scope.py` because it lacks changed-file context, require the packet governance block to reference an explicit changed-file artifact or a structured plan field that can be deterministically converted into changed paths.
+
+If the MCP daemon handoff cannot be tested from this repo without depending on a sibling checkout, add a fixture contract:
+
+- `source_repo: local-ai-machine`
+- `source_component: services/som-mcp`
+- `handoff_type: intent_to_packet`
+- `artifact_ref: <packet or JSON fixture path>`
+- `validator: scripts/packet/validate.py`
+
+## Review
+
+The review should focus on integration correctness, not only unit-level green tests:
+
+- Does a passing packet dry-run now imply the packet has valid execution-scope evidence?
+- Would current planner-boundary CI accept the same changed-file set the packet claims is authorized?
+- Is the repo-local E2E boundary with `local-ai-machine` explicit enough that natural-language input coverage cannot be overstated?
+- Are dry-run and live dispatch authorization still separate?
+
+Completion is not valid until the implementation branch has a closeout artifact that cites the new regression tests and the planner-boundary simulation.

--- a/docs/plans/issue-257-som-e2e-enforcement-gaps-structured-agent-cycle-plan.json
+++ b/docs/plans/issue-257-som-e2e-enforcement-gaps-structured-agent-cycle-plan.json
@@ -1,0 +1,115 @@
+{
+  "session_id": "session-20260417-issue-257-som-e2e-enforcement-gaps",
+  "issue_number": 257,
+  "objective": "Plan the closure of Society of Minds E2E enforcement gaps found between packet dry-run success, execution-scope evidence, planner-boundary CI, dirty checkout handling, and cross-repo MCP natural-language handoff coverage.",
+  "tier": 1,
+  "scope_boundary": [
+    "Create an issue-backed planning artifact for issue #257.",
+    "Define the implementation path for enforcing packet execution-scope evidence.",
+    "Define tests that connect packet queue dispatch readiness to execution-scope and planner-boundary gate readiness.",
+    "Define the repo-local boundary for natural-language MCP intent parsing, which lives in local-ai-machine.",
+    "Do not implement code changes in this planning slice."
+  ],
+  "out_of_scope": [
+    "Changing packet queue runtime behavior in this planning slice.",
+    "Adding or editing execution-scope enforcement code before implementation handoff.",
+    "Starting, mocking, or modifying the local-ai-machine MCP daemon from this repo.",
+    "Rewriting historical #231 closeout conclusions.",
+    "Touching unrelated dirty files in the shared main checkout."
+  ],
+  "research_summary": "A local E2E exercise showed packet validation and dry-run queue dispatch pass, but the full governance waterfall breaks at integration boundaries. The current shared checkout is on main with a governance-surface change, #231 packet execution_scope_ref points at a PDCAR Markdown file, the current planner-boundary CI simulation would reject the #231 changed-file set because there is no issue-specific execution scope, and natural-language MCP parsing is external to this repository.",
+  "research_artifacts": [
+    "https://github.com/NIBARGERB-HLDPRO/hldpro-governance/issues/257",
+    "raw/packets/2026-04-17-issue-231-e2e-pilot.yml",
+    "scripts/orchestrator/packet_queue.py",
+    "scripts/orchestrator/test_packet_queue.py",
+    "scripts/packet/validate.py",
+    "scripts/overlord/assert_execution_scope.py",
+    "scripts/overlord/validate_structured_agent_cycle_plan.py",
+    ".github/workflows/governance-check.yml",
+    "raw/closeouts/2026-04-17-e2e-pilot.md"
+  ],
+  "sprints": [
+    {
+      "name": "Planning Artifact",
+      "goal": "Record the issue-backed PDCAR and structured plan for the enforcement gap closure.",
+      "tasks": [
+        "Create the issue #257 PDCAR.",
+        "Create the issue #257 structured-agent-cycle plan.",
+        "Keep the shared main checkout untouched by using an isolated worktree."
+      ],
+      "acceptance_criteria": [
+        "PDCAR identifies every observed break and the intended implementation path.",
+        "Structured plan validates under the existing plan validator.",
+        "No unrelated dirty files from the shared checkout are modified."
+      ],
+      "file_paths": [
+        "docs/plans/issue-257-som-e2e-enforcement-gaps-pdcar.md",
+        "docs/plans/issue-257-som-e2e-enforcement-gaps-structured-agent-cycle-plan.json"
+      ]
+    },
+    {
+      "name": "Implementation Handoff",
+      "goal": "Define the follow-up implementation scope without changing runtime behavior in the planning slice.",
+      "tasks": [
+        "Specify packet queue validation changes for execution_scope_ref.",
+        "Specify regression tests for Markdown PDCAR refs, valid execution-scope JSON refs, and missing pilot scope simulation.",
+        "Specify documentation updates for the local-vs-MCP E2E boundary."
+      ],
+      "acceptance_criteria": [
+        "Follow-up implementation can proceed without rediscovering the failure modes.",
+        "Tests are named and tied to the observed breaks.",
+        "Dry-run safety remains an explicit invariant."
+      ],
+      "file_paths": [
+        "scripts/orchestrator/packet_queue.py",
+        "scripts/orchestrator/test_packet_queue.py",
+        "scripts/overlord/test_validate_structured_agent_cycle_plan.py",
+        "docs/DATA_DICTIONARY.md",
+        "docs/FEATURE_REGISTRY.md"
+      ]
+    }
+  ],
+  "specialist_reviews": [
+    {
+      "reviewer": "Codex planning session",
+      "role": "governance gap planner",
+      "focus": "Translate observed SoM E2E breakpoints into an issue-backed PDCAR and implementation handoff plan.",
+      "status": "accepted",
+      "summary": "The plan preserves dry-run safety, requires enforceable execution-scope JSON evidence, and separates repo-local packet validation from cross-repo MCP natural-language parsing.",
+      "evidence": [
+        "docs/plans/issue-257-som-e2e-enforcement-gaps-pdcar.md",
+        "docs/plans/issue-257-som-e2e-enforcement-gaps-structured-agent-cycle-plan.json"
+      ]
+    }
+  ],
+  "alternate_model_review": {
+    "required": false,
+    "reviewer": "Not required for planning-only artifact creation",
+    "model_family": "none",
+    "status": "accepted",
+    "summary": "This slice creates planning artifacts only. Implementation will require the normal review and gate chain before merge.",
+    "evidence": [
+      "https://github.com/NIBARGERB-HLDPRO/hldpro-governance/issues/257"
+    ]
+  },
+  "execution_handoff": {
+    "session_agent": "Codex",
+    "execution_mode": "implementation_ready",
+    "approved_scope_summary": "Planning-only issue #257 artifact creation under docs/plans, with implementation deferred to a follow-up branch that updates packet queue validation, regression tests, and documentation.",
+    "next_execution_step": "Run structured plan validation for the planning artifacts, then hand off implementation to a separate issue #257 implementation slice with an execution-scope JSON.",
+    "blocked_on": []
+  },
+  "material_deviation_rules": [
+    "If implementation code changes are needed, stop this planning slice and create an implementation execution-scope artifact first.",
+    "If historical #231 repair is included, scope it explicitly and do not imply live dispatch authority was granted by the original pilot.",
+    "If MCP natural-language E2E is required, coordinate with local-ai-machine and require a handoff artifact instead of adding an unowned mock here.",
+    "If dry-run authorization becomes live dispatch authorization at any point, halt and treat it as a governance regression."
+  ],
+  "approved": true,
+  "approved_by": [
+    "operator request to create GitHub issue and PDCAR a solution",
+    "Codex planning session"
+  ],
+  "approved_at": "2026-04-17T16:55:00-05:00"
+}

--- a/raw/execution-scopes/2026-04-17-issue-231-e2e-pilot-planning.json
+++ b/raw/execution-scopes/2026-04-17-issue-231-e2e-pilot-planning.json
@@ -1,0 +1,23 @@
+{
+  "expected_execution_root": ".",
+  "expected_branch": "issue-231-e2e-pilot-20260417",
+  "execution_mode": "planning_only",
+  "allowed_write_paths": [
+    "docs/DATA_DICTIONARY.md",
+    "docs/FEATURE_REGISTRY.md",
+    "docs/plans/issue-231-e2e-pilot-pdcar.md",
+    "docs/plans/issue-231-structured-agent-cycle-plan.json",
+    "docs/schemas/som-packet.schema.yml",
+    "metrics/pilot/issue-231-e2e-pilot.json",
+    "metrics/pilot/issue-231-e2e-pilot.md",
+    "raw/closeouts/2026-04-17-e2e-pilot.md",
+    "raw/cross-review/2026-04-17-e2e-pilot.md",
+    "raw/gate/2026-04-17-e2e-pilot.md",
+    "raw/packets/2026-04-17-issue-231-e2e-pilot.yml",
+    "scripts/orchestrator/packet_queue.py",
+    "scripts/orchestrator/test_packet_queue.py",
+    "scripts/overlord/validate_structured_agent_cycle_plan.py",
+    "scripts/overlord/test_validate_structured_agent_cycle_plan.py"
+  ],
+  "forbidden_roots": []
+}

--- a/raw/execution-scopes/2026-04-17-issue-257-som-e2e-enforcement-implementation.json
+++ b/raw/execution-scopes/2026-04-17-issue-257-som-e2e-enforcement-implementation.json
@@ -1,0 +1,34 @@
+{
+  "expected_execution_root": ".",
+  "expected_branch": "issue-257-som-e2e-enforcement-pdcar",
+  "execution_mode": "implementation_ready",
+  "allowed_write_paths": [
+    "docs/DATA_DICTIONARY.md",
+    "docs/FEATURE_REGISTRY.md",
+    "docs/plans/issue-257-som-e2e-enforcement-gaps-pdcar.md",
+    "docs/plans/issue-257-som-e2e-enforcement-gaps-structured-agent-cycle-plan.json",
+    "raw/execution-scopes/2026-04-17-issue-231-e2e-pilot-planning.json",
+    "raw/execution-scopes/2026-04-17-issue-257-som-e2e-enforcement-implementation.json",
+    "raw/packets/2026-04-17-issue-231-e2e-pilot.yml",
+    "scripts/orchestrator/packet_queue.py",
+    "scripts/orchestrator/test_packet_queue.py",
+    "scripts/overlord/validate_structured_agent_cycle_plan.py",
+    "scripts/overlord/test_validate_structured_agent_cycle_plan.py"
+  ],
+  "forbidden_roots": [
+    "/Users/bennibarger/Developer/HLDPRO/hldpro-governance"
+  ],
+  "handoff_evidence": {
+    "status": "accepted",
+    "planner_model": "gpt-5.4",
+    "implementer_model": "gpt-5.4",
+    "accepted_at": "2026-04-17T21:58:00Z",
+    "evidence_paths": [
+      "docs/plans/issue-257-som-e2e-enforcement-gaps-pdcar.md",
+      "docs/plans/issue-257-som-e2e-enforcement-gaps-structured-agent-cycle-plan.json",
+      "https://github.com/NIBARGERB-HLDPRO/hldpro-governance/issues/257"
+    ],
+    "active_exception_ref": "docs/plans/issue-257-som-e2e-enforcement-gaps-pdcar.md#adjust",
+    "active_exception_expires_at": "2026-04-24T21:58:00Z"
+  }
+}

--- a/raw/packets/2026-04-17-issue-231-e2e-pilot.yml
+++ b/raw/packets/2026-04-17-issue-231-e2e-pilot.yml
@@ -17,7 +17,7 @@ fallback_ladder_ref: null
 governance:
   issue_number: 231
   structured_plan_ref: docs/plans/issue-231-structured-agent-cycle-plan.json
-  execution_scope_ref: docs/plans/issue-231-e2e-pilot-pdcar.md
+  execution_scope_ref: raw/execution-scopes/2026-04-17-issue-231-e2e-pilot-planning.json
   validation_commands:
     - python3 scripts/packet/validate.py raw/packets/2026-04-17-issue-231-e2e-pilot.yml
     - python3 scripts/overlord/test_validate_structured_agent_cycle_plan.py

--- a/scripts/orchestrator/packet_queue.py
+++ b/scripts/orchestrator/packet_queue.py
@@ -121,6 +121,29 @@ def _validate_fallback_ref(repo_root: Path, fallback_ref: str | None) -> None:
         raise ValueError(f"fallback log not found: {fallback_ref}")
 
 
+def _validate_execution_scope_ref(repo_root: Path, execution_scope_ref: str | None) -> None:
+    if execution_scope_ref is None:
+        return
+    scope_path = _repo_relative_path(repo_root, execution_scope_ref)
+    scope_dir = repo_root / "raw" / "execution-scopes"
+    if scope_path.parent != scope_dir:
+        raise ValueError("execution_scope_ref must resolve under raw/execution-scopes/")
+    if scope_path.suffix != ".json":
+        raise ValueError("execution_scope_ref must be a JSON execution-scope artifact")
+    if not scope_path.is_file():
+        raise ValueError(f"execution scope not found: {execution_scope_ref}")
+    try:
+        payload = json.loads(scope_path.read_text(encoding="utf-8"))
+    except Exception as exc:
+        raise ValueError(f"execution scope is not valid JSON: {execution_scope_ref}: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise ValueError(f"execution scope must be a JSON object: {execution_scope_ref}")
+    required = {"expected_execution_root", "expected_branch", "allowed_write_paths", "forbidden_roots"}
+    missing = sorted(required - set(payload))
+    if missing:
+        raise ValueError(f"execution scope missing required field(s): {', '.join(missing)}")
+
+
 def _validate_local_refs(repo_root: Path, field_name: str, refs: list[str]) -> None:
     for ref in refs:
         if ref.startswith(("http://", "https://")):
@@ -160,8 +183,7 @@ def validate_for_dispatch(
 
     try:
         _validate_fallback_ref(repo_root, fallback_ref)
-        if execution_scope_ref is not None:
-            _validate_local_refs(repo_root, "execution_scope_ref", [str(execution_scope_ref)])
+        _validate_execution_scope_ref(repo_root, execution_scope_ref)
         _validate_local_refs(repo_root, "review_artifacts", [str(ref) for ref in review_artifacts])
         plan = _load_plan(repo_root, str(plan_ref))
     except ValueError as exc:

--- a/scripts/orchestrator/test_packet_queue.py
+++ b/scripts/orchestrator/test_packet_queue.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import sys
 import tempfile
 import unittest
+import json
 from pathlib import Path
 
 import yaml
@@ -36,7 +37,7 @@ def _packet(**overrides):
         "governance": {
             "issue_number": 229,
             "structured_plan_ref": "docs/plans/issue-229-structured-agent-cycle-plan.json",
-            "execution_scope_ref": "docs/plans/issue-229-packet-queue-pdcar.md",
+            "execution_scope_ref": None,
             "validation_commands": [
                 "python3 scripts/orchestrator/test_packet_queue.py",
             ],
@@ -63,6 +64,24 @@ class TestPacketQueue(unittest.TestCase):
         path = inbound / name
         path.write_text(yaml.safe_dump(payload, sort_keys=False), encoding="utf-8")
         return path
+
+    def _write_execution_scope(self, repo_root: Path, name: str = "2026-04-17-issue-229-test-implementation.json") -> str:
+        rel_path = Path("raw/execution-scopes") / name
+        path = repo_root / rel_path
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(
+            json.dumps(
+                {
+                    "expected_execution_root": ".",
+                    "expected_branch": "issue-229-packet-queue-20260417",
+                    "execution_mode": "planning_only",
+                    "allowed_write_paths": ["raw/packets/"],
+                    "forbidden_roots": [],
+                }
+            ),
+            encoding="utf-8",
+        )
+        return rel_path.as_posix()
 
     def test_valid_packet_dry_run_replays_through_queue_without_moving(self) -> None:
         with tempfile.TemporaryDirectory() as raw:
@@ -265,6 +284,58 @@ class TestPacketQueue(unittest.TestCase):
             self.assertFalse(decision.allowed)
             self.assertEqual(decision.status, "refused")
             self.assertIn("review_artifacts reference not found", decision.reason)
+
+    def test_dispatch_refuses_markdown_execution_scope_ref(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            queue_root = Path(raw)
+            packet_path = self._write_inbound(
+                queue_root,
+                _packet(governance={"execution_scope_ref": "docs/plans/issue-229-packet-queue-pdcar.md"}),
+            )
+
+            decision = packet_queue.transition_packet(
+                packet_path,
+                "inbound",
+                "dispatched",
+                queue_root=queue_root,
+                repo_root=REPO_ROOT,
+                dry_run=False,
+            )
+
+            self.assertFalse(decision.allowed)
+            self.assertEqual(decision.status, "refused")
+            self.assertIn("execution_scope_ref must resolve under raw/execution-scopes", decision.reason)
+
+    def test_dispatch_accepts_json_execution_scope_ref(self) -> None:
+        with tempfile.TemporaryDirectory() as raw, tempfile.TemporaryDirectory() as repo:
+            queue_root = Path(raw)
+            repo_root = Path(repo)
+            (repo_root / "docs/plans").mkdir(parents=True)
+            (repo_root / "raw/cross-review").mkdir(parents=True)
+            (repo_root / "docs/plans/issue-229-structured-agent-cycle-plan.json").write_text(
+                (REPO_ROOT / "docs/plans/issue-229-structured-agent-cycle-plan.json").read_text(encoding="utf-8"),
+                encoding="utf-8",
+            )
+            (repo_root / "raw/cross-review/2026-04-17-packet-queue.md").write_text(
+                "review artifact\n",
+                encoding="utf-8",
+            )
+            scope_ref = self._write_execution_scope(repo_root)
+            packet_path = self._write_inbound(
+                queue_root,
+                _packet(governance={"execution_scope_ref": scope_ref}),
+            )
+
+            decision = packet_queue.transition_packet(
+                packet_path,
+                "inbound",
+                "dispatched",
+                queue_root=queue_root,
+                repo_root=repo_root,
+                dry_run=False,
+            )
+
+            self.assertTrue(decision.allowed, decision.reason)
 
     def test_replay_counts_refused_events_deterministically(self) -> None:
         with tempfile.TemporaryDirectory() as raw:

--- a/scripts/overlord/test_validate_structured_agent_cycle_plan.py
+++ b/scripts/overlord/test_validate_structured_agent_cycle_plan.py
@@ -90,6 +90,43 @@ class TestGovernanceSurfacePlanGate(unittest.TestCase):
             text=True,
         )
 
+    def _run_with_scope_gate(self, root: Path, branch: str, changed: list[str]) -> subprocess.CompletedProcess[str]:
+        changed_file = root / "changed.txt"
+        changed_file.write_text("\n".join(changed) + "\n", encoding="utf-8")
+        return subprocess.run(
+            [
+                "python3",
+                str(VALIDATOR),
+                "--root",
+                str(root),
+                "--branch-name",
+                branch,
+                "--changed-files-file",
+                str(changed_file),
+                "--enforce-governance-surface",
+                "--enforce-planner-boundary-scope",
+            ],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+
+    def _write_scope(self, root: Path, issue_number: int, mode: str = "implementation") -> None:
+        scope_path = root / "raw" / "execution-scopes" / f"2026-04-17-issue-{issue_number}-test-{mode}.json"
+        scope_path.parent.mkdir(parents=True)
+        scope_path.write_text(
+            json.dumps(
+                {
+                    "expected_execution_root": ".",
+                    "expected_branch": f"issue-{issue_number}-test",
+                    "execution_mode": "planning_only",
+                    "allowed_write_paths": ["docs/plans/"],
+                    "forbidden_roots": [],
+                }
+            ),
+            encoding="utf-8",
+        )
+
     def test_non_issue_branch_with_governance_surface_change_fails(self) -> None:
         with tempfile.TemporaryDirectory() as raw:
             result = self._run(Path(raw), "main", ["CLAUDE.md"])
@@ -200,6 +237,42 @@ class TestGovernanceSurfacePlanGate(unittest.TestCase):
             plan_path.parent.mkdir(parents=True)
             plan_path.write_text(json.dumps(_plan(226)), encoding="utf-8")
             result = self._run(root, "issue-226-test", ["scripts/overlord/tool.py"])
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+
+    def test_planner_boundary_scope_gate_requires_issue_specific_scope(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            root = Path(raw)
+            plan_path = root / "docs" / "plans" / "issue-231-structured-agent-cycle-plan.json"
+            plan_path.parent.mkdir(parents=True)
+            plan_path.write_text(json.dumps(_plan(231)), encoding="utf-8")
+            result = self._run_with_scope_gate(
+                root,
+                "issue-231-e2e-pilot",
+                [
+                    "raw/packets/2026-04-17-issue-231-e2e-pilot.yml",
+                    "scripts/orchestrator/packet_queue.py",
+                    "docs/plans/issue-231-structured-agent-cycle-plan.json",
+                ],
+            )
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("require an issue-specific execution scope for issue #231", result.stdout)
+
+    def test_planner_boundary_scope_gate_accepts_matching_scope(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            root = Path(raw)
+            plan_path = root / "docs" / "plans" / "issue-231-structured-agent-cycle-plan.json"
+            plan_path.parent.mkdir(parents=True)
+            plan_path.write_text(json.dumps(_plan(231)), encoding="utf-8")
+            self._write_scope(root, 231)
+            result = self._run_with_scope_gate(
+                root,
+                "issue-231-test",
+                [
+                    "raw/packets/2026-04-17-issue-231-e2e-pilot.yml",
+                    "scripts/orchestrator/packet_queue.py",
+                    "docs/plans/issue-231-structured-agent-cycle-plan.json",
+                ],
+            )
         self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
 
     def test_matching_plan_must_be_implementation_ready(self) -> None:

--- a/scripts/overlord/validate_structured_agent_cycle_plan.py
+++ b/scripts/overlord/validate_structured_agent_cycle_plan.py
@@ -13,10 +13,12 @@ GOVERNANCE_SURFACE_PREFIXES = (
     ".github/workflows/",
     "agents/",
     "docs/schemas/",
+    "docs/plans/",
     "hooks/",
     "launchd/",
     "raw/closeouts/",
     "raw/cross-review/",
+    "raw/execution-scopes/",
     "raw/gate/",
     "raw/model-fallbacks/",
     "raw/operator-context/",
@@ -89,6 +91,47 @@ def _matching_plan_payloads(files: list[Path], root: Path, issue_number: int | N
         if isinstance(payload, dict) and payload.get("issue_number") == issue_number:
             matches.append((file_path.relative_to(root), payload))
     return matches
+
+
+def _matching_execution_scopes(root: Path, issue_number: int | None, mode: str) -> list[Path]:
+    if issue_number is None:
+        return []
+    scope_root = root / "raw" / "execution-scopes"
+    if not scope_root.is_dir():
+        return []
+    return sorted(scope_root.glob(f"*issue-{issue_number}*{mode}*.json"))
+
+
+def _validate_planner_boundary_scope_presence(
+    root: Path,
+    branch_name: str,
+    changed_files: list[str],
+    failures: list[str],
+) -> None:
+    boundary_changes = [path for path in changed_files if _is_governance_surface(path)]
+    if not boundary_changes:
+        return
+
+    issue_number = _branch_issue_number(branch_name)
+    if issue_number is None:
+        failures.append(
+            "planner-boundary changes require a branch name containing `issue-<number>` so execution-scope evidence can be resolved; changed paths: "
+            + ", ".join(boundary_changes)
+        )
+        return
+
+    implementation_scopes = _matching_execution_scopes(root, issue_number, "implementation")
+    planning_scopes = _matching_execution_scopes(root, issue_number, "planning")
+    if len(implementation_scopes) > 1:
+        failures.append(f"multiple implementation execution scopes match issue #{issue_number}")
+    if len(planning_scopes) > 1:
+        failures.append(f"multiple planning execution scopes match issue #{issue_number}")
+    if not implementation_scopes and not planning_scopes:
+        failures.append(
+            f"planner-boundary changes require an issue-specific execution scope for issue #{issue_number}; "
+            f"expected raw/execution-scopes/*issue-{issue_number}*implementation*.json or *issue-{issue_number}*planning*.json; "
+            "changed paths: " + ", ".join(boundary_changes)
+        )
 
 
 def _validate_implementation_ready_plan(path: Path, payload: object, failures: list[str]) -> None:
@@ -201,6 +244,7 @@ def main() -> int:
     parser.add_argument("--branch-name", default="", help="Optional branch name for enforcement decisions.")
     parser.add_argument("--changed-files-file", type=Path, help="Optional newline-delimited changed file list for governance-surface enforcement.")
     parser.add_argument("--enforce-governance-surface", action="store_true", help="Require an approved issue-specific plan when governance-surface files changed.")
+    parser.add_argument("--enforce-planner-boundary-scope", action="store_true", help="Require issue-specific execution-scope evidence when planner-boundary files changed.")
     args = parser.parse_args()
 
     root = Path(args.root).resolve()
@@ -231,6 +275,9 @@ def main() -> int:
             )
         for rel_path, payload in matches:
             _validate_implementation_ready_plan(rel_path, payload, failures)
+
+    if args.enforce_planner_boundary_scope:
+        _validate_planner_boundary_scope_presence(root, args.branch_name, changed_files, failures)
 
     for file_path in files:
         payload = _load_json(file_path)


### PR DESCRIPTION
## Summary

Closes #257.

This PR closes the SoM E2E enforcement gaps found between packet dry-run success and hard-gated execution-scope readiness.

Changes:

- Refuse packet `governance.execution_scope_ref` values unless they resolve to JSON artifacts under `raw/execution-scopes/`.
- Add regression tests proving PDCAR Markdown refs are refused and valid JSON execution-scope refs pass.
- Add `validate_structured_agent_cycle_plan.py --enforce-planner-boundary-scope` for local E2E simulation of the CI planner-boundary scope-presence check.
- Add tests proving a pilot-style changed-file set fails without a matching issue execution scope and passes with one.
- Repair the #231 pilot packet to reference `raw/execution-scopes/2026-04-17-issue-231-e2e-pilot-planning.json` instead of its PDCAR Markdown file.
- Document the updated packet queue and planning gate contracts in `DATA_DICTIONARY.md` and `FEATURE_REGISTRY.md`.

## Validation

```text
PASS: python3 scripts/orchestrator/test_packet_queue.py
PASS: python3 scripts/packet/test_validate.py
PASS: python3 scripts/overlord/test_validate_structured_agent_cycle_plan.py
PASS: python3 scripts/packet/validate.py raw/packets/2026-04-17-issue-231-e2e-pilot.yml
PASS: python3 scripts/orchestrator/packet_queue.py --queue-root /tmp/issue-231-packet-queue-prepush transition --packet /Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-257-som-e2e-enforcement-pdcar/raw/packets/2026-04-17-issue-231-e2e-pilot.yml --from-state inbound --to-state dispatched --dry-run
PASS: python3 scripts/overlord/validate_structured_agent_cycle_plan.py --root . --branch-name issue-257-som-e2e-enforcement-pdcar --changed-files-file /tmp/issue-257-implementation-changed-files.txt --enforce-governance-surface --enforce-planner-boundary-scope
PASS: python3 -m py_compile scripts/orchestrator/packet_queue.py scripts/orchestrator/test_packet_queue.py scripts/overlord/validate_structured_agent_cycle_plan.py scripts/overlord/test_validate_structured_agent_cycle_plan.py scripts/packet/validate.py
```

Known local-only note: `assert_execution_scope.py` correctly failed when checking the forbidden shared root because `/Users/bennibarger/Developer/HLDPRO/hldpro-governance` has unrelated dirty work from other active sessions. This was not bypassed.
