### PR TITLE
[codex] Add HITL relay validators

### DIFF
--- a/docs/plans/issue-300-hitl-validators-pdcar.md
+++ b/docs/plans/issue-300-hitl-validators-pdcar.md
@@ -1,0 +1,49 @@
+# PDCAR: HITL Relay Validators And Policy Gates
+
+Date: 2026-04-18
+Repo: `hldpro-governance`
+Branch: `issue-300-hitl-validators`
+Issue: [#300](https://github.com/NIBARGERB-HLDPRO/hldpro-governance/issues/300)
+Parent epic: [#296](https://github.com/NIBARGERB-HLDPRO/hldpro-governance/issues/296)
+Status: IMPLEMENTATION_READY
+Canonical plan: `docs/plans/issue-300-structured-agent-cycle-plan.json`
+
+## Problem
+
+The HITL relay has packet contracts and security policy, but downstream queue, AIS, MCP, and session adapter work needs deterministic validators that fail closed before notification or instruction dispatch.
+
+## Plan
+
+Add `scripts/packet/validate_hitl_relay.py` and focused tests that enforce schema, correlation, operator provenance, confidence, stale-session, duplicate/replay/expired, and PII/channel policy gates.
+
+## Do
+
+- Add the validator.
+- Add tests for valid examples and negative controls.
+- Update the schema to allow duplicate/replayed/expired metadata on inbound replies.
+- Document validator responsibilities.
+
+## Check
+
+- `python3 -m pytest scripts/packet/test_validate_hitl_relay.py`
+- `python3 -m pytest scripts/packet/test_hitl_relay_schema.py`
+- Structured-plan governance gate.
+- Planner-boundary execution-scope gate.
+- Local CI Gate.
+
+## Act
+
+If later slices need more runtime metadata, update the schema/validator through issue-backed contract changes before enabling the affected path.
+
+## Review
+
+Same-family exception is recorded for this no-HITL deterministic validator slice. Runtime and transport slices still need their own review evidence.
+
+## Acceptance Criteria
+
+- [ ] Invalid HITL request/response/instruction packets fail before notification or instruction dispatch.
+- [ ] Self-approval/provenance gaps are refused by requiring verified operator provenance for approval-like actions.
+- [ ] Ambiguous/low-confidence replies cannot produce executable instructions.
+- [ ] PII-sensitive packets fail closed for external channels.
+- [ ] Stale sessions require resume packets.
+- [ ] Duplicate/replayed/expired replies cannot produce instructions.

--- a/docs/plans/issue-300-structured-agent-cycle-plan.json
+++ b/docs/plans/issue-300-structured-agent-cycle-plan.json
@@ -1,0 +1,100 @@
+{
+  "session_id": "session-20260418-issue-300-hitl-validators",
+  "issue_number": 300,
+  "objective": "Implement deterministic HITL relay validators and policy gates that enforce the merged #299 packet contracts and #302 security/data-handling policy before AIS or MCP runtime paths can emit session instructions.",
+  "tier": 1,
+  "scope_boundary": [
+    "Add a governance-owned HITL relay validator under scripts/packet.",
+    "Enforce schema, correlation, operator provenance, allowed action, confidence, stale-session, duplicate/replay/expired, and PII/channel policy gates.",
+    "Add focused tests covering valid and fail-closed negative controls.",
+    "Keep this slice inside hldpro-governance."
+  ],
+  "out_of_scope": [
+    "Implementing queue processing, AIS transport, MCP runtime, or local CLI adapters.",
+    "Changing sibling repos.",
+    "Closing parent epic #296.",
+    "Running final cross-repo E2E proof."
+  ],
+  "research_summary": "Issue #299 added HITL relay packet schemas and fixtures. Issue #302 added security/data-handling policy. Issue #300 now adds deterministic validation that ties those contracts to enforceable behavior before downstream queue, AIS, MCP, and CLI adapter slices proceed.",
+  "research_artifacts": [
+    "GitHub issue #296",
+    "GitHub issue #299",
+    "GitHub issue #300",
+    "GitHub issue #302",
+    "docs/schemas/hitl-relay-packet.schema.json",
+    "docs/runbooks/hitl-relay-security.md",
+    "scripts/packet/test_hitl_relay_schema.py"
+  ],
+  "sprints": [
+    {
+      "name": "Validator And Negative Controls",
+      "goal": "Add deterministic policy validation for HITL relay packets.",
+      "tasks": [
+        "Create scripts/packet/validate_hitl_relay.py.",
+        "Add tests for valid examples and invalid schema examples.",
+        "Add tests for wrong session, low confidence, duplicate, expired, PII external channel, stale session, and missing notification correlation.",
+        "Document validator responsibilities in docs/schemas/README.md."
+      ],
+      "acceptance_criteria": [
+        "Invalid HITL request/response/instruction packets fail before notification or instruction dispatch.",
+        "Self-approval/provenance gaps are refused by requiring verified operator provenance for approval-like actions.",
+        "Ambiguous/low-confidence replies cannot produce executable instructions.",
+        "PII-sensitive packets fail closed for external channels.",
+        "Stale sessions require resume packets.",
+        "Duplicate/replayed/expired replies cannot produce instructions."
+      ],
+      "file_paths": [
+        "scripts/packet/validate_hitl_relay.py",
+        "scripts/packet/test_validate_hitl_relay.py",
+        "docs/schemas/hitl-relay-packet.schema.json",
+        "docs/schemas/README.md",
+        "docs/plans/issue-300-structured-agent-cycle-plan.json",
+        "docs/plans/issue-300-hitl-validators-pdcar.md",
+        "raw/exceptions/2026-04-18-issue-300-same-family-validators.md",
+        "raw/execution-scopes/2026-04-18-issue-300-hitl-validators-implementation.json"
+      ]
+    }
+  ],
+  "specialist_reviews": [
+    {
+      "reviewer": "Codex implementation session",
+      "role": "governance validator implementer",
+      "focus": "HITL relay deterministic validation, policy gates, negative controls, and final E2E prerequisites.",
+      "status": "accepted_with_followup",
+      "summary": "The validator slice can proceed under the operator's no-HITL instruction. Queue/AIS/MCP/runtime slices remain separate and must consume this validator.",
+      "evidence": [
+        "GitHub issue #300",
+        "scripts/packet/validate_hitl_relay.py",
+        "scripts/packet/test_validate_hitl_relay.py"
+      ]
+    }
+  ],
+  "alternate_model_review": {
+    "required": true,
+    "reviewer": "same-family-implementation-fallback",
+    "model_family": "openai",
+    "status": "accepted_with_followup",
+    "summary": "True alternate-family review is not available in this no-HITL Codex lane. This slice is deterministic validator work with focused tests and a same-family exception recorded.",
+    "evidence": [
+      "raw/exceptions/2026-04-18-issue-300-same-family-validators.md"
+    ]
+  },
+  "execution_handoff": {
+    "session_agent": "Codex",
+    "execution_mode": "implementation_ready",
+    "approved_scope_summary": "Issue #300 may add HITL relay validator code/tests, update the HITL schema for validator metadata, document validator responsibilities, and add planning/scope artifacts. It may not implement queue processing, AIS transport, MCP runtime, local CLI adapters, or sibling repo changes.",
+    "next_execution_step": "Validate tests, publish PR, and keep parent #296 open for queue, transport, runtime, adapter, and final E2E slices.",
+    "blocked_on": []
+  },
+  "material_deviation_rules": [
+    "Implementing AIS or MCP runtime behavior in this validator slice is a material deviation.",
+    "Allowing duplicate/replayed/expired replies to produce instructions is a material deviation.",
+    "Allowing PII external-channel routing by default is a material deviation.",
+    "Editing sibling repos from this branch is a material deviation."
+  ],
+  "approved": true,
+  "approved_by": [
+    "operator no-HITL instruction 2026-04-18"
+  ],
+  "approved_at": "2026-04-18T23:23:46Z"
+}

--- a/docs/schemas/README.md
+++ b/docs/schemas/README.md
@@ -40,6 +40,16 @@ A JSON Schema describing the always-on SoM HITL relay packet contract:
 
 Examples live under `docs/schemas/examples/hitl-relay/`. Valid examples must pass schema validation; invalid examples must fail closed.
 
+The deterministic policy validator lives at `scripts/packet/validate_hitl_relay.py`. It layers issue #300 governance rules on top of the schema:
+
+- response and instruction packets require notification/response correlation;
+- approval-like decisions require verified operator provenance;
+- duplicate, replayed, or expired replies cannot produce instructions;
+- low-confidence replies must normalize to `clarify`;
+- PII-tagged/detected packets fail closed for external channels;
+- stale sessions require resume packets instead of session instructions;
+- instruction targets must match the exact local session ID.
+
 ## Validator
 
 **File:** `scripts/packet/validate.py`

--- a/docs/schemas/hitl-relay-packet.schema.json
+++ b/docs/schemas/hitl-relay-packet.schema.json
@@ -415,6 +415,15 @@
         "sender_verified": {
           "type": "boolean",
           "const": true
+        },
+        "duplicate": {
+          "type": "boolean"
+        },
+        "replayed": {
+          "type": "boolean"
+        },
+        "expired": {
+          "type": "boolean"
         }
       }
     },

--- a/raw/exceptions/2026-04-18-issue-300-same-family-validators.md
+++ b/raw/exceptions/2026-04-18-issue-300-same-family-validators.md
@@ -1,0 +1,17 @@
+# Same-Family Implementation Exception: Issue #300
+
+Date: 2026-04-18
+Issue: [#300](https://github.com/NIBARGERB-HLDPRO/hldpro-governance/issues/300)
+Parent epic: [#296](https://github.com/NIBARGERB-HLDPRO/hldpro-governance/issues/296)
+Scope: HITL relay validators and policy gates
+Expires: 2026-04-19T23:23:46Z
+
+## Reason
+
+The operator instructed this session to continue with no HITL. This slice implements deterministic governance validators and tests only. It does not implement AIS transport, MCP runtime behavior, local CLI adapters, or sibling repo changes.
+
+## Controls
+
+- Validator tests cover fail-closed negative controls.
+- Runtime and transport behavior remain out of scope.
+- Parent epic #296 remains open for final E2E proof.

--- a/raw/execution-scopes/2026-04-18-issue-300-hitl-validators-implementation.json
+++ b/raw/execution-scopes/2026-04-18-issue-300-hitl-validators-implementation.json
@@ -1,0 +1,58 @@
+{
+  "expected_execution_root": "{repo_root}",
+  "expected_branch": "issue-300-hitl-validators",
+  "execution_mode": "implementation_ready",
+  "handoff_evidence": {
+    "status": "accepted",
+    "planner_model": "gpt-5.4",
+    "implementer_model": "gpt-5.4",
+    "accepted_at": "2026-04-18T23:23:46Z",
+    "evidence_paths": [
+      "docs/plans/issue-300-structured-agent-cycle-plan.json",
+      "docs/plans/issue-300-hitl-validators-pdcar.md",
+      "raw/exceptions/2026-04-18-issue-300-same-family-validators.md"
+    ],
+    "active_exception_ref": "raw/exceptions/2026-04-18-issue-300-same-family-validators.md",
+    "active_exception_expires_at": "2026-04-19T23:23:46Z"
+  },
+  "allowed_write_paths": [
+    "scripts/packet/validate_hitl_relay.py",
+    "scripts/packet/test_validate_hitl_relay.py",
+    "docs/schemas/hitl-relay-packet.schema.json",
+    "docs/schemas/README.md",
+    "docs/plans/issue-300-structured-agent-cycle-plan.json",
+    "docs/plans/issue-300-hitl-validators-pdcar.md",
+    "raw/exceptions/2026-04-18-issue-300-same-family-validators.md",
+    "raw/execution-scopes/2026-04-18-issue-300-hitl-validators-implementation.json"
+  ],
+  "forbidden_roots": [
+    "/Users/bennibarger/Developer/HLDPRO/hldpro-governance",
+    "/Users/bennibarger/Developer/HLDPRO/local-ai-machine",
+    "/Users/bennibarger/Developer/HLDPRO/ai-integration-services",
+    "/Users/bennibarger/Developer/HLDPRO/knocktracker",
+    "/Users/bennibarger/Developer/HLDPRO/HealthcarePlatform",
+    "/Users/bennibarger/Developer/HLDPRO/ASC-Evaluator"
+  ],
+  "active_parallel_roots": [
+    {
+      "path": "/Users/bennibarger/Developer/HLDPRO/hldpro-governance",
+      "reason": "Shared main checkout contains pre-existing operator/parallel planning files and is not the issue #300 execution root."
+    },
+    {
+      "path": "/Users/bennibarger/Developer/HLDPRO/local-ai-machine",
+      "reason": "Sibling repo has active unrelated runtime work; issue #300 does not edit it."
+    },
+    {
+      "path": "/Users/bennibarger/Developer/HLDPRO/ai-integration-services",
+      "reason": "Sibling repo has active unrelated transport work; issue #300 does not edit it."
+    },
+    {
+      "path": "/Users/bennibarger/Developer/HLDPRO/knocktracker",
+      "reason": "Sibling repo has active unrelated work; issue #300 does not edit it."
+    },
+    {
+      "path": "/Users/bennibarger/Developer/HLDPRO/HealthcarePlatform",
+      "reason": "Sibling repo has active unrelated work; issue #300 does not edit it."
+    }
+  ]
+}

--- a/scripts/packet/test_validate_hitl_relay.py
+++ b/scripts/packet/test_validate_hitl_relay.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import copy
+import json
+import sys
+from pathlib import Path
+
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+from validate_hitl_relay import validate_hitl_packet  # noqa: E402
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+EXAMPLES = REPO_ROOT / "docs" / "schemas" / "examples" / "hitl-relay"
+
+
+def _load(name: str) -> dict:
+    return json.loads((EXAMPLES / "valid" / name).read_text(encoding="utf-8"))
+
+
+def test_valid_examples_pass_policy_validation() -> None:
+    for path in sorted((EXAMPLES / "valid").glob("*.json")):
+        packet = json.loads(path.read_text(encoding="utf-8"))
+        passed, failures = validate_hitl_packet(packet)
+        assert passed, f"{path} failed: {failures}"
+
+
+def test_invalid_examples_fail_policy_validation() -> None:
+    for path in sorted((EXAMPLES / "invalid").glob("*.json")):
+        packet = json.loads(path.read_text(encoding="utf-8"))
+        passed, failures = validate_hitl_packet(packet)
+        assert not passed, f"{path} unexpectedly passed"
+        assert failures
+
+
+def test_session_instruction_requires_matching_target_session() -> None:
+    packet = _load("session-instruction.json")
+    packet["instruction"]["target_session_id"] = "other-session"
+    passed, failures = validate_hitl_packet(packet)
+    assert not passed
+    assert any("target_session_id" in failure for failure in failures)
+
+
+def test_low_confidence_non_clarify_decision_fails_closed() -> None:
+    packet = _load("session-instruction.json")
+    packet["normalized_decision"]["confidence"] = 0.42
+    passed, failures = validate_hitl_packet(packet)
+    assert not passed
+    assert any("low-confidence" in failure for failure in failures)
+
+
+def test_low_confidence_clarify_decision_passes_without_instruction() -> None:
+    packet = copy.deepcopy(_load("session-instruction.json"))
+    packet["packet_type"] = "normalized_decision"
+    packet.pop("instruction")
+    packet["normalized_decision"]["action"] = "clarify"
+    packet["normalized_decision"]["confidence"] = 0.42
+    passed, failures = validate_hitl_packet(packet)
+    assert passed, failures
+
+
+def test_duplicate_reply_cannot_produce_instruction() -> None:
+    packet = _load("session-instruction.json")
+    packet["operator_reply"]["duplicate"] = True
+    passed, failures = validate_hitl_packet(packet)
+    assert not passed
+    assert any("duplicate" in failure for failure in failures)
+
+
+def test_expired_reply_cannot_produce_instruction() -> None:
+    packet = _load("session-instruction.json")
+    packet["operator_reply"]["expired"] = True
+    passed, failures = validate_hitl_packet(packet)
+    assert not passed
+    assert any("expired" in failure for failure in failures)
+
+
+def test_pii_external_channel_fails_closed() -> None:
+    packet = _load("session-instruction.json")
+    packet["policy"]["pii_mode"] = "detected"
+    packet["policy"]["data_classification"] = "pii"
+    packet["operator_reply"]["channel"] = "sms"
+    passed, failures = validate_hitl_packet(packet)
+    assert not passed
+    assert any("external channel" in failure for failure in failures)
+
+
+def test_stale_session_requires_resume_packet() -> None:
+    packet = _load("session-instruction.json")
+    packet["session"]["state"] = "stale"
+    passed, failures = validate_hitl_packet(packet)
+    assert not passed
+    assert any("stale sessions" in failure for failure in failures)
+
+
+def test_response_requires_notification_and_response_ids() -> None:
+    packet = copy.deepcopy(_load("session-instruction.json"))
+    packet["packet_type"] = "hitl_response"
+    packet.pop("normalized_decision")
+    packet.pop("instruction")
+    packet["correlation"].pop("notification_id")
+    passed, failures = validate_hitl_packet(packet)
+    assert not passed
+    assert any("notification_id" in failure for failure in failures)

--- a/scripts/packet/validate_hitl_relay.py
+++ b/scripts/packet/validate_hitl_relay.py
@@ -1,0 +1,212 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+from jsonschema import Draft202012Validator
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCHEMA_PATH = REPO_ROOT / "docs" / "schemas" / "hitl-relay-packet.schema.json"
+SECURITY_POLICY_REF = "docs/runbooks/hitl-relay-security.md"
+
+APPROVAL_ACTIONS = {"approve", "merge_when_green"}
+LOCAL_CHANNELS = {"local_fixture"}
+EXTERNAL_CHANNELS = {"sms", "slack", "email", "other"}
+MIN_CONFIDENCE = 0.80
+
+
+def load_packet(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _schema_validator() -> Draft202012Validator:
+    schema = json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
+    Draft202012Validator.check_schema(schema)
+    return Draft202012Validator(schema)
+
+
+def validate_schema(packet: dict[str, Any]) -> list[str]:
+    errors = sorted(_schema_validator().iter_errors(packet), key=lambda error: list(error.path))
+    return [f"schema: {error.message}" for error in errors]
+
+
+def _packet_type(packet: dict[str, Any]) -> str:
+    return str(packet.get("packet_type", ""))
+
+
+def _correlation(packet: dict[str, Any]) -> dict[str, Any]:
+    value = packet.get("correlation")
+    return value if isinstance(value, dict) else {}
+
+
+def _session(packet: dict[str, Any]) -> dict[str, Any]:
+    value = packet.get("session")
+    return value if isinstance(value, dict) else {}
+
+
+def _policy(packet: dict[str, Any]) -> dict[str, Any]:
+    value = packet.get("policy")
+    return value if isinstance(value, dict) else {}
+
+
+def _operator_reply(packet: dict[str, Any]) -> dict[str, Any]:
+    value = packet.get("operator_reply")
+    return value if isinstance(value, dict) else {}
+
+
+def _decision(packet: dict[str, Any]) -> dict[str, Any]:
+    value = packet.get("normalized_decision")
+    return value if isinstance(value, dict) else {}
+
+
+def _instruction(packet: dict[str, Any]) -> dict[str, Any]:
+    value = packet.get("instruction")
+    return value if isinstance(value, dict) else {}
+
+
+def validate_policy_refs(packet: dict[str, Any]) -> list[str]:
+    policy = _policy(packet)
+    failures: list[str] = []
+    if policy.get("channel_policy_ref") != SECURITY_POLICY_REF:
+        failures.append(f"policy: channel_policy_ref must be {SECURITY_POLICY_REF}")
+    retention = policy.get("retention_policy_ref")
+    if _packet_type(packet) in {"hitl_response", "normalized_decision", "session_instruction", "audit_record"}:
+        if not retention:
+            failures.append("policy: response/instruction/audit packets require retention_policy_ref")
+    return failures
+
+
+def validate_correlation(packet: dict[str, Any]) -> list[str]:
+    packet_type = _packet_type(packet)
+    correlation = _correlation(packet)
+    failures: list[str] = []
+    if packet_type in {"hitl_response", "normalized_decision", "session_instruction", "session_resume", "audit_record"}:
+        for field in ("notification_id", "response_id"):
+            if not correlation.get(field):
+                failures.append(f"correlation: {packet_type} requires {field}")
+    if packet_type in {"session_instruction", "session_resume"} and not correlation.get("parent_packet_id"):
+        failures.append(f"correlation: {packet_type} requires parent_packet_id")
+    return failures
+
+
+def validate_operator_reply(packet: dict[str, Any]) -> list[str]:
+    packet_type = _packet_type(packet)
+    if packet_type not in {"hitl_response", "normalized_decision", "session_instruction"}:
+        return []
+
+    reply = _operator_reply(packet)
+    failures: list[str] = []
+    if reply.get("sender_verified") is not True:
+        failures.append("operator_reply: sender_verified must be true")
+    if not str(reply.get("sender_ref", "")).startswith("operator:"):
+        failures.append("operator_reply: sender_ref must identify an operator")
+    for flag in ("duplicate", "replayed", "expired"):
+        if reply.get(flag) is True:
+            failures.append(f"operator_reply: {flag} replies cannot produce decisions or instructions")
+    return failures
+
+
+def validate_pii_channel_policy(packet: dict[str, Any]) -> list[str]:
+    policy = _policy(packet)
+    reply = _operator_reply(packet)
+    pii_mode = policy.get("pii_mode")
+    classification = policy.get("data_classification")
+    channel = reply.get("channel")
+    if (pii_mode in {"tagged", "detected", "lam_only"} or classification == "pii") and channel in EXTERNAL_CHANNELS:
+        return [f"policy: {pii_mode}/{classification} packets cannot use external channel {channel}"]
+    return []
+
+
+def validate_normalized_decision(packet: dict[str, Any]) -> list[str]:
+    packet_type = _packet_type(packet)
+    if packet_type not in {"normalized_decision", "session_instruction"}:
+        return []
+
+    decision = _decision(packet)
+    action = decision.get("action")
+    confidence = decision.get("confidence")
+    failures: list[str] = []
+    if decision.get("validation_required") is not True:
+        failures.append("normalized_decision: validation_required must be true")
+    if isinstance(confidence, (int, float)) and confidence < MIN_CONFIDENCE and action != "clarify":
+        failures.append("normalized_decision: low-confidence replies must normalize to clarify")
+    if action in APPROVAL_ACTIONS and not _operator_reply(packet):
+        failures.append("normalized_decision: approval actions require operator_reply provenance")
+    return failures
+
+
+def validate_instruction(packet: dict[str, Any]) -> list[str]:
+    if _packet_type(packet) != "session_instruction":
+        return []
+
+    session = _session(packet)
+    decision = _decision(packet)
+    instruction = _instruction(packet)
+    failures: list[str] = []
+    if session.get("state") == "stale":
+        failures.append("instruction: stale sessions require session_resume, not session_instruction")
+    if instruction.get("target_session_id") != session.get("session_id"):
+        failures.append("instruction: target_session_id must match session.session_id")
+    if instruction.get("action") != decision.get("action"):
+        failures.append("instruction: action must match normalized_decision.action")
+    if not instruction.get("audit_refs"):
+        failures.append("instruction: audit_refs are required")
+    return failures
+
+
+def validate_resume(packet: dict[str, Any]) -> list[str]:
+    if _packet_type(packet) != "session_resume":
+        return []
+    session = _session(packet)
+    if session.get("state") not in {"stale", "blocked"}:
+        return ["resume: session_resume requires stale or blocked session state"]
+    return []
+
+
+def validate_hitl_packet(packet: dict[str, Any]) -> tuple[bool, list[str]]:
+    failures: list[str] = []
+    checks = [
+        validate_schema,
+        validate_policy_refs,
+        validate_correlation,
+        validate_operator_reply,
+        validate_pii_channel_policy,
+        validate_normalized_decision,
+        validate_instruction,
+        validate_resume,
+    ]
+    for check in checks:
+        failures.extend(check(packet))
+    return (not failures, failures)
+
+
+def _run_cli(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Validate a HITL relay packet JSON file")
+    parser.add_argument("packet_file")
+    parser.add_argument("--json", action="store_true", help="Emit machine-readable JSON")
+    args = parser.parse_args(argv)
+
+    packet_path = Path(args.packet_file)
+    try:
+        packet = load_packet(packet_path)
+    except Exception as exc:
+        payload = {"status": "refused", "reason": f"failed to read packet: {exc}", "packet_id": None}
+        print(json.dumps(payload) if args.json else f"::error::{payload['reason']}")
+        return 1
+
+    passed, failures = validate_hitl_packet(packet)
+    payload = {
+        "status": "ok" if passed else "refused",
+        "reason": "; ".join(failures) if failures else "ok",
+        "packet_id": packet.get("packet_id"),
+    }
+    print(json.dumps(payload) if args.json else payload["reason"])
+    return 0 if passed else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(_run_cli())


### PR DESCRIPTION
## Summary

Implements the #300 validator and policy gate slice for the SoM HITL relay epic.

## What Changed

- Adds `scripts/packet/validate_hitl_relay.py`, a deterministic validator layered on the #299 schema and #302 policy.
- Adds tests for:
  - valid examples
  - invalid schema examples
  - wrong session target
  - low-confidence non-clarify refusal
  - low-confidence clarify allowance
  - duplicate reply refusal
  - expired reply refusal
  - PII external-channel refusal
  - stale-session instruction refusal
  - missing notification/response correlation
- Extends the schema to allow inbound reply status metadata: `duplicate`, `replayed`, `expired`.
- Documents validator responsibilities in `docs/schemas/README.md`.
- Adds issue-backed plan/PDCAR, exception, and execution scope for #300.

## Validation

- `python3 -m pytest scripts/packet/test_hitl_relay_schema.py scripts/packet/test_validate_hitl_relay.py`
- `python3 scripts/overlord/validate_structured_agent_cycle_plan.py --root . --branch-name issue-300-hitl-validators --require-if-issue-branch --changed-files-file /tmp/issue-300-changed-files.txt --enforce-governance-surface --enforce-planner-boundary-scope`
- `python3 scripts/overlord/assert_execution_scope.py --scope raw/execution-scopes/2026-04-18-issue-300-hitl-validators-implementation.json --changed-files-file /tmp/issue-300-changed-files.txt`
- `tools/local-ci-gate/bin/hldpro-local-ci --changed-files-file /tmp/issue-300-changed-files.txt`

Local CI Gate verdict: PASS.

Closes #300. Parent #296 remains open for queue-first prototype, AIS/LAM runtime work, and final E2E proof.
