### PR TITLE
[codex] Add HITL relay queue prototype

### DIFF
--- a/docs/DATA_DICTIONARY.md
+++ b/docs/DATA_DICTIONARY.md
@@ -107,6 +107,26 @@ Contract:
 
 ---
 
+### HITL Relay Queue
+**Generator:** `scripts/orchestrator/hitl_relay_queue.py`
+**Storage:** `raw/hitl-relay/queue/`
+**Audit log:** `raw/hitl-relay/queue/audit/events.jsonl`
+
+Queue directories:
+| Directory | Description |
+|-----------|-------------|
+| `requests` | Valid local CLI checkpoint HITL request packets |
+| `responses` | Verified local operator response packets |
+| `decisions` | Normalized bounded decision packets |
+| `session-inbox` | Validated session instruction packets addressed to one local CLI session |
+| `session-resume` | Resume packets for stale, blocked, or missing sessions |
+| `dead-letter` | Invalid packets with explicit validation reasons |
+| `audit` | JSONL replay evidence for the request, response, decision, validation, instruction, and resume path |
+
+Every packet emitted by the relay queue is validated with `scripts/packet/validate_hitl_relay.py` before it is written outside `dead-letter`.
+
+---
+
 ### Self-Learning Knowledge Report
 **Generator:** `scripts/orchestrator/self_learning.py`
 **Default storage:** `metrics/self-learning/latest.json` and `metrics/self-learning/latest.md`

--- a/docs/FEATURE_REGISTRY.md
+++ b/docs/FEATURE_REGISTRY.md
@@ -158,6 +158,14 @@
 | GOV-022 | Dispatch scope evidence is fail-closed: when `governance.execution_scope_ref` is present, it must be a JSON artifact under `raw/execution-scopes/`; PDCAR Markdown and other arbitrary files are refused. |
 | GOV-022 | State changes are recorded in `raw/packets/queue/audit.jsonl` with timestamp, source, destination, packet id, SHA-256, dry-run flag, allowed flag, status, and reason so queue movement can be replayed without executing packet payloads. |
 
+### HITL_RELAY_QUEUE
+
+| Feature ID | Notes |
+|---|---|
+| GOV-025 | `scripts/orchestrator/hitl_relay_queue.py` provides the queue-first HITL relay prototype for issue #301, using local request, response, decision, session-inbox, session-resume, dead-letter, and audit directories under `raw/hitl-relay/queue/`. |
+| GOV-025 | The prototype writes packets with temp-file-then-rename semantics and validates every emitted HITL packet through `scripts/packet/validate_hitl_relay.py` before it reaches a session inbox or resume queue. |
+| GOV-025 | Approval, request-changes, clarification, stale-session, duplicate, expired, dead-letter, and replay paths are covered by `scripts/orchestrator/test_hitl_relay_queue.py`; live AIS transport and MCP session control remain separate repo slices. |
+
 ### SELF_LEARNING_LOOP
 
 | Feature ID | Notes |

--- a/docs/plans/issue-301-hitl-queue-prototype-pdcar.md
+++ b/docs/plans/issue-301-hitl-queue-prototype-pdcar.md
@@ -1,0 +1,52 @@
+# PDCAR: Queue-First HITL Relay Prototype
+
+Date: 2026-04-18
+Repo: `hldpro-governance`
+Branch: `issue-301-hitl-queue-prototype`
+Issue: [#301](https://github.com/NIBARGERB-HLDPRO/hldpro-governance/issues/301)
+Parent epic: [#296](https://github.com/NIBARGERB-HLDPRO/hldpro-governance/issues/296)
+Status: IMPLEMENTATION_READY
+Canonical plan: `docs/plans/issue-301-structured-agent-cycle-plan.json`
+
+## Problem
+
+The HITL relay has packet contracts, policy, and validators, but downstream AIS/MCP/session-adapter work needs a local queue-first proof that request, response, decision, instruction, resume, dead-letter, and audit behavior is enforceable before live messaging or terminal control exists.
+
+## Plan
+
+Add a governance-owned local queue prototype under `scripts/orchestrator/` that builds HITL request packets from local CLI checkpoint fixtures, processes verified local response fixtures, emits bounded session instructions or resume packets, and dead-letters invalid paths with explicit validation errors.
+
+## Do
+
+- Add `scripts/orchestrator/hitl_relay_queue.py`.
+- Add focused queue tests for approval, request-changes, ambiguity, stale session, invalid duplicate/expired responses, and replay.
+- Document the queue surface in schema, feature registry, and data dictionary docs.
+- Record cross-review and same-family/no-HITL exception evidence.
+
+## Check
+
+- `python3 -m pytest scripts/orchestrator/test_hitl_relay_queue.py scripts/packet/test_validate_hitl_relay.py`
+- Structured-plan governance gate.
+- Planner-boundary execution-scope gate.
+- Local CI Gate.
+
+## Act
+
+Downstream AIS/MCP/local CLI adapter slices must consume this queue contract instead of bypassing validation or writing directly to session control surfaces.
+
+## Review
+
+Subagent cross-review accepted the placement and reuse of existing queue patterns with follow-up boundaries for transport/runtime work. Same-family/no-HITL exception is recorded for this deterministic implementation slice.
+
+## Acceptance Criteria
+
+- [ ] A local CLI checkpoint fixture creates a valid HITL request packet.
+- [ ] A valid local approval response fixture produces a bounded session instruction packet.
+- [ ] A request-changes response fixture preserves feedback without treating it as approval.
+- [ ] An ambiguous response fixture produces a clarification request and no instruction packet.
+- [ ] A stale-session fixture produces a resume packet instead of targeting another session.
+- [ ] Queue transitions are auditable and replayable.
+- [ ] Invalid packets land in dead-letter or fail with explicit validation errors.
+- [ ] Dry-run queue tests cover approval, request-changes, ambiguity, stale session, and dead-letter behavior.
+- [ ] Replay test reconstructs the decision path from request, response, normalized decision, validation, and instruction evidence.
+- [ ] Local CI Gate passes.

--- a/docs/plans/issue-301-structured-agent-cycle-plan.json
+++ b/docs/plans/issue-301-structured-agent-cycle-plan.json
@@ -1,0 +1,103 @@
+{
+  "session_id": "session-20260418-issue-301-hitl-queue-prototype",
+  "issue_number": 301,
+  "objective": "Implement the queue-first local HITL relay prototype so finished-work and checkpoint packets can be validated, transformed, audited, and routed locally before AIS transport or MCP session control slices consume the contract.",
+  "tier": 1,
+  "scope_boundary": [
+    "Add a governance-owned local HITL relay queue prototype under scripts/orchestrator.",
+    "Use dedicated local queue directories for requests, responses, decisions, session inbox, session resume, dead-letter, and audit records.",
+    "Validate emitted HITL relay packets with scripts/packet/validate_hitl_relay.py.",
+    "Add focused tests for approval, request-changes, ambiguity, stale session, dead-letter, and replay behavior.",
+    "Keep this slice inside hldpro-governance."
+  ],
+  "out_of_scope": [
+    "Implementing AIS SMS, Slack, email, or webhook transport.",
+    "Implementing MCP runtime orchestration or live local terminal/session control.",
+    "Changing sibling repositories.",
+    "Closing parent epic #296.",
+    "Running final cross-repo E2E proof."
+  ],
+  "research_summary": "Issue #299 added HITL relay packet contracts, issue #302 added security/data-handling policy, and issue #300 added deterministic validation. Issue #301 now proves the local queue path that downstream AIS, MCP, and CLI adapter slices must consume.",
+  "research_artifacts": [
+    "GitHub issue #296",
+    "GitHub issue #301",
+    "docs/schemas/hitl-relay-packet.schema.json",
+    "docs/runbooks/hitl-relay-security.md",
+    "scripts/packet/validate_hitl_relay.py",
+    "scripts/orchestrator/packet_queue.py",
+    "raw/cross-review/2026-04-18-issue-301-hitl-queue-prototype.md"
+  ],
+  "sprints": [
+    {
+      "name": "Queue-First Relay Prototype",
+      "goal": "Add deterministic local queue behavior for HITL request, response, decision, instruction, resume, dead-letter, and audit paths.",
+      "tasks": [
+        "Create scripts/orchestrator/hitl_relay_queue.py.",
+        "Add tests for request creation, approval instruction, request-changes instruction, clarification, stale-session resume, invalid dead-letter, and audit replay.",
+        "Document the queue surface in docs/schemas/README.md, docs/FEATURE_REGISTRY.md, and docs/DATA_DICTIONARY.md.",
+        "Record issue-backed PDCAR, execution scope, exception, and cross-review evidence."
+      ],
+      "acceptance_criteria": [
+        "A local CLI checkpoint fixture creates a valid HITL request packet.",
+        "A valid local approval response fixture produces a bounded session instruction packet.",
+        "A request-changes response fixture preserves feedback without treating it as approval.",
+        "An ambiguous response fixture produces a clarification request and no instruction packet.",
+        "A stale-session fixture produces a resume packet instead of targeting another session.",
+        "Invalid packets land in dead-letter with explicit validation errors.",
+        "Replay reconstructs request, response, normalized decision, validation, and instruction evidence."
+      ],
+      "file_paths": [
+        "scripts/orchestrator/hitl_relay_queue.py",
+        "scripts/orchestrator/test_hitl_relay_queue.py",
+        "docs/schemas/README.md",
+        "docs/FEATURE_REGISTRY.md",
+        "docs/DATA_DICTIONARY.md",
+        "docs/plans/issue-301-structured-agent-cycle-plan.json",
+        "docs/plans/issue-301-hitl-queue-prototype-pdcar.md",
+        "raw/cross-review/2026-04-18-issue-301-hitl-queue-prototype.md",
+        "raw/exceptions/2026-04-18-issue-301-same-family-queue-prototype.md",
+        "raw/execution-scopes/2026-04-18-issue-301-hitl-queue-prototype-implementation.json"
+      ]
+    }
+  ],
+  "specialist_reviews": [
+    {
+      "reviewer": "Dewey subagent",
+      "role": "queue-pattern reviewer",
+      "focus": "Existing queue atomic write and audit patterns, placement of the HITL queue prototype, and governance artifact requirements.",
+      "status": "accepted_with_followup",
+      "summary": "The prototype should live under scripts/orchestrator, reuse temp-file-then-rename and replayable JSONL audit patterns, and keep AIS/MCP/session runtime work out of scope.",
+      "evidence": [
+        "raw/cross-review/2026-04-18-issue-301-hitl-queue-prototype.md"
+      ]
+    }
+  ],
+  "alternate_model_review": {
+    "required": true,
+    "reviewer": "same-family-implementation-fallback",
+    "model_family": "openai",
+    "status": "accepted_with_followup",
+    "summary": "True alternate-family review is not available in this no-HITL Codex lane. This slice is deterministic local queue work with focused tests and a same-family exception recorded.",
+    "evidence": [
+      "raw/exceptions/2026-04-18-issue-301-same-family-queue-prototype.md"
+    ]
+  },
+  "execution_handoff": {
+    "session_agent": "Codex",
+    "execution_mode": "implementation_ready",
+    "approved_scope_summary": "Issue #301 may add local HITL queue prototype code/tests, update queue/schema registry documentation, and add planning/scope artifacts. It may not implement live transport, MCP runtime behavior, local terminal/session adapters, or sibling repo changes.",
+    "next_execution_step": "Validate tests, publish PR, and keep parent #296 open for transport, runtime, adapter, and final E2E slices.",
+    "blocked_on": []
+  },
+  "material_deviation_rules": [
+    "Implementing AIS or MCP runtime behavior in this queue slice is a material deviation.",
+    "Writing directly to live terminal/session control surfaces is a material deviation.",
+    "Allowing unvalidated HITL packets into session-inbox or session-resume is a material deviation.",
+    "Editing sibling repos from this branch is a material deviation."
+  ],
+  "approved": true,
+  "approved_by": [
+    "operator no-HITL instruction 2026-04-18"
+  ],
+  "approved_at": "2026-04-18T23:33:18Z"
+}

--- a/docs/schemas/README.md
+++ b/docs/schemas/README.md
@@ -50,6 +50,8 @@ The deterministic policy validator lives at `scripts/packet/validate_hitl_relay.
 - stale sessions require resume packets instead of session instructions;
 - instruction targets must match the exact local session ID.
 
+The queue-first local prototype lives at `scripts/orchestrator/hitl_relay_queue.py`. It consumes local request/response fixtures, emits validated HITL relay packets into dedicated queue directories under `raw/hitl-relay/queue/`, and records replayable JSONL audit evidence. This prototype deliberately stops at local queues; AIS transport, MCP orchestration, and terminal/session adapters are owned by downstream repository slices.
+
 ## Validator
 
 **File:** `scripts/packet/validate.py`

--- a/raw/cross-review/2026-04-18-issue-301-hitl-queue-prototype.md
+++ b/raw/cross-review/2026-04-18-issue-301-hitl-queue-prototype.md
@@ -1,0 +1,24 @@
+# Cross-Review: Issue #301 Queue-First HITL Relay Prototype
+
+Date: 2026-04-18
+Issue: [#301](https://github.com/NIBARGERB-HLDPRO/hldpro-governance/issues/301)
+Parent epic: [#296](https://github.com/NIBARGERB-HLDPRO/hldpro-governance/issues/296)
+Reviewer: Dewey subagent
+Status: ACCEPTED_WITH_FOLLOWUP
+
+## Findings
+
+- Reuse `scripts/orchestrator/packet_queue.py` patterns for temp-file-then-rename writes and replayable JSONL audit events.
+- Place the local HITL queue prototype under `scripts/orchestrator/`, next to the existing queue orchestrator.
+- Keep runtime daemon, AIS transport, and local CLI control out of this repo slice.
+- Add issue-backed governance artifacts for #301: structured plan, PDCAR, execution scope, and same-family/no-HITL exception evidence.
+
+## Implementation Response
+
+The #301 implementation adds `scripts/orchestrator/hitl_relay_queue.py` and focused tests under `scripts/orchestrator/test_hitl_relay_queue.py`. The queue writes local HITL request, response, normalized decision, session instruction, session resume, dead-letter, and audit artifacts under `raw/hitl-relay/queue/` using atomic JSON writes. It validates every emitted packet with `scripts/packet/validate_hitl_relay.py`.
+
+## Follow-Up Boundaries
+
+- AIS bridge transport remains tracked by `NIBARGERB-HLDPRO/ai-integration-services#1144`.
+- MCP orchestrator and local CLI adapter work remain tracked by `NIBARGERB-HLDPRO/local-ai-machine#462` and `#463`.
+- Final cross-repo E2E proof remains tracked by #303.

--- a/raw/exceptions/2026-04-18-issue-301-same-family-queue-prototype.md
+++ b/raw/exceptions/2026-04-18-issue-301-same-family-queue-prototype.md
@@ -1,0 +1,18 @@
+# Same-Family Implementation Exception: Issue #301
+
+Date: 2026-04-18
+Issue: [#301](https://github.com/NIBARGERB-HLDPRO/hldpro-governance/issues/301)
+Parent epic: [#296](https://github.com/NIBARGERB-HLDPRO/hldpro-governance/issues/296)
+Scope: Queue-first HITL relay prototype
+Expires: 2026-04-19T23:33:18Z
+
+## Reason
+
+The operator instructed this session to continue with no HITL. This slice implements a deterministic local queue prototype and tests only. It does not implement AIS transport, MCP runtime behavior, live SMS/Slack parsing, or local terminal/session control.
+
+## Controls
+
+- A subagent cross-review checked the intended placement and patterns before implementation.
+- The prototype validates every emitted HITL packet through the deterministic #300 validator.
+- Tests cover approval, request-changes, clarification, stale-session resume, duplicate/expired dead-letter, and audit replay paths.
+- Parent epic #296 remains open for downstream runtime and final E2E proof.

--- a/raw/execution-scopes/2026-04-18-issue-301-hitl-queue-prototype-implementation.json
+++ b/raw/execution-scopes/2026-04-18-issue-301-hitl-queue-prototype-implementation.json
@@ -1,0 +1,61 @@
+{
+  "expected_execution_root": "{repo_root}",
+  "expected_branch": "issue-301-hitl-queue-prototype",
+  "execution_mode": "implementation_ready",
+  "handoff_evidence": {
+    "status": "accepted",
+    "planner_model": "gpt-5.4",
+    "implementer_model": "gpt-5.4",
+    "accepted_at": "2026-04-18T23:33:18Z",
+    "evidence_paths": [
+      "docs/plans/issue-301-structured-agent-cycle-plan.json",
+      "docs/plans/issue-301-hitl-queue-prototype-pdcar.md",
+      "raw/cross-review/2026-04-18-issue-301-hitl-queue-prototype.md",
+      "raw/exceptions/2026-04-18-issue-301-same-family-queue-prototype.md"
+    ],
+    "active_exception_ref": "raw/exceptions/2026-04-18-issue-301-same-family-queue-prototype.md",
+    "active_exception_expires_at": "2026-04-19T23:33:18Z"
+  },
+  "allowed_write_paths": [
+    "scripts/orchestrator/hitl_relay_queue.py",
+    "scripts/orchestrator/test_hitl_relay_queue.py",
+    "docs/schemas/README.md",
+    "docs/FEATURE_REGISTRY.md",
+    "docs/DATA_DICTIONARY.md",
+    "docs/plans/issue-301-structured-agent-cycle-plan.json",
+    "docs/plans/issue-301-hitl-queue-prototype-pdcar.md",
+    "raw/cross-review/2026-04-18-issue-301-hitl-queue-prototype.md",
+    "raw/exceptions/2026-04-18-issue-301-same-family-queue-prototype.md",
+    "raw/execution-scopes/2026-04-18-issue-301-hitl-queue-prototype-implementation.json"
+  ],
+  "forbidden_roots": [
+    "/Users/bennibarger/Developer/HLDPRO/hldpro-governance",
+    "/Users/bennibarger/Developer/HLDPRO/local-ai-machine",
+    "/Users/bennibarger/Developer/HLDPRO/ai-integration-services",
+    "/Users/bennibarger/Developer/HLDPRO/knocktracker",
+    "/Users/bennibarger/Developer/HLDPRO/HealthcarePlatform",
+    "/Users/bennibarger/Developer/HLDPRO/ASC-Evaluator"
+  ],
+  "active_parallel_roots": [
+    {
+      "path": "/Users/bennibarger/Developer/HLDPRO/hldpro-governance",
+      "reason": "Shared main checkout may contain operator or parallel work and is not the issue #301 execution root."
+    },
+    {
+      "path": "/Users/bennibarger/Developer/HLDPRO/local-ai-machine",
+      "reason": "Sibling repo owns MCP/session runtime work and is not edited by this slice."
+    },
+    {
+      "path": "/Users/bennibarger/Developer/HLDPRO/ai-integration-services",
+      "reason": "Sibling repo owns AIS transport work and is not edited by this slice."
+    },
+    {
+      "path": "/Users/bennibarger/Developer/HLDPRO/knocktracker",
+      "reason": "Sibling repo has unrelated work and is not edited by this slice."
+    },
+    {
+      "path": "/Users/bennibarger/Developer/HLDPRO/HealthcarePlatform",
+      "reason": "Sibling repo has unrelated work and is not edited by this slice."
+    }
+  ]
+}

--- a/scripts/orchestrator/hitl_relay_queue.py
+++ b/scripts/orchestrator/hitl_relay_queue.py
@@ -1,0 +1,444 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import uuid
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "packet"))
+
+from validate_hitl_relay import validate_hitl_packet  # noqa: E402
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_QUEUE_ROOT = REPO_ROOT / "raw" / "hitl-relay" / "queue"
+SECURITY_POLICY_REF = "docs/runbooks/hitl-relay-security.md"
+RETENTION_POLICY_REF = "docs/runbooks/hitl-relay-security.md#retention"
+MODEL_ID = "gpt-5.4"
+MODEL_FAMILY = "openai"
+APPROVAL_ACTIONS = {"approve", "merge_when_green"}
+INSTRUCTION_ACTIONS = {"approve", "merge_when_green", "request_changes", "pause", "details", "create_followup_issue"}
+QUEUE_DIRS = (
+    "requests",
+    "responses",
+    "decisions",
+    "session-inbox",
+    "session-resume",
+    "dead-letter",
+    "audit",
+)
+
+
+@dataclass(frozen=True)
+class QueueResult:
+    status: str
+    action: str
+    packet_path: Path | None
+    reason: str
+    packet_id: str | None = None
+
+
+def utc_now() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def ensure_queue(root: Path = DEFAULT_QUEUE_ROOT) -> None:
+    for name in QUEUE_DIRS:
+        (root / name).mkdir(parents=True, exist_ok=True)
+
+
+def packet_uuid(*parts: Any) -> str:
+    return str(uuid.uuid5(uuid.NAMESPACE_URL, "|".join(str(part) for part in parts)))
+
+
+def atomic_write_json(payload: dict[str, Any], destination: Path) -> Path:
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    tmp_path = destination.with_name(f".{destination.name}.{datetime.now(timezone.utc).timestamp()}.tmp")
+    tmp_path.write_text(json.dumps(payload, indent=2, sort_keys=False) + "\n", encoding="utf-8")
+    tmp_path.replace(destination)
+    return destination
+
+
+def append_audit(root: Path, event: dict[str, Any]) -> None:
+    audit_dir = root / "audit"
+    audit_dir.mkdir(parents=True, exist_ok=True)
+    with (audit_dir / "events.jsonl").open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps({"timestamp": utc_now(), **event}, sort_keys=True) + "\n")
+
+
+def load_packet(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"packet must be a JSON object: {path}")
+    return payload
+
+
+def _base_packet(
+    *,
+    packet_type: str,
+    issue_number: int,
+    session: dict[str, Any],
+    correlation: dict[str, Any],
+    policy: dict[str, Any] | None = None,
+    packet_id: str | None = None,
+) -> dict[str, Any]:
+    return {
+        "schema_version": 1,
+        "packet_id": packet_id or packet_uuid(packet_type, correlation.get("request_id"), correlation.get("response_id", "")),
+        "packet_type": packet_type,
+        "created_at": utc_now(),
+        "issue_number": issue_number,
+        "repo": {"owner": "NIBARGERB-HLDPRO", "name": "hldpro-governance"},
+        "session": session,
+        "correlation": correlation,
+        "policy": policy
+        or {
+            "pii_mode": "none",
+            "data_classification": "internal",
+            "channel_policy_ref": SECURITY_POLICY_REF,
+        },
+    }
+
+
+def build_request(
+    *,
+    issue_number: int,
+    session_id: str,
+    cli: str,
+    request_id: str,
+    event_type: str,
+    artifacts: list[dict[str, str]],
+    allowed_actions: list[str],
+    prompt_ref: str,
+    pii_mode: str = "none",
+    data_classification: str = "internal",
+) -> dict[str, Any]:
+    packet = _base_packet(
+        packet_type="hitl_request",
+        issue_number=issue_number,
+        session={"session_id": session_id, "cli": cli, "state": "waiting_hitl"},
+        correlation={"request_id": request_id},
+        policy={
+            "pii_mode": pii_mode,
+            "data_classification": data_classification,
+            "channel_policy_ref": SECURITY_POLICY_REF,
+        },
+        packet_id=packet_uuid("hitl_request", issue_number, session_id, request_id),
+    )
+    packet.update(
+        {
+            "event_type": event_type,
+            "artifacts": artifacts,
+            "requested_decision": {
+                "decision_type": "approval" if any(action in APPROVAL_ACTIONS for action in allowed_actions) else "feedback",
+                "allowed_actions": allowed_actions,
+                "prompt_ref": prompt_ref,
+            },
+        }
+    )
+    return packet
+
+
+def enqueue_request(packet: dict[str, Any], *, queue_root: Path = DEFAULT_QUEUE_ROOT) -> QueueResult:
+    ensure_queue(queue_root)
+    return _validated_write(packet, queue_root / "requests" / f"{packet.get('packet_id', 'unknown')}.json", queue_root)
+
+
+def process_response(
+    request_packet: dict[str, Any],
+    *,
+    response_id: str,
+    notification_id: str,
+    action: str,
+    confidence: float,
+    raw_message_ref: str,
+    sender_ref: str = "operator:ben",
+    message_id: str = "local-message-001",
+    channel: str = "local_fixture",
+    session_state: str = "waiting_hitl",
+    duplicate: bool = False,
+    replayed: bool = False,
+    expired: bool = False,
+    queue_root: Path = DEFAULT_QUEUE_ROOT,
+) -> QueueResult:
+    ensure_queue(queue_root)
+    response_packet = _build_response_packet(
+        request_packet,
+        response_id=response_id,
+        notification_id=notification_id,
+        sender_ref=sender_ref,
+        message_id=message_id,
+        raw_message_ref=raw_message_ref,
+        channel=channel,
+        session_state=session_state,
+        duplicate=duplicate,
+        replayed=replayed,
+        expired=expired,
+    )
+    response_result = _validated_write(
+        response_packet,
+        queue_root / "responses" / f"{response_packet['packet_id']}.json",
+        queue_root,
+    )
+    if response_result.status != "ok":
+        return response_result
+
+    decision_packet = _build_decision_packet(response_packet, action=action, confidence=confidence)
+    decision_result = _validated_write(
+        decision_packet,
+        queue_root / "decisions" / f"{decision_packet['packet_id']}.json",
+        queue_root,
+    )
+    if decision_result.status != "ok":
+        return decision_result
+
+    if action == "clarify" or confidence < 0.80:
+        append_audit(
+            queue_root,
+            {
+                "event": "clarification_requested",
+                "request_id": response_packet["correlation"]["request_id"],
+                "response_id": response_id,
+                "decision_packet_id": decision_packet["packet_id"],
+                "reason": "ambiguous_or_low_confidence",
+            },
+        )
+        return QueueResult("clarify", "clarify", decision_result.packet_path, "clarification requested", decision_packet["packet_id"])
+
+    if session_state == "stale":
+        resume_packet = _build_resume_packet(decision_packet)
+        resume_result = _validated_write(
+            resume_packet,
+            queue_root / "session-resume" / f"{resume_packet['packet_id']}.json",
+            queue_root,
+        )
+        return QueueResult(resume_result.status, "resume_session", resume_result.packet_path, resume_result.reason, resume_packet["packet_id"])
+
+    if action not in INSTRUCTION_ACTIONS:
+        return _dead_letter(
+            decision_packet,
+            queue_root,
+            f"unsupported normalized action for queue instruction: {action}",
+        )
+
+    instruction_packet = _build_instruction_packet(decision_packet)
+    instruction_result = _validated_write(
+        instruction_packet,
+        queue_root / "session-inbox" / f"{instruction_packet['packet_id']}.json",
+        queue_root,
+    )
+    return QueueResult(
+        instruction_result.status,
+        action,
+        instruction_result.packet_path,
+        instruction_result.reason,
+        instruction_packet["packet_id"],
+    )
+
+
+def _build_response_packet(
+    request_packet: dict[str, Any],
+    *,
+    response_id: str,
+    notification_id: str,
+    sender_ref: str,
+    message_id: str,
+    raw_message_ref: str,
+    channel: str,
+    session_state: str,
+    duplicate: bool,
+    replayed: bool,
+    expired: bool,
+) -> dict[str, Any]:
+    session = dict(request_packet["session"])
+    session["state"] = session_state
+    policy = dict(request_packet["policy"])
+    policy["retention_policy_ref"] = RETENTION_POLICY_REF
+    correlation = {
+        "request_id": request_packet["correlation"]["request_id"],
+        "parent_packet_id": request_packet["packet_id"],
+        "notification_id": notification_id,
+        "response_id": response_id,
+    }
+    packet = _base_packet(
+        packet_type="hitl_response",
+        issue_number=int(request_packet["issue_number"]),
+        session=session,
+        correlation=correlation,
+        policy=policy,
+        packet_id=packet_uuid("hitl_response", request_packet["packet_id"], response_id),
+    )
+    reply: dict[str, Any] = {
+        "channel": channel,
+        "sender_ref": sender_ref,
+        "message_id": message_id,
+        "received_at": utc_now(),
+        "raw_message_ref": raw_message_ref,
+        "sender_verified": True,
+    }
+    for flag, enabled in (("duplicate", duplicate), ("replayed", replayed), ("expired", expired)):
+        if enabled:
+            reply[flag] = True
+    packet["operator_reply"] = reply
+    return packet
+
+
+def _build_decision_packet(response_packet: dict[str, Any], *, action: str, confidence: float) -> dict[str, Any]:
+    packet = dict(response_packet)
+    packet["packet_type"] = "normalized_decision"
+    packet["packet_id"] = packet_uuid("normalized_decision", response_packet["packet_id"], action, confidence)
+    packet["created_at"] = utc_now()
+    packet["normalized_decision"] = {
+        "action": action,
+        "confidence": confidence,
+        "model_id": MODEL_ID,
+        "model_family": MODEL_FAMILY,
+        "raw_message_ref": response_packet["operator_reply"]["raw_message_ref"],
+        "validation_required": True,
+    }
+    return packet
+
+
+def _build_instruction_packet(decision_packet: dict[str, Any]) -> dict[str, Any]:
+    packet = dict(decision_packet)
+    action = packet["normalized_decision"]["action"]
+    packet["packet_type"] = "session_instruction"
+    packet["packet_id"] = packet_uuid("session_instruction", decision_packet["packet_id"], action)
+    packet["created_at"] = utc_now()
+    packet["instruction"] = {
+        "action": action,
+        "target_session_id": packet["session"]["session_id"],
+        "constraints": ["require_governance_validation", "require_audit_replay"],
+        "audit_refs": [
+            f"raw/hitl-relay/queue/requests/{packet['correlation']['parent_packet_id']}.json",
+            packet["operator_reply"]["raw_message_ref"],
+            "raw/hitl-relay/queue/audit/events.jsonl",
+        ],
+    }
+    return packet
+
+
+def _build_resume_packet(decision_packet: dict[str, Any]) -> dict[str, Any]:
+    packet = {
+        key: value
+        for key, value in decision_packet.items()
+        if key not in {"operator_reply", "normalized_decision"}
+    }
+    packet["packet_type"] = "session_resume"
+    packet["packet_id"] = packet_uuid("session_resume", decision_packet["packet_id"])
+    packet["created_at"] = utc_now()
+    packet["resume"] = {
+        "reason": "session_stale",
+        "resume_context_refs": [
+            f"raw/hitl-relay/queue/requests/{packet['correlation']['parent_packet_id']}.json",
+            decision_packet["operator_reply"]["raw_message_ref"],
+            "raw/hitl-relay/queue/audit/events.jsonl",
+        ],
+    }
+    return packet
+
+
+def _validated_write(packet: dict[str, Any], destination: Path, queue_root: Path) -> QueueResult:
+    passed, failures = validate_hitl_packet(packet)
+    if not passed:
+        return _dead_letter(packet, queue_root, "; ".join(failures))
+    atomic_write_json(packet, destination)
+    append_audit(
+        queue_root,
+        {
+            "event": "packet_written",
+            "packet_id": packet["packet_id"],
+            "packet_type": packet["packet_type"],
+            "path": str(destination),
+            "request_id": packet["correlation"]["request_id"],
+            "response_id": packet["correlation"].get("response_id"),
+            "session_id": packet["session"]["session_id"],
+        },
+    )
+    return QueueResult("ok", packet["packet_type"], destination, "validated and written", packet["packet_id"])
+
+
+def _dead_letter(packet: dict[str, Any], queue_root: Path, reason: str) -> QueueResult:
+    dead_id = str(packet.get("packet_id") or packet_uuid("dead-letter", reason, utc_now()))
+    destination = queue_root / "dead-letter" / f"{dead_id}.json"
+    atomic_write_json({"reason": reason, "packet": packet}, destination)
+    append_audit(
+        queue_root,
+        {
+            "event": "dead_letter",
+            "packet_id": packet.get("packet_id"),
+            "packet_type": packet.get("packet_type"),
+            "path": str(destination),
+            "request_id": (packet.get("correlation") or {}).get("request_id"),
+            "reason": reason,
+        },
+    )
+    return QueueResult("dead_letter", str(packet.get("packet_type") or "unknown"), destination, reason, packet.get("packet_id"))
+
+
+def replay_audit(audit_path: Path) -> dict[str, Any]:
+    events = []
+    for line in audit_path.read_text(encoding="utf-8").splitlines():
+        if line.strip():
+            events.append(json.loads(line))
+    decision_trace = [event["event"] for event in events]
+    return {
+        "events": len(events),
+        "dead_letters": sum(1 for event in events if event.get("event") == "dead_letter"),
+        "request_ids": sorted({str(event["request_id"]) for event in events if event.get("request_id")}),
+        "session_ids": sorted({str(event["session_id"]) for event in events if event.get("session_id")}),
+        "packet_types": [event["packet_type"] for event in events if event.get("event") == "packet_written"],
+        "decision_trace": decision_trace,
+    }
+
+
+def _run_cli(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Run local HITL relay queue operations")
+    parser.add_argument("--queue-root", type=Path, default=DEFAULT_QUEUE_ROOT)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    enqueue = subparsers.add_parser("enqueue-request")
+    enqueue.add_argument("request_json", type=Path)
+
+    process = subparsers.add_parser("process-response")
+    process.add_argument("request_json", type=Path)
+    process.add_argument("--response-id", required=True)
+    process.add_argument("--notification-id", required=True)
+    process.add_argument("--action", required=True)
+    process.add_argument("--confidence", type=float, required=True)
+    process.add_argument("--raw-message-ref", required=True)
+    process.add_argument("--session-state", default="waiting_hitl")
+
+    replay = subparsers.add_parser("replay")
+    replay.add_argument("--audit", type=Path)
+
+    args = parser.parse_args(argv)
+    if args.command == "enqueue-request":
+        result = enqueue_request(load_packet(args.request_json), queue_root=args.queue_root)
+    elif args.command == "process-response":
+        result = process_response(
+            load_packet(args.request_json),
+            response_id=args.response_id,
+            notification_id=args.notification_id,
+            action=args.action,
+            confidence=args.confidence,
+            raw_message_ref=args.raw_message_ref,
+            session_state=args.session_state,
+            queue_root=args.queue_root,
+        )
+    else:
+        audit_path = args.audit or args.queue_root / "audit" / "events.jsonl"
+        print(json.dumps(replay_audit(audit_path), sort_keys=True))
+        return 0
+
+    print(json.dumps(result.__dict__, default=str, sort_keys=True))
+    return 0 if result.status in {"ok", "clarify"} else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(_run_cli())

--- a/scripts/orchestrator/test_hitl_relay_queue.py
+++ b/scripts/orchestrator/test_hitl_relay_queue.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import sys
+import tempfile
+from pathlib import Path
+
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+import hitl_relay_queue  # noqa: E402
+
+
+def _request() -> dict:
+    return hitl_relay_queue.build_request(
+        issue_number=301,
+        session_id="codex-20260418-issue-301",
+        cli="codex",
+        request_id="hitl-20260418-301",
+        event_type="hitl_checkpoint",
+        artifacts=[
+            {"kind": "plan", "ref": "docs/plans/issue-301-structured-agent-cycle-plan.json"},
+            {
+                "kind": "execution_scope",
+                "ref": "raw/execution-scopes/2026-04-18-issue-301-hitl-queue-prototype-implementation.json",
+            },
+        ],
+        allowed_actions=["merge_when_green", "request_changes", "pause", "details"],
+        prompt_ref="raw/hitl-relay/queue/requests/hitl-20260418-301.md",
+    )
+
+
+def _process(
+    queue_root: Path,
+    request: dict,
+    *,
+    action: str,
+    confidence: float = 0.98,
+    response_id: str = "local-response-301",
+    session_state: str = "waiting_hitl",
+    duplicate: bool = False,
+    expired: bool = False,
+) -> hitl_relay_queue.QueueResult:
+    return hitl_relay_queue.process_response(
+        request,
+        response_id=response_id,
+        notification_id="local-notification-301",
+        action=action,
+        confidence=confidence,
+        raw_message_ref=f"raw/hitl-relay/queue/responses/{response_id}.json",
+        session_state=session_state,
+        duplicate=duplicate,
+        expired=expired,
+        queue_root=queue_root,
+    )
+
+
+def test_local_cli_checkpoint_fixture_creates_valid_hitl_request() -> None:
+    with tempfile.TemporaryDirectory() as raw:
+        queue_root = Path(raw)
+        result = hitl_relay_queue.enqueue_request(_request(), queue_root=queue_root)
+
+        assert result.status == "ok", result.reason
+        assert result.packet_path is not None
+        assert result.packet_path.parent.name == "requests"
+        packet = json.loads(result.packet_path.read_text(encoding="utf-8"))
+        assert packet["packet_type"] == "hitl_request"
+        assert packet["session"]["state"] == "waiting_hitl"
+
+
+def test_valid_approval_response_produces_bounded_session_instruction() -> None:
+    with tempfile.TemporaryDirectory() as raw:
+        queue_root = Path(raw)
+        request = _request()
+        hitl_relay_queue.enqueue_request(request, queue_root=queue_root)
+
+        result = _process(queue_root, request, action="merge_when_green")
+
+        assert result.status == "ok", result.reason
+        assert result.packet_path is not None
+        assert result.packet_path.parent.name == "session-inbox"
+        instruction = json.loads(result.packet_path.read_text(encoding="utf-8"))
+        assert instruction["packet_type"] == "session_instruction"
+        assert instruction["instruction"]["action"] == "merge_when_green"
+        assert instruction["instruction"]["target_session_id"] == request["session"]["session_id"]
+        assert instruction["correlation"]["request_id"] == request["correlation"]["request_id"]
+        assert instruction["correlation"]["notification_id"] == "local-notification-301"
+        assert instruction["correlation"]["response_id"] == "local-response-301"
+
+
+def test_request_changes_response_preserves_feedback_path_without_approval() -> None:
+    with tempfile.TemporaryDirectory() as raw:
+        queue_root = Path(raw)
+        request = _request()
+
+        result = _process(queue_root, request, action="request_changes", response_id="local-response-changes")
+
+        assert result.status == "ok", result.reason
+        assert result.packet_path is not None
+        packet = json.loads(result.packet_path.read_text(encoding="utf-8"))
+        assert packet["instruction"]["action"] == "request_changes"
+        assert packet["normalized_decision"]["action"] != "merge_when_green"
+        assert packet["operator_reply"]["raw_message_ref"].endswith("local-response-changes.json")
+
+
+def test_ambiguous_response_produces_clarification_and_no_instruction() -> None:
+    with tempfile.TemporaryDirectory() as raw:
+        queue_root = Path(raw)
+        request = _request()
+
+        result = _process(queue_root, request, action="clarify", confidence=0.42)
+
+        assert result.status == "clarify", result.reason
+        assert not any((queue_root / "session-inbox").glob("*.json"))
+        assert any((queue_root / "decisions").glob("*.json"))
+        replay = hitl_relay_queue.replay_audit(queue_root / "audit" / "events.jsonl")
+        assert "clarification_requested" in replay["decision_trace"]
+
+
+def test_stale_session_fixture_produces_resume_packet() -> None:
+    with tempfile.TemporaryDirectory() as raw:
+        queue_root = Path(raw)
+        request = _request()
+
+        result = _process(queue_root, request, action="merge_when_green", session_state="stale")
+
+        assert result.status == "ok", result.reason
+        assert result.packet_path is not None
+        assert result.packet_path.parent.name == "session-resume"
+        assert not any((queue_root / "session-inbox").glob("*.json"))
+        resume = json.loads(result.packet_path.read_text(encoding="utf-8"))
+        assert resume["packet_type"] == "session_resume"
+        assert resume["resume"]["reason"] == "session_stale"
+
+
+def test_invalid_packet_lands_in_dead_letter_with_validation_errors() -> None:
+    with tempfile.TemporaryDirectory() as raw:
+        queue_root = Path(raw)
+        request = _request()
+
+        result = _process(queue_root, request, action="merge_when_green", duplicate=True)
+
+        assert result.status == "dead_letter"
+        assert result.packet_path is not None
+        assert result.packet_path.parent.name == "dead-letter"
+        dead = json.loads(result.packet_path.read_text(encoding="utf-8"))
+        assert "duplicate" in dead["reason"]
+
+
+def test_expired_response_fails_closed_to_dead_letter() -> None:
+    with tempfile.TemporaryDirectory() as raw:
+        queue_root = Path(raw)
+        request = _request()
+
+        result = _process(queue_root, request, action="merge_when_green", expired=True)
+
+        assert result.status == "dead_letter"
+        assert result.packet_path is not None
+        dead = json.loads(result.packet_path.read_text(encoding="utf-8"))
+        assert "expired" in dead["reason"]
+
+
+def test_replay_reconstructs_decision_path() -> None:
+    with tempfile.TemporaryDirectory() as raw:
+        queue_root = Path(raw)
+        request = _request()
+        hitl_relay_queue.enqueue_request(request, queue_root=queue_root)
+        _process(queue_root, request, action="merge_when_green")
+
+        replay = hitl_relay_queue.replay_audit(queue_root / "audit" / "events.jsonl")
+
+        assert replay["dead_letters"] == 0
+        assert replay["request_ids"] == ["hitl-20260418-301"]
+        assert replay["session_ids"] == ["codex-20260418-issue-301"]
+        assert replay["packet_types"] == [
+            "hitl_request",
+            "hitl_response",
+            "normalized_decision",
+            "session_instruction",
+        ]


### PR DESCRIPTION
## Summary
- add queue-first local HITL relay prototype for request/response/decision/session-inbox/session-resume/dead-letter/audit paths
- validate every emitted HITL packet through the deterministic #300 validator before writing outside dead-letter
- add #301 PDCAR, structured plan, execution scope, same-family exception, and cross-review evidence

## Validation
- python3 -m pytest scripts/orchestrator/test_hitl_relay_queue.py scripts/packet/test_validate_hitl_relay.py scripts/packet/test_hitl_relay_schema.py
- python3 -m pytest scripts/orchestrator/test_packet_queue.py scripts/orchestrator/test_hitl_relay_queue.py scripts/packet/test_validate_hitl_relay.py scripts/packet/test_hitl_relay_schema.py
- python3 scripts/overlord/validate_structured_agent_cycle_plan.py --root . --branch-name issue-301-hitl-queue-prototype --require-if-issue-branch --changed-files-file /tmp/issue-301-changed-files.txt --enforce-governance-surface --enforce-planner-boundary-scope
- python3 scripts/overlord/assert_execution_scope.py --scope raw/execution-scopes/2026-04-18-issue-301-hitl-queue-prototype-implementation.json --changed-files-file /tmp/issue-301-changed-files.txt
- tools/local-ci-gate/bin/hldpro-local-ci --changed-files-file /tmp/issue-301-changed-files.txt

Closes #301. Parent #296 remains open for AIS/MCP/session adapter slices and final #303 E2E proof.