### PR TITLE
Add Stampede org repo intake planning

### DIFF
--- a/docs/plans/issue-359-stampede-overlord-intake-pdcar.md
+++ b/docs/plans/issue-359-stampede-overlord-intake-pdcar.md
@@ -1,0 +1,60 @@
+# Issue #359 - Stampede Overlord Governance Intake PDCA/R
+
+Branch: `codex/issue-359-stampede-overlord-intake-runbook`
+Issue: [#359](https://github.com/NIBARGERB-HLDPRO/hldpro-governance/issues/359)
+Parent epic: [#298](https://github.com/NIBARGERB-HLDPRO/hldpro-governance/issues/298)
+Target repo: [NIBARGERB-HLDPRO/Stampede](https://github.com/NIBARGERB-HLDPRO/Stampede)
+
+## Plan
+
+`Stampede` was created as a private org repository for the PHASE0 development cycle. Repo-local HLDPRO product governance is already installed and live GitHub controls are active, but the governance repo does not yet include `Stampede` in Overlord registry sources. That means sweep, metrics, compendium, raw feed sync, memory integrity, Codex ingestion, code governance, and graph/wiki generation cannot select the repo through `docs/governed_repos.json`.
+
+The immediate #359 slice is planning and repeatability: preserve the Stampede audit handoff and create a reusable runbook for creating or adding org-level repos without confusing three separate layers:
+
+- GitHub org/repo controls
+- repo-local product governance files
+- Overlord governance registry enrollment
+
+## Do
+
+- Use the read-only Stampede audit handoff as the evidence baseline for #359.
+- Create a structured issue #359 plan that names scope, exclusions, risks, and validation.
+- Create a runbook for creating a new org repo or onboarding an existing repo into HLDPRO governance.
+- Explicitly record that `Stampede` Overlord enrollment is not complete until registry and graph target changes land in a follow-up implementation slice.
+- Leave unrelated generated `graphify-out/*` changes untouched unless a later validator requires regenerated artifacts.
+
+## Check
+
+Planning/runbook acceptance requires:
+
+- `python3 scripts/overlord/validate_structured_agent_cycle_plan.py --root .`
+- `python3 scripts/overlord/assert_execution_scope.py --scope raw/execution-scopes/2026-04-19-issue-359-stampede-overlord-intake-planning.json --changed-files-file <issue-359-changed-files>`
+- `python3 -m json.tool docs/plans/issue-359-structured-agent-cycle-plan.json`
+- `git diff --check`
+- Confirm `docs/governed_repos.json` and `docs/graphify_targets.json` remain unchanged in this planning slice.
+
+Follow-up implementation acceptance for actual Stampede enrollment must include:
+
+- Add `Stampede` to `docs/governed_repos.json` with explicit tier and subsystem flags.
+- Add `Stampede` to `docs/graphify_targets.json` if graph/wiki generation is selected.
+- Run `python3 scripts/overlord/validate_governed_repos.py`.
+- Run `python3 scripts/overlord/check_org_repo_inventory.py --live --format text`.
+- Verify `python3 scripts/overlord/validate_governed_repos.py --print-subsystem sweep` includes `Stampede` when sweep is enabled.
+- Regenerate compendium/graph artifacts only when the implementation slice scope includes them.
+
+## Act
+
+If this planning slice validates, publish it as a focused PR under #359. Do not claim `Stampede` is Overlord-enrolled from this PR alone. The next implementation PR must decide the intended governance tier, security tier, graphify participation, and subsystem flags before touching registry sources.
+
+If another org repo is created during this work, apply the new runbook and create a separate issue-backed intake unless it is part of the same #298 coverage gap.
+
+## Retrospective
+
+Expected residual work after this planning slice:
+
+- `Stampede` registry enrollment in `docs/governed_repos.json`.
+- Optional `Stampede` graph/wiki target setup.
+- Solo-owner review policy decision for repos where GitHub blocks self-approval.
+- `Stampede` PR #3 evidence refresh merge or closure.
+- `Stampede` Dependabot PR #1 review and merge or explicit deferral.
+- Code security / CodeQL decision for the `Stampede` tier.

--- a/docs/plans/issue-359-structured-agent-cycle-plan.json
+++ b/docs/plans/issue-359-structured-agent-cycle-plan.json
@@ -1,0 +1,127 @@
+{
+  "session_id": "session-20260419-issue-359-stampede-overlord-intake",
+  "issue_number": 359,
+  "objective": "Create the issue-backed planning and runbook surface for adding Stampede, and future org repos, to HLDPRO GitHub governance and Overlord registry coverage.",
+  "tier": 1,
+  "scope_boundary": [
+    "Document the current Stampede governance state from read-only audit evidence.",
+    "Create a PDCAR for issue #359.",
+    "Create a reusable runbook for creating or adding org-level repositories.",
+    "Separate GitHub rules, repo-local governance files, and Overlord registry enrollment.",
+    "Define validation and follow-up gates for the later Stampede registry implementation slice."
+  ],
+  "out_of_scope": [
+    "Editing the Stampede repository.",
+    "Editing docs/governed_repos.json in this planning slice.",
+    "Editing docs/graphify_targets.json in this planning slice.",
+    "Regenerating or staging graphify-out artifacts unless a later implementation scope includes them.",
+    "Changing GitHub rulesets or security settings.",
+    "Merging Stampede pull requests.",
+    "Changing Overlord workflow behavior."
+  ],
+  "research_summary": "A read-only audit confirmed that NIBARGERB-HLDPRO/Stampede exists, has repo-local governance files, active org and repo rulesets, passing required checks, Dependabot security updates, secret scanning, and push protection. The same audit confirmed the governance repo has no Stampede entry in docs/governed_repos.json or docs/graphify_targets.json, so Overlord sweep and related registry-driven activities do not include it. Issue #359 tracks the planning and repeatable runbook needed before the implementation slice enrolls Stampede.",
+  "research_artifacts": [
+    "GitHub issue #359",
+    "Read-only Stampede audit handoff from subagent 019da738-2f13-73d0-be90-dfe80cff09c3",
+    "NIBARGERB-HLDPRO/Stampede PR #2",
+    "NIBARGERB-HLDPRO/Stampede PR #3",
+    "NIBARGERB-HLDPRO/Stampede ruleset 15267782",
+    "NIBARGERB-HLDPRO org rulesets 14715976 and 14716006",
+    "docs/governed_repos.json",
+    "docs/graphify_targets.json",
+    "docs/plans/issue-298-org-repo-governance-coverage-pdcar.md"
+  ],
+  "sprints": [
+    {
+      "name": "Planning And Runbook",
+      "goal": "Produce issue #359 planning artifacts and a repeatable org repo intake runbook.",
+      "tasks": [
+        "Create issue #359 PDCAR.",
+        "Create structured agent cycle plan for #359.",
+        "Create execution-scope artifact for the docs-only planning slice.",
+        "Create org repo intake runbook with create, onboard, GitHub guard, repo-local guard, and Overlord enrollment stages."
+      ],
+      "acceptance_criteria": [
+        "PDCAR references issue #359 and the Stampede audit evidence.",
+        "Runbook distinguishes new repo creation from existing repo onboarding.",
+        "Runbook names the required GitHub, repo-local, and Overlord validation commands.",
+        "No registry or graph target edits are included in the planning slice."
+      ],
+      "file_paths": [
+        "docs/plans/issue-359-stampede-overlord-intake-pdcar.md",
+        "docs/plans/issue-359-structured-agent-cycle-plan.json",
+        "raw/execution-scopes/2026-04-19-issue-359-stampede-overlord-intake-planning.json",
+        "docs/runbooks/org-repo-intake.md"
+      ]
+    },
+    {
+      "name": "Stampede Enrollment Follow-Up",
+      "goal": "Define the next implementation slice that actually enrolls Stampede in Overlord.",
+      "tasks": [
+        "Choose Stampede governance tier and security tier.",
+        "Choose enabled_subsystems flags for sweep, metrics, memory_integrity, codex_ingestion, compendium, raw_feed_sync, code_governance, and graphify.",
+        "Add Stampede to docs/governed_repos.json.",
+        "Add Stampede to docs/graphify_targets.json if graphify is enabled.",
+        "Run registry, inventory, and generated artifact validation in a separate implementation PR."
+      ],
+      "acceptance_criteria": [
+        "Follow-up implementation scope is issue-backed before registry writes.",
+        "Registry validator passes.",
+        "Live org inventory agrees with registry or has explicit issue-backed classification.",
+        "Subsystem print commands include or exclude Stampede according to the selected flags."
+      ],
+      "file_paths": [
+        "docs/governed_repos.json",
+        "docs/graphify_targets.json",
+        "docs/ORG_GOVERNANCE_COMPENDIUM.md",
+        "graphify-out/",
+        "wiki/"
+      ]
+    }
+  ],
+  "specialist_reviews": [
+    {
+      "reviewer": "Ramanujan",
+      "role": "read-only Stampede auditor",
+      "focus": "Existing Stampede repo state, GitHub controls, check health, security settings, PR state, audit log evidence, and Overlord enrollment gaps.",
+      "status": "accepted_with_followup",
+      "summary": "Audit found GitHub and repo-local governance active, required checks passing, Dependabot and secret scanning active, and Overlord registry enrollment missing.",
+      "evidence": [
+        "Subagent 019da738-2f13-73d0-be90-dfe80cff09c3 final handoff",
+        "GitHub repo NIBARGERB-HLDPRO/Stampede",
+        "GitHub issue #359"
+      ]
+    }
+  ],
+  "alternate_model_review": {
+    "required": true,
+    "reviewer": "same-family-docs-fallback",
+    "model_family": "openai",
+    "status": "accepted_with_followup",
+    "summary": "True alternate-family review is not available in this lane. The change is docs-only planning/runbook work backed by a read-only subagent audit and deterministic validators.",
+    "evidence": [
+      "Subagent 019da738-2f13-73d0-be90-dfe80cff09c3 final handoff",
+      "Issue #359"
+    ]
+  },
+  "execution_handoff": {
+    "session_agent": "Codex",
+    "execution_mode": "implementation_ready",
+    "approved_scope_summary": "Issue #359 may add planning, execution-scope, and runbook files for Stampede Overlord intake. It may not edit Stampede, governed_repos, graphify targets, or generated graph/wiki artifacts in this planning slice.",
+    "next_execution_step": "Validate the planning artifacts, open a focused PR, then schedule a separate implementation slice for actual Stampede registry enrollment.",
+    "blocked_on": []
+  },
+  "material_deviation_rules": [
+    "If registry enrollment is requested in the same PR, stop and update scope before editing docs/governed_repos.json.",
+    "If graph/wiki artifacts need regeneration, stop and include generated artifact paths in a separate implementation scope.",
+    "If Stampede repo edits are needed, stop and use a downstream repo execution scope.",
+    "If solo-owner review policy changes are needed, create or update a ruleset exception/runbook entry before changing enforcement."
+  ],
+  "approved": true,
+  "approved_by": [
+    "GitHub issue #359",
+    "Operator instruction: use audit handoff with #359 and follow repo rules",
+    "Read-only audit subagent handoff"
+  ],
+  "approved_at": "2026-04-19T19:30:00Z"
+}

--- a/docs/runbooks/org-repo-intake.md
+++ b/docs/runbooks/org-repo-intake.md
@@ -1,0 +1,255 @@
+# Org Repo Intake Runbook
+
+## Purpose
+
+Use this runbook when creating a new `NIBARGERB-HLDPRO` repository or adding an existing repository to org-level governance. The goal is to make every repo's status explicit across three layers:
+
+- GitHub org and repo controls
+- repo-local product governance files
+- Overlord registry, sweep, graph, metrics, memory, Codex, and compendium coverage
+
+Do not treat one layer as proof of another. A repo can have branch rules and still be absent from Overlord. A repo can be in `docs/governed_repos.json` and still lack repo-local required checks.
+
+## Inputs
+
+Collect these before writes:
+
+- Repo name and GitHub owner, usually `NIBARGERB-HLDPRO/<repo>`.
+- Whether this is a new repo or an existing repo.
+- Default branch.
+- Local checkout path under `$HLDPRO_REPOS_ROOT` or `~/Developer/HLDPRO`.
+- Governance tier: `full`, `full-hipaa`, `standard`, `limited`, `adoption_blocked`, or `exempt`.
+- Security tier: `baseline`, `full-pentagi`, `full-pentagi-hipaa`, or `exempt`.
+- Intended subsystem flags: `graphify`, `sweep`, `metrics`, `memory_integrity`, `codex_ingestion`, `compendium`, `raw_feed_sync`, and `code_governance`.
+- Issue number in `hldpro-governance` for intake planning and closeout.
+
+## Stage 0 - Plan
+
+Every intake needs an issue-backed planning surface before registry or downstream writes.
+
+Required artifacts:
+
+- `docs/plans/issue-<n>-<repo>-intake-pdcar.md`
+- `docs/plans/issue-<n>-structured-agent-cycle-plan.json`
+- `raw/execution-scopes/<date>-issue-<n>-<repo>-intake-<mode>.json`
+
+The PDCAR must state whether the slice is:
+
+- discovery only,
+- repo creation plus local governance bootstrap,
+- Overlord registry enrollment,
+- generated graph/wiki refresh,
+- closeout only.
+
+If multiple people or agents are active in the repo, record the active roots in the execution scope and keep writes inside `allowed_write_paths`.
+
+Validation:
+
+```bash
+python3 scripts/overlord/validate_structured_agent_cycle_plan.py --root .
+python3 scripts/overlord/assert_execution_scope.py --scope raw/execution-scopes/<scope>.json --changed-files-file <changed-files>
+git diff --check
+```
+
+## Stage 1 - Create Or Resolve The GitHub Repo
+
+For a new repo:
+
+```bash
+gh repo create NIBARGERB-HLDPRO/<repo> --private --source /path/to/local/repo --remote origin --push
+```
+
+For an existing repo:
+
+```bash
+gh repo view NIBARGERB-HLDPRO/<repo> --json nameWithOwner,url,visibility,defaultBranchRef,viewerPermission
+git -C /path/to/local/repo remote -v
+```
+
+Confirm:
+
+```bash
+gh repo view NIBARGERB-HLDPRO/<repo> --json nameWithOwner,owner,visibility,isPrivate,defaultBranchRef,viewerPermission,url
+gh api user/memberships/orgs/NIBARGERB-HLDPRO --jq '{organization: .organization.login, role, state}'
+```
+
+## Stage 2 - Install Repo-Local Product Governance
+
+Minimum product repo files:
+
+```text
+.github/CODEOWNERS
+.github/dependabot.yml
+.github/pull_request_template.md
+.github/workflows/governance-check.yml
+.github/workflows/gitleaks.yml
+.gitleaks.toml
+.hldpro/governance-tooling.json
+docs/PROGRESS.md
+docs/exception-register.md
+```
+
+The exact workflow commands must match the repo's stack. Do not copy a profile that cannot run in the target repo. If only Phase 0 artifacts exist, use deterministic artifact validation and secret scanning until the application stack exists.
+
+Validate locally before push:
+
+```bash
+python3 -m json.tool .hldpro/governance-tooling.json >/dev/null
+git diff --check
+```
+
+Add stack-specific validation, for example:
+
+```bash
+python3 -m json.tool label_schema_v0_1.json >/dev/null
+python3 -m json.tool baselines_v0_1.json >/dev/null
+python3 - <<'PY'
+from pathlib import Path
+import yaml
+
+with Path("phase0.yaml").open("r", encoding="utf-8") as handle:
+    yaml.safe_load(handle)
+PY
+```
+
+## Stage 3 - Apply GitHub Rules And Security Guards
+
+Confirm inherited org rulesets:
+
+```bash
+gh api /orgs/NIBARGERB-HLDPRO/rulesets --jq '.[] | [.id,.name,.enforcement] | @tsv'
+```
+
+Create a repo-level main policy only after the required check workflows exist on the default branch. Required status contexts must exactly match live check names.
+
+Example repo ruleset shape:
+
+```bash
+gh api --method POST /repos/NIBARGERB-HLDPRO/<repo>/rulesets --input ruleset.json
+```
+
+The policy should normally include:
+
+- deletion block
+- non-fast-forward block
+- pull request required
+- one approving review
+- code-owner review
+- review-thread resolution
+- strict required checks
+- no bypass actors unless an issue-backed exception exists
+
+Enable security settings:
+
+```bash
+gh api -X PUT /repos/NIBARGERB-HLDPRO/<repo>/vulnerability-alerts --silent
+gh api -X PUT /repos/NIBARGERB-HLDPRO/<repo>/automated-security-fixes --silent
+gh api -X PATCH /repos/NIBARGERB-HLDPRO/<repo> --input - <<'JSON'
+{
+  "security_and_analysis": {
+    "secret_scanning": {"status": "enabled"},
+    "secret_scanning_push_protection": {"status": "enabled"},
+    "secret_scanning_non_provider_patterns": {"status": "enabled"},
+    "secret_scanning_validity_checks": {"status": "enabled"},
+    "dependabot_security_updates": {"status": "enabled"}
+  }
+}
+JSON
+```
+
+Verify:
+
+```bash
+gh api /repos/NIBARGERB-HLDPRO/<repo>/rulesets --jq '.[] | [.id,.name,.source_type,.enforcement] | @tsv'
+gh api /repos/NIBARGERB-HLDPRO/<repo>/vulnerability-alerts -i
+gh api /repos/NIBARGERB-HLDPRO/<repo>/automated-security-fixes --jq '{enabled,paused}'
+gh api /repos/NIBARGERB-HLDPRO/<repo> --jq '{web_commit_signoff_required,security_and_analysis}'
+gh run list --repo NIBARGERB-HLDPRO/<repo> --branch main --limit 10
+```
+
+Classic branch protection may return `404 Branch not protected` when rulesets are the active protection mechanism. In that case, verify the rulesets directly instead of creating duplicate classic protection.
+
+## Stage 4 - Enroll In Overlord
+
+Repo-local GitHub governance is not Overlord enrollment. Add the repo to `docs/governed_repos.json` with all required fields:
+
+- `repo_slug`
+- `display_name`
+- `repo_dir_name`
+- `github_repo`
+- `local_path`
+- `ci_checkout_path`
+- `graph_output_path`
+- `wiki_path`
+- `project_path`
+- `governance_tier`
+- `security_tier`
+- `lifecycle_status`
+- `governance_status`
+- `classification`
+- `description`
+- `enabled_subsystems`
+
+If `graphify` is enabled, add a matching row to `docs/graphify_targets.json`.
+
+Validate:
+
+```bash
+python3 scripts/overlord/validate_governed_repos.py
+python3 scripts/overlord/check_org_repo_inventory.py --live --format text
+python3 scripts/knowledge_base/graphify_targets.py show --repo-slug <repo-slug>
+python3 scripts/overlord/validate_governed_repos.py --print-subsystem sweep
+python3 scripts/overlord/validate_governed_repos.py --print-subsystem code_governance
+python3 scripts/overlord/validate_governed_repos.py --print-subsystem metrics
+python3 scripts/overlord/validate_governed_repos.py --print-subsystem compendium
+```
+
+Regenerate compendium, graph, wiki, metrics, or raw-feed artifacts only when the implementation scope includes those paths.
+
+## Stage 5 - PR And Closeout
+
+Before opening a PR:
+
+```bash
+python3 scripts/overlord/validate_structured_agent_cycle_plan.py --root .
+python3 scripts/overlord/assert_execution_scope.py --scope raw/execution-scopes/<scope>.json --changed-files-file <changed-files>
+python3 scripts/overlord/validate_governed_repos.py
+git diff --check
+```
+
+PR body must include:
+
+- issue link,
+- repo URL,
+- created or existing repo status,
+- ruleset IDs,
+- security setting evidence,
+- required check run IDs,
+- registry subsystem selection,
+- open risks and deferrals.
+
+Closeout must not claim completion until:
+
+- GitHub org/repo controls are active or explicitly deferred.
+- Repo-local governance files are committed on the default branch or explicitly deferred.
+- Overlord registry enrollment is complete or explicitly classified as `adoption_blocked`, `limited`, or `exempt`.
+- Required checks pass on the PR and, after merge, on `main`.
+
+## Solo-Owner Repos
+
+GitHub blocks self-approval. If a solo-owner repo requires one approving review, normal merges will block even when checks pass.
+
+Preferred options:
+
+1. Add a second trusted reviewer with write access.
+2. Keep the ruleset strict and use a documented temporary ruleset-disable override only when the operator explicitly authorizes it.
+3. Create an issue-backed exception with expiry or review cadence before weakening review requirements.
+
+When an override is used:
+
+- back up the ruleset,
+- disable only the minimum repo-level overlay,
+- merge,
+- immediately restore the ruleset,
+- capture audit-log evidence,
+- update `docs/exception-register.md` if the override is repeatable.

--- a/raw/execution-scopes/2026-04-19-issue-359-stampede-overlord-intake-planning.json
+++ b/raw/execution-scopes/2026-04-19-issue-359-stampede-overlord-intake-planning.json
@@ -1,0 +1,40 @@
+{
+  "expected_execution_root": "{repo_root}",
+  "expected_branch": "codex/issue-359-stampede-overlord-intake-runbook",
+  "execution_mode": "planning_only",
+  "allowed_write_paths": [
+    "docs/plans/issue-359-stampede-overlord-intake-pdcar.md",
+    "docs/plans/issue-359-structured-agent-cycle-plan.json",
+    "raw/execution-scopes/2026-04-19-issue-359-stampede-overlord-intake-planning.json",
+    "docs/runbooks/org-repo-intake.md"
+  ],
+  "forbidden_roots": [
+    "/Users/bennibarger/Developer/HLDPRO/PHASE0",
+    "/Users/bennibarger/Developer/HLDPRO/local-ai-machine",
+    "/Users/bennibarger/Developer/HLDPRO/ai-integration-services",
+    "/Users/bennibarger/Developer/HLDPRO/knocktracker",
+    "/Users/bennibarger/Developer/HLDPRO/HealthcarePlatform"
+  ],
+  "active_parallel_roots": [
+    {
+      "path": "/Users/bennibarger/Developer/HLDPRO/PHASE0",
+      "reason": "Stampede has open PR/review activity; issue #359 planning does not edit the downstream repo."
+    },
+    {
+      "path": "/Users/bennibarger/Developer/HLDPRO/local-ai-machine",
+      "reason": "LAM may have unrelated active work; issue #359 does not edit downstream repos."
+    },
+    {
+      "path": "/Users/bennibarger/Developer/HLDPRO/ai-integration-services",
+      "reason": "AIS may have unrelated active work; issue #359 does not edit downstream repos."
+    },
+    {
+      "path": "/Users/bennibarger/Developer/HLDPRO/knocktracker",
+      "reason": "Knocktracker may have unrelated active work; issue #359 does not edit downstream repos."
+    },
+    {
+      "path": "/Users/bennibarger/Developer/HLDPRO/HealthcarePlatform",
+      "reason": "HealthcarePlatform may have unrelated active work; issue #359 does not edit downstream repos."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Adds issue #359 PDCAR for Stampede Overlord intake planning.
- Adds a structured agent cycle plan and execution scope for the docs-only planning slice.
- Adds a reusable org repo intake runbook covering new repo creation, existing repo onboarding, repo-local governance, GitHub rules/security guards, Overlord enrollment, validation, closeout, and solo-owner handling.

## Scope

This is planning/runbook work only. It intentionally does not edit:

- docs/governed_repos.json
- docs/graphify_targets.json
- Stampede repo files
- generated graph/wiki artifacts

## Validation

- python3 -m json.tool docs/plans/issue-359-structured-agent-cycle-plan.json
- python3 -m json.tool raw/execution-scopes/2026-04-19-issue-359-stampede-overlord-intake-planning.json
- python3 scripts/overlord/validate_structured_agent_cycle_plan.py --root . --branch-name codex/issue-359-stampede-overlord-intake-runbook --changed-files-file <issue-359 changed files> --enforce-governance-surface
- python3 scripts/overlord/assert_execution_scope.py --scope raw/execution-scopes/2026-04-19-issue-359-stampede-overlord-intake-planning.json --changed-files-file <issue-359 changed files>
- git diff --check -- <issue-359 changed files>

Refs #359. Actual Stampede registry enrollment remains follow-up implementation work.