### PR TITLE
[codex] Add HITL relay security policy

### DIFF
--- a/docs/plans/issue-302-hitl-security-policy-pdcar.md
+++ b/docs/plans/issue-302-hitl-security-policy-pdcar.md
@@ -1,0 +1,49 @@
+# PDCAR: HITL Relay Security And Data-Handling Policy
+
+Date: 2026-04-18
+Repo: `hldpro-governance`
+Branch: `issue-302-hitl-security-policy`
+Issue: [#302](https://github.com/NIBARGERB-HLDPRO/hldpro-governance/issues/302)
+Parent epic: [#296](https://github.com/NIBARGERB-HLDPRO/hldpro-governance/issues/296)
+Status: IMPLEMENTATION_READY
+Canonical plan: `docs/plans/issue-302-structured-agent-cycle-plan.json`
+
+## Problem
+
+The HITL relay will send operator prompts and receive replies through AIS-backed channels. Before validators, AIS, MCP, or CLI adapters use that path, the system needs explicit data-handling rules for minimization, redaction, retention, sender verification, replay protection, token scope, and PII/channel behavior.
+
+## Plan
+
+Add a governance-owned policy runbook that downstream implementation slices must cite and enforce.
+
+## Do
+
+- Add `docs/runbooks/hitl-relay-security.md`.
+- Define classification and channel rules.
+- Define minimization and redaction requirements.
+- Define raw message retention/deletion and audit reference rules.
+- Define sender verification, replay, duplicate, expiration, and token scope requirements.
+
+## Check
+
+- `python3 -m json.tool docs/plans/issue-302-structured-agent-cycle-plan.json`
+- Structured-plan governance gate.
+- Planner-boundary execution-scope gate.
+- Local CI Gate.
+
+## Act
+
+If AIS, MCP, validator, or session-adapter slices find policy gaps, update this runbook through issue-backed policy changes before enabling the affected path.
+
+## Review
+
+Same-family exception is recorded for this no-HITL policy slice. Later runtime and transport slices still need their own review evidence.
+
+## Acceptance Criteria
+
+- [ ] Policy states what data may leave local control for each classification and channel.
+- [ ] Policy requires redaction or summary minimization before AIS receives HITL notification content when source artifacts may contain sensitive data.
+- [ ] Policy defines raw message retention/deletion and audit-reference rules.
+- [ ] Policy defines sender verification, webhook signature, replay, duplicate, and expiration requirements.
+- [ ] Policy defines token/secret scope expectations.
+- [ ] Policy states PII-tagged or PII-detected packets fail closed unless a local-only route is explicitly available.

--- a/docs/plans/issue-302-structured-agent-cycle-plan.json
+++ b/docs/plans/issue-302-structured-agent-cycle-plan.json
@@ -1,0 +1,97 @@
+{
+  "session_id": "session-20260418-issue-302-hitl-security-policy",
+  "issue_number": 302,
+  "objective": "Implement the security and data-handling policy slice for the always-on SoM HITL relay so AIS, MCP, validator, and session-adapter implementation issues have concrete rules for minimization, redaction, retention, sender verification, token scope, replay protection, and channel-specific PII handling.",
+  "tier": 1,
+  "scope_boundary": [
+    "Add a governance-owned HITL relay security and data-handling runbook.",
+    "Define payload minimization, redaction, retention, sender verification, token scope, replay protection, and channel policy.",
+    "Keep the slice policy-only.",
+    "Do not implement AIS, MCP, or local CLI runtime behavior."
+  ],
+  "out_of_scope": [
+    "Implementing validators, transport, webhook handlers, MCP runtime, or local CLI session adapters.",
+    "Enabling production SMS, Slack, email, or other channels.",
+    "Changing sibling repos.",
+    "Closing parent epic #296."
+  ],
+  "research_summary": "Subagent review of the #296 planning package found that security/privacy needed a concrete data-handling policy before messaging or runtime work starts. The policy must make payload minimization, redaction, retention/deletion, sender verification, webhook replay protection, token scope, and channel-specific PII rules explicit. This slice satisfies that prerequisite and feeds the later validator, AIS, MCP, and final E2E issues.",
+  "research_artifacts": [
+    "GitHub issue #296",
+    "GitHub issue #302",
+    "GitHub issue #299",
+    "docs/plans/issue-296-structured-agent-cycle-plan.json",
+    "docs/plans/issue-296-som-hitl-relay-pdcar.md",
+    "docs/schemas/hitl-relay-packet.schema.json",
+    "STANDARDS.md"
+  ],
+  "sprints": [
+    {
+      "name": "Security And Data Policy",
+      "goal": "Define the policy that every HITL relay transport and runtime slice must cite before moving session data across boundaries.",
+      "tasks": [
+        "Create docs/runbooks/hitl-relay-security.md.",
+        "Define classification and channel rules.",
+        "Define minimization and redaction requirements.",
+        "Define raw message retention/deletion and audit reference requirements.",
+        "Define sender verification, replay, duplicate, expiration, and token scope requirements."
+      ],
+      "acceptance_criteria": [
+        "Policy states what data may leave local control for each classification and channel.",
+        "Policy requires redaction or summary minimization before AIS receives HITL notification content when source artifacts may contain sensitive data.",
+        "Policy defines raw message retention/deletion and audit-reference rules.",
+        "Policy defines sender verification, webhook signature, replay, duplicate, and expiration requirements.",
+        "Policy defines token/secret scope expectations.",
+        "Policy states PII-tagged or PII-detected packets fail closed unless a local-only route is explicitly available."
+      ],
+      "file_paths": [
+        "docs/runbooks/hitl-relay-security.md",
+        "docs/plans/issue-302-structured-agent-cycle-plan.json",
+        "docs/plans/issue-302-hitl-security-policy-pdcar.md",
+        "raw/exceptions/2026-04-18-issue-302-same-family-policy.md",
+        "raw/execution-scopes/2026-04-18-issue-302-hitl-security-policy-implementation.json"
+      ]
+    }
+  ],
+  "specialist_reviews": [
+    {
+      "reviewer": "Codex implementation session",
+      "role": "governance policy implementer",
+      "focus": "HITL relay data handling, channel policy, audit replay, and fail-closed security rules.",
+      "status": "accepted_with_followup",
+      "summary": "The policy slice can proceed under the operator's no-HITL instruction. Later AIS/MCP/validator slices must cite and enforce it.",
+      "evidence": [
+        "GitHub issue #302",
+        "docs/runbooks/hitl-relay-security.md"
+      ]
+    }
+  ],
+  "alternate_model_review": {
+    "required": true,
+    "reviewer": "same-family-implementation-fallback",
+    "model_family": "openai",
+    "status": "accepted_with_followup",
+    "summary": "True alternate-family review is not available in this no-HITL Codex lane. This slice is policy-only, with a same-family exception recorded. Runtime and transport slices still require their own review evidence.",
+    "evidence": [
+      "raw/exceptions/2026-04-18-issue-302-same-family-policy.md"
+    ]
+  },
+  "execution_handoff": {
+    "session_agent": "Codex",
+    "execution_mode": "implementation_ready",
+    "approved_scope_summary": "Issue #302 may add HITL relay security/data policy docs plus planning and execution-scope artifacts. It may not implement validators, transport, MCP, local CLI adapters, or sibling repo changes.",
+    "next_execution_step": "Validate the policy package, publish PR, and keep parent #296 open for enforcement and E2E slices.",
+    "blocked_on": []
+  },
+  "material_deviation_rules": [
+    "Enabling production messaging channels in this policy slice is a material deviation.",
+    "Allowing PII-tagged or PII-detected packets to leave local control by default is a material deviation.",
+    "Allowing raw human text to become terminal input is a material deviation.",
+    "Editing sibling repos from this branch is a material deviation."
+  ],
+  "approved": true,
+  "approved_by": [
+    "operator no-HITL instruction 2026-04-18"
+  ],
+  "approved_at": "2026-04-18T23:19:00Z"
+}

--- a/docs/runbooks/hitl-relay-security.md
+++ b/docs/runbooks/hitl-relay-security.md
@@ -1,0 +1,152 @@
+# HITL Relay Security And Data-Handling Policy
+
+Issue: [#302](https://github.com/NIBARGERB-HLDPRO/hldpro-governance/issues/302)
+Parent epic: [#296](https://github.com/NIBARGERB-HLDPRO/hldpro-governance/issues/296)
+Status: ACTIVE POLICY
+
+## Purpose
+
+This policy defines what the always-on SoM HITL relay may send through AIS-backed messaging channels, what must stay local, how inbound replies are verified and retained, and what evidence must exist for audit replay.
+
+The relay path is:
+
+```text
+local CLI checkpoint
+-> HITL packet
+-> local SoM/MCP orchestrator
+-> AIS outbound notification
+-> operator reply
+-> AIS inbound event
+-> local normalizer and governance gate
+-> session instruction or resume packet
+```
+
+AIS is transport only. Governance policy, normalization, validation, and session instruction emission remain outside AIS.
+
+## Data Classification
+
+| Classification | May leave local control? | Rule |
+|---|---:|---|
+| `public` | Yes | May be included in notification bodies if relevant. |
+| `internal` | Yes, minimized | Send only the decision prompt, issue/PR links, check status, and short summary. |
+| `sensitive` | Conditional | Redact payload details; send only references and a minimal decision prompt. |
+| `pii` | No by default | Must fail closed unless a local-only operator channel is explicitly approved. |
+
+PII-tagged or PII-detected packets must not be sent to cloud LLMs, Windows fallback, SMS, Slack, email, or other external channels unless a later issue records an explicit exception and local-only route.
+
+## Payload Minimization
+
+Outbound notification bodies must prefer references over content:
+
+- include issue number, repo, branch, PR/check links, requested decision, and allowed response actions;
+- include short summaries only when data classification permits it;
+- omit raw diffs, logs, secrets, patient/client/user data, tokens, local paths containing sensitive names, and unredacted exception traces;
+- include `notification_id` so replies can be correlated without repeating sensitive context.
+
+For `sensitive` packets, AIS receives a minimized message and opaque references. The local orchestrator retains the richer context.
+
+## Redaction Before AIS Or AI Hops
+
+Before a HITL notification leaves the local orchestrator:
+
+1. Classify the packet with `policy.data_classification` and `policy.pii_mode`.
+2. Redact secrets, tokens, credentials, phone numbers, email addresses, access keys, patient/client identifiers, and raw message bodies.
+3. Replace redacted fields with evidence references or hashes when audit replay requires proof.
+4. Refuse dispatch if classification or redaction cannot complete.
+
+The LLM normalizer may receive raw inbound reply content only through a local route unless the reply is classified non-sensitive and policy allows cloud processing.
+
+## Raw Message Retention
+
+Raw inbound and outbound message bodies are not stored in executable packets.
+
+Required retention rules:
+
+- executable packets store `raw_message_ref`, not `raw_message_body`;
+- raw message stores must be access-controlled and scoped to the relay service;
+- retention defaults to 30 days unless a narrower channel policy applies;
+- deletion must preserve audit references, IDs, hashes, timestamps, sender verification result, and normalized decision;
+- final closeout must not paste raw sensitive message bodies.
+
+## Sender Verification
+
+Inbound replies must fail closed unless AIS records:
+
+- channel;
+- sender reference;
+- message ID;
+- notification ID or correlation key;
+- received timestamp;
+- sender verification result;
+- duplicate/replay status;
+- expiration status.
+
+Unknown senders, unsigned webhooks, failed signatures, expired replies, and uncorrelated replies cannot produce session instructions.
+
+## Webhook Replay And Duplicate Handling
+
+AIS inbound events must be idempotent by `message_id` and `notification_id`.
+
+Required behavior:
+
+- duplicate valid replies return the existing response event or a duplicate marker;
+- replayed webhook payloads are refused or marked duplicate;
+- expired notification replies are refused or converted into a clarification event;
+- conflicting replies for the same notification require local orchestrator clarification.
+
+## Token And Secret Scope
+
+AIS and MCP integration credentials must use the narrowest workable scope:
+
+- AIS outbound sender credentials may send messages only through configured channels;
+- AIS inbound webhook secrets may verify signatures only;
+- local orchestrator tokens may read/write only the approved relay queues and packet artifacts;
+- GitHub tokens used in closeout or issue comments must not be exposed to AIS payloads;
+- secrets must never be included in notification text, packet fields, closeouts, or audit excerpts.
+
+## Channel Rules
+
+| Channel | Initial status | Notes |
+|---|---|---|
+| Local fixture | Allowed | Required for dry-run and CI-safe E2E. |
+| SMS | Planned | Allowed only for non-PII minimized prompts after sender verification exists. |
+| Slack | Planned | Allowed only for non-PII minimized prompts after app signing and sender verification exist. |
+| Email | Deferred | Requires a separate retention and sender-verification review. |
+| Other | Disabled | Must be added by issue-backed policy update. |
+
+Initial epic acceptance requires at least one real or sandboxed AIS-backed transport. SMS and Slack are not both mandatory unless a later issue makes both mandatory.
+
+## Audit Replay Evidence
+
+The final E2E proof must reconstruct a decision using:
+
+- session ID;
+- HITL request packet ID;
+- notification ID;
+- sender verification result;
+- inbound message/event ID;
+- raw message reference or hash;
+- normalized decision;
+- governance validator result;
+- instruction or resume packet ID;
+- local session consumption or resume evidence.
+
+Audit replay should prove the decision path without exposing unnecessary raw content.
+
+## Fail-Closed Conditions
+
+The relay must refuse or halt when:
+
+- `pii_mode` is `tagged`, `detected`, or `lam_only` and no local-only route is approved;
+- data classification is missing or unknown;
+- sender verification fails;
+- webhook signature is missing or invalid;
+- notification ID is missing, expired, replayed, or uncorrelated;
+- normalized decision action is outside the allowed vocabulary;
+- session ID does not match the target session;
+- raw human text would be used as terminal input;
+- required audit evidence is missing.
+
+## Closeout Requirement
+
+Every implementation slice that touches AIS, MCP, validators, or session adapters must cite this policy and record whether it changed the data classification, retention, sender verification, token scope, or channel rule.

--- a/raw/exceptions/2026-04-18-issue-302-same-family-policy.md
+++ b/raw/exceptions/2026-04-18-issue-302-same-family-policy.md
@@ -1,0 +1,18 @@
+# Same-Family Implementation Exception: Issue #302
+
+Date: 2026-04-18
+Issue: [#302](https://github.com/NIBARGERB-HLDPRO/hldpro-governance/issues/302)
+Parent epic: [#296](https://github.com/NIBARGERB-HLDPRO/hldpro-governance/issues/296)
+Scope: HITL relay security and data-handling policy
+Expires: 2026-04-19T23:19:00Z
+
+## Reason
+
+The operator instructed this session to continue with no HITL. This slice is policy-only and does not enable production messaging channels or implement runtime behavior.
+
+## Controls
+
+- No AIS, MCP, local CLI, or sibling repo implementation is allowed in this slice.
+- PII-tagged and PII-detected packets fail closed by default.
+- Final E2E proof remains tracked by issue #303.
+- Parent epic #296 remains open.

--- a/raw/execution-scopes/2026-04-18-issue-302-hitl-security-policy-implementation.json
+++ b/raw/execution-scopes/2026-04-18-issue-302-hitl-security-policy-implementation.json
@@ -1,0 +1,55 @@
+{
+  "expected_execution_root": "{repo_root}",
+  "expected_branch": "issue-302-hitl-security-policy",
+  "execution_mode": "implementation_ready",
+  "handoff_evidence": {
+    "status": "accepted",
+    "planner_model": "gpt-5.4",
+    "implementer_model": "gpt-5.4",
+    "accepted_at": "2026-04-18T23:19:00Z",
+    "evidence_paths": [
+      "docs/plans/issue-302-structured-agent-cycle-plan.json",
+      "docs/plans/issue-302-hitl-security-policy-pdcar.md",
+      "raw/exceptions/2026-04-18-issue-302-same-family-policy.md"
+    ],
+    "active_exception_ref": "raw/exceptions/2026-04-18-issue-302-same-family-policy.md",
+    "active_exception_expires_at": "2026-04-19T23:19:00Z"
+  },
+  "allowed_write_paths": [
+    "docs/runbooks/hitl-relay-security.md",
+    "docs/plans/issue-302-structured-agent-cycle-plan.json",
+    "docs/plans/issue-302-hitl-security-policy-pdcar.md",
+    "raw/exceptions/2026-04-18-issue-302-same-family-policy.md",
+    "raw/execution-scopes/2026-04-18-issue-302-hitl-security-policy-implementation.json"
+  ],
+  "forbidden_roots": [
+    "/Users/bennibarger/Developer/HLDPRO/hldpro-governance",
+    "/Users/bennibarger/Developer/HLDPRO/local-ai-machine",
+    "/Users/bennibarger/Developer/HLDPRO/ai-integration-services",
+    "/Users/bennibarger/Developer/HLDPRO/knocktracker",
+    "/Users/bennibarger/Developer/HLDPRO/HealthcarePlatform",
+    "/Users/bennibarger/Developer/HLDPRO/ASC-Evaluator"
+  ],
+  "active_parallel_roots": [
+    {
+      "path": "/Users/bennibarger/Developer/HLDPRO/hldpro-governance",
+      "reason": "Shared main checkout contains pre-existing operator/parallel planning files and is not the issue #302 execution root."
+    },
+    {
+      "path": "/Users/bennibarger/Developer/HLDPRO/local-ai-machine",
+      "reason": "Sibling repo has active unrelated runtime work; issue #302 does not edit it."
+    },
+    {
+      "path": "/Users/bennibarger/Developer/HLDPRO/ai-integration-services",
+      "reason": "Sibling repo has active unrelated transport work; issue #302 does not edit it."
+    },
+    {
+      "path": "/Users/bennibarger/Developer/HLDPRO/knocktracker",
+      "reason": "Sibling repo has active unrelated work; issue #302 does not edit it."
+    },
+    {
+      "path": "/Users/bennibarger/Developer/HLDPRO/HealthcarePlatform",
+      "reason": "Sibling repo has active unrelated work; issue #302 does not edit it."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Implements the #302 security/data-handling policy slice for the SoM HITL relay epic.

## What Changed

- Adds `docs/runbooks/hitl-relay-security.md` covering:
  - data classification and channel rules
  - payload minimization
  - redaction before AIS or AI hops
  - raw message retention/deletion
  - sender verification
  - webhook replay and duplicate handling
  - token/secret scope
  - channel enablement rules
  - audit replay evidence
  - fail-closed conditions
- Adds issue #302 plan/PDCAR, same-family exception, and execution-scope evidence.

## Validation

- `python3 -m json.tool docs/plans/issue-302-structured-agent-cycle-plan.json`
- `python3 -m json.tool raw/execution-scopes/2026-04-18-issue-302-hitl-security-policy-implementation.json`
- `python3 scripts/overlord/validate_structured_agent_cycle_plan.py --root . --branch-name issue-302-hitl-security-policy --require-if-issue-branch --changed-files-file /tmp/issue-302-changed-files.txt --enforce-governance-surface --enforce-planner-boundary-scope`
- `python3 scripts/overlord/assert_execution_scope.py --scope raw/execution-scopes/2026-04-18-issue-302-hitl-security-policy-implementation.json --changed-files-file /tmp/issue-302-changed-files.txt`
- `tools/local-ci-gate/bin/hldpro-local-ci --changed-files-file /tmp/issue-302-changed-files.txt`

Local CI Gate verdict: PASS.

Closes #302. Parent #296 remains open for validators, AIS/LAM runtime work, and final E2E proof.
