### PR TITLE
[codex] Add HITL relay packet contracts

### DIFF
--- a/docs/plans/issue-299-hitl-packet-contracts-pdcar.md
+++ b/docs/plans/issue-299-hitl-packet-contracts-pdcar.md
@@ -1,0 +1,50 @@
+# PDCAR: HITL Relay Packet Contracts
+
+Date: 2026-04-18
+Repo: `hldpro-governance`
+Branch: `issue-299-hitl-packet-contracts`
+Issue: [#299](https://github.com/NIBARGERB-HLDPRO/hldpro-governance/issues/299)
+Parent epic: [#296](https://github.com/NIBARGERB-HLDPRO/hldpro-governance/issues/296)
+Status: IMPLEMENTATION_READY
+Canonical plan: `docs/plans/issue-299-structured-agent-cycle-plan.json`
+
+## Problem
+
+The HITL relay epic needs a stable packet contract before validators, AIS transport, MCP orchestration, or local CLI adapters can safely depend on it. Without a contract, external replies could be confused with executable instructions, session identity could be lost, and final E2E audit replay would be weak.
+
+## Plan
+
+Add a governance-owned JSON schema for HITL relay packets, valid and invalid examples, and focused tests proving the contract accepts expected packet types and rejects unsafe shapes.
+
+## Do
+
+- Add `docs/schemas/hitl-relay-packet.schema.json`.
+- Add valid examples for HITL request, session instruction, and session resume packets.
+- Add invalid examples for raw message body and missing provenance cases.
+- Add a focused schema test under `scripts/packet/`.
+- Document the schema in `docs/schemas/README.md`.
+
+## Check
+
+- `python3 -m json.tool docs/schemas/hitl-relay-packet.schema.json`
+- `python3 -m pytest scripts/packet/test_hitl_relay_schema.py`
+- Structured-plan governance gate.
+- Planner-boundary execution-scope gate.
+- Local CI Gate.
+
+## Act
+
+If schema tests reveal ambiguity, revise the contract before any runtime validator issue starts. If a future implementation needs a field not represented here, update the schema through an issue-backed contract-change slice.
+
+## Review
+
+Same-family exception is recorded for this no-HITL schema contract slice. Runtime, AIS, MCP, and final E2E slices still require their own review evidence.
+
+## Acceptance Criteria
+
+- [ ] Schema defines all packet types required by issue #299.
+- [ ] Valid fixtures pass schema validation.
+- [ ] Invalid fixtures fail schema validation.
+- [ ] Raw message bodies are rejected by schema shape.
+- [ ] Session instruction packets require normalized decision and audit references.
+- [ ] Contract records request/session/notification/response correlation fields needed by final #296 E2E proof.

--- a/docs/plans/issue-299-structured-agent-cycle-plan.json
+++ b/docs/plans/issue-299-structured-agent-cycle-plan.json
@@ -1,0 +1,103 @@
+{
+  "session_id": "session-20260418-issue-299-hitl-packet-contracts",
+  "issue_number": 299,
+  "objective": "Implement the governance-owned HITL relay packet contract slice for issue #299 by adding schema definitions, valid/invalid fixtures, and focused schema tests for always-on SoM HITL relay packet types.",
+  "tier": 1,
+  "scope_boundary": [
+    "Add the HITL relay packet schema under docs/schemas.",
+    "Add valid and invalid examples proving the contract accepts bounded packets and rejects unsafe shapes.",
+    "Add focused tests for schema validity and fixture behavior.",
+    "Document the schema in docs/schemas/README.md.",
+    "Keep this slice limited to governance contracts and tests."
+  ],
+  "out_of_scope": [
+    "Implementing runtime validators beyond schema fixture tests.",
+    "Implementing AIS notification transport.",
+    "Implementing local-ai-machine MCP runtime or CLI session adapters.",
+    "Changing sibling repos from this branch.",
+    "Closing parent epic #296."
+  ],
+  "research_summary": "Issue #296 decomposed the always-on SoM HITL relay into child slices. Issue #299 owns the first governance contract slice: define the packet shape before validators, AIS transport, MCP orchestration, or local CLI adapters depend on it. The contract must preserve raw replies as references only, bound normalized decisions to allowed actions, and keep session identity/correlation fields explicit for final E2E audit replay.",
+  "research_artifacts": [
+    "GitHub issue #296",
+    "GitHub issue #299",
+    "docs/plans/issue-296-structured-agent-cycle-plan.json",
+    "docs/plans/issue-296-som-hitl-relay-pdcar.md",
+    "docs/schemas/som-packet.schema.yml",
+    "docs/schemas/README.md",
+    "scripts/packet/validate.py"
+  ],
+  "sprints": [
+    {
+      "name": "Contract Schema And Fixtures",
+      "goal": "Add the canonical HITL relay packet schema plus valid/invalid contract fixtures.",
+      "tasks": [
+        "Create docs/schemas/hitl-relay-packet.schema.json.",
+        "Create valid fixtures for HITL request, session instruction, and session resume packets.",
+        "Create invalid fixtures for raw message body and missing provenance cases.",
+        "Document the schema and fixture location in docs/schemas/README.md.",
+        "Add focused schema tests under scripts/packet."
+      ],
+      "acceptance_criteria": [
+        "The schema defines all packet types required by issue #299.",
+        "Valid fixtures pass schema validation.",
+        "Invalid fixtures fail schema validation.",
+        "Raw message bodies are rejected by schema shape.",
+        "Session instruction packets require normalized decision and audit references.",
+        "The contract records request/session/notification/response correlation fields needed by the final #296 E2E proof."
+      ],
+      "file_paths": [
+        "docs/schemas/hitl-relay-packet.schema.json",
+        "docs/schemas/examples/hitl-relay/",
+        "docs/schemas/README.md",
+        "scripts/packet/test_hitl_relay_schema.py",
+        "docs/plans/issue-299-structured-agent-cycle-plan.json",
+        "docs/plans/issue-299-hitl-packet-contracts-pdcar.md",
+        "raw/exceptions/2026-04-18-issue-299-same-family-contracts.md",
+        "raw/execution-scopes/2026-04-18-issue-299-hitl-packet-contracts-implementation.json"
+      ]
+    }
+  ],
+  "specialist_reviews": [
+    {
+      "reviewer": "Codex implementation session",
+      "role": "governance contract implementer",
+      "focus": "Schema shape, fixture coverage, raw-message refusal, and E2E correlation fields.",
+      "status": "accepted_with_followup",
+      "summary": "The schema contract slice can proceed under the operator's no-HITL instruction. Follow-up slices must implement runtime validators, AIS transport, MCP orchestration, and final E2E proof.",
+      "evidence": [
+        "GitHub issue #299",
+        "docs/schemas/hitl-relay-packet.schema.json",
+        "scripts/packet/test_hitl_relay_schema.py"
+      ]
+    }
+  ],
+  "alternate_model_review": {
+    "required": true,
+    "reviewer": "same-family-implementation-fallback",
+    "model_family": "openai",
+    "status": "accepted_with_followup",
+    "summary": "True alternate-family review is not available in this no-HITL Codex lane. This slice is limited to schema contracts and fixture tests, with a same-family exception recorded. Runtime and transport slices still require their own review evidence.",
+    "evidence": [
+      "raw/exceptions/2026-04-18-issue-299-same-family-contracts.md"
+    ]
+  },
+  "execution_handoff": {
+    "session_agent": "Codex",
+    "execution_mode": "implementation_ready",
+    "approved_scope_summary": "Issue #299 may add HITL relay schema contract files, examples, focused schema tests, and planning/scope artifacts. It may not implement runtime transport, MCP orchestration, or sibling repo changes.",
+    "next_execution_step": "Validate schema fixtures, run local CI gate, publish PR, and keep parent #296 open for downstream slices and final E2E proof.",
+    "blocked_on": []
+  },
+  "material_deviation_rules": [
+    "Adding runtime AIS or MCP behavior in this schema contract slice is a material deviation.",
+    "Allowing raw external message bodies inside session instruction packets is a material deviation.",
+    "Removing final E2E correlation fields is a material deviation.",
+    "Editing sibling repos from this branch is a material deviation."
+  ],
+  "approved": true,
+  "approved_by": [
+    "operator no-HITL instruction 2026-04-18"
+  ],
+  "approved_at": "2026-04-18T23:13:15Z"
+}

--- a/docs/schemas/README.md
+++ b/docs/schemas/README.md
@@ -24,6 +24,22 @@ A JSON Schema YAML describing the canonical handoff packet shape:
 - **runbook_ref** (string, optional): Runbook URL or path
 - **fallback_ladder_ref** (string, optional): Fallback tier-down scenario reference
 
+**File:** `hitl-relay-packet.schema.json`
+
+A JSON Schema describing the always-on SoM HITL relay packet contract:
+
+- **packet_type**: One of `session_event`, `hitl_request`, `hitl_response`, `normalized_decision`, `session_instruction`, `session_resume`, or `audit_record`
+- **session**: CLI session identity, CLI type, and current state
+- **correlation**: Request, notification, response, and parent packet IDs for end-to-end traceability
+- **policy**: PII mode, data classification, channel policy reference, and optional retention policy reference
+- **operator_reply**: Sender/channel/message metadata plus a raw message reference; raw message bodies are not allowed in the packet
+- **normalized_decision**: Bounded action, confidence, model identity, raw message reference, and validation-required marker
+- **instruction**: Bounded action addressed to an exact target session with audit references
+- **resume**: Stale/missing/wrong-target session recovery context
+- **audit**: Evidence references and decision trace steps used by the final E2E proof
+
+Examples live under `docs/schemas/examples/hitl-relay/`. Valid examples must pass schema validation; invalid examples must fail closed.
+
 ## Validator
 
 **File:** `scripts/packet/validate.py`

--- a/docs/schemas/examples/hitl-relay/invalid/missing-provenance.json
+++ b/docs/schemas/examples/hitl-relay/invalid/missing-provenance.json
@@ -1,0 +1,31 @@
+{
+  "schema_version": 1,
+  "packet_id": "55555555-5555-4555-8555-555555555555",
+  "packet_type": "session_instruction",
+  "created_at": "2026-04-18T23:17:15Z",
+  "issue_number": 296,
+  "repo": {
+    "owner": "NIBARGERB-HLDPRO",
+    "name": "hldpro-governance"
+  },
+  "session": {
+    "session_id": "codex-20260418-issue-296",
+    "cli": "codex",
+    "state": "waiting_hitl"
+  },
+  "correlation": {
+    "request_id": "hitl-20260418-001"
+  },
+  "policy": {
+    "pii_mode": "none",
+    "data_classification": "internal",
+    "channel_policy_ref": "docs/runbooks/hitl-relay-security.md"
+  },
+  "instruction": {
+    "action": "approve",
+    "target_session_id": "codex-20260418-issue-296",
+    "audit_refs": [
+      "raw/hitl-requests/hitl-20260418-001.json"
+    ]
+  }
+}

--- a/docs/schemas/examples/hitl-relay/invalid/raw-message-body.json
+++ b/docs/schemas/examples/hitl-relay/invalid/raw-message-body.json
@@ -1,0 +1,35 @@
+{
+  "schema_version": 1,
+  "packet_id": "44444444-4444-4444-8444-444444444444",
+  "packet_type": "hitl_response",
+  "created_at": "2026-04-18T23:16:15Z",
+  "issue_number": 296,
+  "repo": {
+    "owner": "NIBARGERB-HLDPRO",
+    "name": "hldpro-governance"
+  },
+  "session": {
+    "session_id": "codex-20260418-issue-296",
+    "cli": "codex",
+    "state": "waiting_hitl"
+  },
+  "correlation": {
+    "request_id": "hitl-20260418-001",
+    "notification_id": "ais-notify-20260418-001",
+    "response_id": "ais-inbound-20260418-001"
+  },
+  "policy": {
+    "pii_mode": "none",
+    "data_classification": "internal",
+    "channel_policy_ref": "docs/runbooks/hitl-relay-security.md"
+  },
+  "operator_reply": {
+    "channel": "sms",
+    "sender_ref": "operator:ben",
+    "message_id": "sms-001",
+    "received_at": "2026-04-18T23:16:00Z",
+    "raw_message_ref": "raw/hitl-responses/ais-inbound-20260418-001.json",
+    "sender_verified": true,
+    "raw_message_body": "merge it"
+  }
+}

--- a/docs/schemas/examples/hitl-relay/valid/hitl-request.json
+++ b/docs/schemas/examples/hitl-relay/valid/hitl-request.json
@@ -1,0 +1,45 @@
+{
+  "schema_version": 1,
+  "packet_id": "11111111-1111-4111-8111-111111111111",
+  "packet_type": "hitl_request",
+  "created_at": "2026-04-18T23:13:15Z",
+  "issue_number": 296,
+  "repo": {
+    "owner": "NIBARGERB-HLDPRO",
+    "name": "hldpro-governance"
+  },
+  "session": {
+    "session_id": "codex-20260418-issue-296",
+    "cli": "codex",
+    "state": "waiting_hitl"
+  },
+  "correlation": {
+    "request_id": "hitl-20260418-001"
+  },
+  "policy": {
+    "pii_mode": "none",
+    "data_classification": "internal",
+    "channel_policy_ref": "docs/runbooks/hitl-relay-security.md"
+  },
+  "event_type": "hitl_checkpoint",
+  "artifacts": [
+    {
+      "kind": "plan",
+      "ref": "docs/plans/issue-296-structured-agent-cycle-plan.json"
+    },
+    {
+      "kind": "execution_scope",
+      "ref": "raw/execution-scopes/2026-04-18-issue-296-som-hitl-relay-planning.json"
+    }
+  ],
+  "requested_decision": {
+    "decision_type": "approval",
+    "allowed_actions": [
+      "approve",
+      "request_changes",
+      "pause",
+      "details"
+    ],
+    "prompt_ref": "raw/hitl-requests/hitl-20260418-001.md"
+  }
+}

--- a/docs/schemas/examples/hitl-relay/valid/session-instruction.json
+++ b/docs/schemas/examples/hitl-relay/valid/session-instruction.json
@@ -1,0 +1,57 @@
+{
+  "schema_version": 1,
+  "packet_id": "22222222-2222-4222-8222-222222222222",
+  "packet_type": "session_instruction",
+  "created_at": "2026-04-18T23:14:15Z",
+  "issue_number": 296,
+  "repo": {
+    "owner": "NIBARGERB-HLDPRO",
+    "name": "hldpro-governance"
+  },
+  "session": {
+    "session_id": "codex-20260418-issue-296",
+    "cli": "codex",
+    "state": "waiting_hitl"
+  },
+  "correlation": {
+    "request_id": "hitl-20260418-001",
+    "parent_packet_id": "11111111-1111-4111-8111-111111111111",
+    "notification_id": "ais-notify-20260418-001",
+    "response_id": "ais-inbound-20260418-001"
+  },
+  "policy": {
+    "pii_mode": "none",
+    "data_classification": "internal",
+    "channel_policy_ref": "docs/runbooks/hitl-relay-security.md",
+    "retention_policy_ref": "docs/runbooks/hitl-relay-security.md#retention"
+  },
+  "operator_reply": {
+    "channel": "local_fixture",
+    "sender_ref": "operator:ben",
+    "message_id": "local-message-001",
+    "received_at": "2026-04-18T23:14:00Z",
+    "raw_message_ref": "raw/hitl-responses/ais-inbound-20260418-001.json",
+    "sender_verified": true
+  },
+  "normalized_decision": {
+    "action": "merge_when_green",
+    "confidence": 0.98,
+    "model_id": "gpt-5.4",
+    "model_family": "openai",
+    "raw_message_ref": "raw/hitl-responses/ais-inbound-20260418-001.json",
+    "validation_required": true
+  },
+  "instruction": {
+    "action": "merge_when_green",
+    "target_session_id": "codex-20260418-issue-296",
+    "constraints": [
+      "require_ci_green",
+      "require_closeout"
+    ],
+    "audit_refs": [
+      "raw/hitl-requests/hitl-20260418-001.json",
+      "raw/hitl-responses/ais-inbound-20260418-001.json",
+      "raw/gate/2026-04-18-hitl-validation.md"
+    ]
+  }
+}

--- a/docs/schemas/examples/hitl-relay/valid/session-resume.json
+++ b/docs/schemas/examples/hitl-relay/valid/session-resume.json
@@ -1,0 +1,35 @@
+{
+  "schema_version": 1,
+  "packet_id": "33333333-3333-4333-8333-333333333333",
+  "packet_type": "session_resume",
+  "created_at": "2026-04-18T23:15:15Z",
+  "issue_number": 296,
+  "repo": {
+    "owner": "NIBARGERB-HLDPRO",
+    "name": "hldpro-governance"
+  },
+  "session": {
+    "session_id": "codex-20260418-issue-296",
+    "cli": "codex",
+    "state": "stale"
+  },
+  "correlation": {
+    "request_id": "hitl-20260418-001",
+    "parent_packet_id": "11111111-1111-4111-8111-111111111111",
+    "notification_id": "ais-notify-20260418-001",
+    "response_id": "ais-inbound-20260418-001"
+  },
+  "policy": {
+    "pii_mode": "none",
+    "data_classification": "internal",
+    "channel_policy_ref": "docs/runbooks/hitl-relay-security.md"
+  },
+  "resume": {
+    "reason": "session_stale",
+    "resume_context_refs": [
+      "raw/hitl-requests/hitl-20260418-001.json",
+      "raw/hitl-responses/ais-inbound-20260418-001.json",
+      "raw/closeouts/2026-04-18-hitl-checkpoint.md"
+    ]
+  }
+}

--- a/docs/schemas/hitl-relay-packet.schema.json
+++ b/docs/schemas/hitl-relay-packet.schema.json
@@ -1,0 +1,578 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "docs/schemas/hitl-relay-packet.schema.json",
+  "title": "HITL Relay Packet",
+  "description": "Governance-owned packet contract for always-on Society of Minds human-in-the-loop relay events, responses, decisions, instructions, resumes, and audit records.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "packet_id",
+    "packet_type",
+    "created_at",
+    "issue_number",
+    "repo",
+    "session",
+    "correlation",
+    "policy"
+  ],
+  "properties": {
+    "schema_version": {
+      "type": "integer",
+      "const": 1
+    },
+    "packet_id": {
+      "type": "string",
+      "format": "uuid"
+    },
+    "packet_type": {
+      "type": "string",
+      "enum": [
+        "session_event",
+        "hitl_request",
+        "hitl_response",
+        "normalized_decision",
+        "session_instruction",
+        "session_resume",
+        "audit_record"
+      ]
+    },
+    "created_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "issue_number": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "repo": {
+      "$ref": "#/$defs/repo"
+    },
+    "session": {
+      "$ref": "#/$defs/session"
+    },
+    "correlation": {
+      "$ref": "#/$defs/correlation"
+    },
+    "policy": {
+      "$ref": "#/$defs/policy"
+    },
+    "event_type": {
+      "type": "string",
+      "enum": [
+        "session_started",
+        "epic_completed",
+        "hitl_checkpoint",
+        "governance_gate_failed",
+        "pr_ready",
+        "merge_ready",
+        "blocked",
+        "user_input_required",
+        "session_stale"
+      ]
+    },
+    "artifacts": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/artifact"
+      }
+    },
+    "requested_decision": {
+      "$ref": "#/$defs/requestedDecision"
+    },
+    "operator_reply": {
+      "$ref": "#/$defs/operatorReply"
+    },
+    "normalized_decision": {
+      "$ref": "#/$defs/normalizedDecision"
+    },
+    "instruction": {
+      "$ref": "#/$defs/instruction"
+    },
+    "resume": {
+      "$ref": "#/$defs/resume"
+    },
+    "audit": {
+      "$ref": "#/$defs/audit"
+    }
+  },
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "packet_type": {
+            "const": "session_event"
+          }
+        }
+      },
+      "then": {
+        "required": [
+          "event_type",
+          "artifacts"
+        ]
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "packet_type": {
+            "const": "hitl_request"
+          }
+        }
+      },
+      "then": {
+        "required": [
+          "event_type",
+          "artifacts",
+          "requested_decision"
+        ]
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "packet_type": {
+            "const": "hitl_response"
+          }
+        }
+      },
+      "then": {
+        "required": [
+          "operator_reply"
+        ]
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "packet_type": {
+            "const": "normalized_decision"
+          }
+        }
+      },
+      "then": {
+        "required": [
+          "operator_reply",
+          "normalized_decision"
+        ]
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "packet_type": {
+            "const": "session_instruction"
+          }
+        }
+      },
+      "then": {
+        "required": [
+          "normalized_decision",
+          "instruction"
+        ]
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "packet_type": {
+            "const": "session_resume"
+          }
+        }
+      },
+      "then": {
+        "required": [
+          "resume"
+        ]
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "packet_type": {
+            "const": "audit_record"
+          }
+        }
+      },
+      "then": {
+        "required": [
+          "audit"
+        ]
+      }
+    }
+  ],
+  "$defs": {
+    "repo": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "owner",
+        "name"
+      ],
+      "properties": {
+        "owner": {
+          "type": "string",
+          "minLength": 1
+        },
+        "name": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "session": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "session_id",
+        "cli",
+        "state"
+      ],
+      "properties": {
+        "session_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "cli": {
+          "type": "string",
+          "enum": [
+            "codex",
+            "claude",
+            "som-worker",
+            "other"
+          ]
+        },
+        "state": {
+          "type": "string",
+          "enum": [
+            "active",
+            "waiting_hitl",
+            "completed",
+            "blocked",
+            "stale",
+            "resumed"
+          ]
+        }
+      }
+    },
+    "correlation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "request_id"
+      ],
+      "properties": {
+        "request_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "parent_packet_id": {
+          "type": "string",
+          "format": "uuid"
+        },
+        "notification_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "response_id": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "policy": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "pii_mode",
+        "data_classification",
+        "channel_policy_ref"
+      ],
+      "properties": {
+        "pii_mode": {
+          "type": "string",
+          "enum": [
+            "none",
+            "tagged",
+            "detected",
+            "lam_only"
+          ]
+        },
+        "data_classification": {
+          "type": "string",
+          "enum": [
+            "public",
+            "internal",
+            "sensitive",
+            "pii"
+          ]
+        },
+        "channel_policy_ref": {
+          "type": "string",
+          "minLength": 1
+        },
+        "retention_policy_ref": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "artifact": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "kind",
+        "ref"
+      ],
+      "properties": {
+        "kind": {
+          "type": "string",
+          "enum": [
+            "plan",
+            "execution_scope",
+            "pr",
+            "check",
+            "closeout",
+            "packet",
+            "audit",
+            "other"
+          ]
+        },
+        "ref": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "requestedDecision": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "decision_type",
+        "allowed_actions"
+      ],
+      "properties": {
+        "decision_type": {
+          "type": "string",
+          "enum": [
+            "approval",
+            "feedback",
+            "clarification",
+            "escalation"
+          ]
+        },
+        "allowed_actions": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/$defs/action"
+          }
+        },
+        "prompt_ref": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "operatorReply": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "channel",
+        "sender_ref",
+        "message_id",
+        "received_at",
+        "raw_message_ref",
+        "sender_verified"
+      ],
+      "properties": {
+        "channel": {
+          "type": "string",
+          "enum": [
+            "sms",
+            "slack",
+            "email",
+            "local_fixture",
+            "other"
+          ]
+        },
+        "sender_ref": {
+          "type": "string",
+          "minLength": 1
+        },
+        "message_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "received_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "raw_message_ref": {
+          "type": "string",
+          "minLength": 1
+        },
+        "sender_verified": {
+          "type": "boolean",
+          "const": true
+        }
+      }
+    },
+    "normalizedDecision": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "action",
+        "confidence",
+        "model_id",
+        "model_family",
+        "raw_message_ref",
+        "validation_required"
+      ],
+      "properties": {
+        "action": {
+          "$ref": "#/$defs/action"
+        },
+        "confidence": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1
+        },
+        "model_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "model_family": {
+          "type": "string",
+          "minLength": 1
+        },
+        "raw_message_ref": {
+          "type": "string",
+          "minLength": 1
+        },
+        "validation_required": {
+          "type": "boolean",
+          "const": true
+        }
+      }
+    },
+    "instruction": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "action",
+        "target_session_id",
+        "audit_refs"
+      ],
+      "properties": {
+        "action": {
+          "$ref": "#/$defs/action"
+        },
+        "target_session_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "constraints": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "audit_refs": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      }
+    },
+    "resume": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "reason",
+        "resume_context_refs"
+      ],
+      "properties": {
+        "reason": {
+          "type": "string",
+          "enum": [
+            "session_stale",
+            "session_missing",
+            "session_refused_wrong_target"
+          ]
+        },
+        "resume_context_refs": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      }
+    },
+    "audit": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "subject_packet_ids",
+        "evidence_refs",
+        "decision_trace"
+      ],
+      "properties": {
+        "subject_packet_ids": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "format": "uuid"
+          }
+        },
+        "evidence_refs": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "decision_trace": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "enum": [
+              "hitl_request",
+              "notification_delivery",
+              "sender_verification",
+              "inbound_response",
+              "normalization",
+              "governance_validation",
+              "session_instruction",
+              "session_consumption",
+              "session_resume"
+            ]
+          }
+        }
+      }
+    },
+    "action": {
+      "type": "string",
+      "enum": [
+        "approve",
+        "request_changes",
+        "pause",
+        "details",
+        "merge_when_green",
+        "create_followup_issue",
+        "resume_session",
+        "escalate",
+        "clarify"
+      ]
+    }
+  }
+}

--- a/raw/exceptions/2026-04-18-issue-299-same-family-contracts.md
+++ b/raw/exceptions/2026-04-18-issue-299-same-family-contracts.md
@@ -1,0 +1,18 @@
+# Same-Family Implementation Exception: Issue #299
+
+Date: 2026-04-18
+Issue: [#299](https://github.com/NIBARGERB-HLDPRO/hldpro-governance/issues/299)
+Parent epic: [#296](https://github.com/NIBARGERB-HLDPRO/hldpro-governance/issues/296)
+Scope: HITL relay packet contracts
+Expires: 2026-04-19T23:13:15Z
+
+## Reason
+
+The operator instructed this session to continue with no HITL. This slice is limited to governance schema contracts, fixtures, docs, tests, and scope artifacts. It does not implement AIS transport, MCP runtime behavior, local CLI adapters, or sibling repo changes.
+
+## Controls
+
+- Runtime and transport behavior remain out of scope.
+- Raw external message bodies must not be accepted in executable packet shapes.
+- Final E2E proof remains tracked separately by issue #303.
+- Parent epic #296 remains open.

--- a/raw/execution-scopes/2026-04-18-issue-299-hitl-packet-contracts-implementation.json
+++ b/raw/execution-scopes/2026-04-18-issue-299-hitl-packet-contracts-implementation.json
@@ -1,0 +1,58 @@
+{
+  "expected_execution_root": "{repo_root}",
+  "expected_branch": "issue-299-hitl-packet-contracts",
+  "execution_mode": "implementation_ready",
+  "handoff_evidence": {
+    "status": "accepted",
+    "planner_model": "gpt-5.4",
+    "implementer_model": "gpt-5.4",
+    "accepted_at": "2026-04-18T23:13:15Z",
+    "evidence_paths": [
+      "docs/plans/issue-299-structured-agent-cycle-plan.json",
+      "docs/plans/issue-299-hitl-packet-contracts-pdcar.md",
+      "raw/exceptions/2026-04-18-issue-299-same-family-contracts.md"
+    ],
+    "active_exception_ref": "raw/exceptions/2026-04-18-issue-299-same-family-contracts.md",
+    "active_exception_expires_at": "2026-04-19T23:13:15Z"
+  },
+  "allowed_write_paths": [
+    "docs/schemas/hitl-relay-packet.schema.json",
+    "docs/schemas/examples/hitl-relay/",
+    "docs/schemas/README.md",
+    "scripts/packet/test_hitl_relay_schema.py",
+    "docs/plans/issue-299-structured-agent-cycle-plan.json",
+    "docs/plans/issue-299-hitl-packet-contracts-pdcar.md",
+    "raw/exceptions/2026-04-18-issue-299-same-family-contracts.md",
+    "raw/execution-scopes/2026-04-18-issue-299-hitl-packet-contracts-implementation.json"
+  ],
+  "forbidden_roots": [
+    "/Users/bennibarger/Developer/HLDPRO/hldpro-governance",
+    "/Users/bennibarger/Developer/HLDPRO/local-ai-machine",
+    "/Users/bennibarger/Developer/HLDPRO/ai-integration-services",
+    "/Users/bennibarger/Developer/HLDPRO/knocktracker",
+    "/Users/bennibarger/Developer/HLDPRO/HealthcarePlatform",
+    "/Users/bennibarger/Developer/HLDPRO/ASC-Evaluator"
+  ],
+  "active_parallel_roots": [
+    {
+      "path": "/Users/bennibarger/Developer/HLDPRO/hldpro-governance",
+      "reason": "Shared main checkout contains pre-existing operator/parallel planning files and is not the issue #299 execution root."
+    },
+    {
+      "path": "/Users/bennibarger/Developer/HLDPRO/local-ai-machine",
+      "reason": "Sibling repo has active unrelated runtime work; issue #299 does not edit it."
+    },
+    {
+      "path": "/Users/bennibarger/Developer/HLDPRO/ai-integration-services",
+      "reason": "Sibling repo has active unrelated transport work; issue #299 does not edit it."
+    },
+    {
+      "path": "/Users/bennibarger/Developer/HLDPRO/knocktracker",
+      "reason": "Sibling repo has active unrelated work; issue #299 does not edit it."
+    },
+    {
+      "path": "/Users/bennibarger/Developer/HLDPRO/HealthcarePlatform",
+      "reason": "Sibling repo has active unrelated work; issue #299 does not edit it."
+    }
+  ]
+}

--- a/scripts/packet/test_hitl_relay_schema.py
+++ b/scripts/packet/test_hitl_relay_schema.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from jsonschema import Draft202012Validator
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCHEMA_PATH = REPO_ROOT / "docs" / "schemas" / "hitl-relay-packet.schema.json"
+EXAMPLE_ROOT = REPO_ROOT / "docs" / "schemas" / "examples" / "hitl-relay"
+
+
+def _validator() -> Draft202012Validator:
+    schema = json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
+    Draft202012Validator.check_schema(schema)
+    return Draft202012Validator(schema)
+
+
+def _load(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def test_valid_hitl_relay_examples_pass() -> None:
+    validator = _validator()
+    valid_files = sorted((EXAMPLE_ROOT / "valid").glob("*.json"))
+    assert valid_files, "expected valid HITL relay examples"
+    for example in valid_files:
+        errors = sorted(validator.iter_errors(_load(example)), key=lambda error: error.path)
+        assert not errors, f"{example} failed schema validation: {[error.message for error in errors]}"
+
+
+def test_invalid_hitl_relay_examples_fail() -> None:
+    validator = _validator()
+    invalid_files = sorted((EXAMPLE_ROOT / "invalid").glob("*.json"))
+    assert invalid_files, "expected invalid HITL relay examples"
+    for example in invalid_files:
+        errors = sorted(validator.iter_errors(_load(example)), key=lambda error: error.path)
+        assert errors, f"{example} unexpectedly passed schema validation"


### PR DESCRIPTION
## Summary

Implements the first #296 child slice: governance-owned HITL relay packet contracts for issue #299.

## What Changed

- Adds `docs/schemas/hitl-relay-packet.schema.json` for HITL relay packet types:
  - `session_event`
  - `hitl_request`
  - `hitl_response`
  - `normalized_decision`
  - `session_instruction`
  - `session_resume`
  - `audit_record`
- Adds valid fixtures for HITL request, session instruction, and session resume packets.
- Adds invalid fixtures proving raw message bodies and missing provenance fail closed.
- Adds focused schema tests under `scripts/packet/`.
- Documents the new schema in `docs/schemas/README.md`.
- Adds issue #299 plan/PDCAR, same-family exception, and execution-scope evidence.

## Validation

- `python3 -m json.tool docs/schemas/hitl-relay-packet.schema.json`
- `python3 -m json.tool docs/plans/issue-299-structured-agent-cycle-plan.json`
- `python3 -m json.tool raw/execution-scopes/2026-04-18-issue-299-hitl-packet-contracts-implementation.json`
- `python3 -m pytest scripts/packet/test_hitl_relay_schema.py`
- `python3 scripts/overlord/validate_structured_agent_cycle_plan.py --root . --branch-name issue-299-hitl-packet-contracts --require-if-issue-branch --changed-files-file /tmp/issue-299-changed-files.txt --enforce-governance-surface --enforce-planner-boundary-scope`
- `python3 scripts/overlord/assert_execution_scope.py --scope raw/execution-scopes/2026-04-18-issue-299-hitl-packet-contracts-implementation.json --changed-files-file /tmp/issue-299-changed-files.txt`
- `tools/local-ci-gate/bin/hldpro-local-ci --changed-files-file /tmp/issue-299-changed-files.txt`

Local CI Gate verdict: PASS.

Closes #299. Parent epic #296 remains open for validators, security policy, AIS/LAM implementation, and final E2E proof.
