### PR TITLE
Record Remote MCP Cloudflare Access blocker

### DIFF
--- a/docs/plans/issue-368-remote-mcp-cloudflare-access-blocker-pdcar.md
+++ b/docs/plans/issue-368-remote-mcp-cloudflare-access-blocker-pdcar.md
@@ -1,0 +1,35 @@
+# PDCAR: Issue #368 Remote MCP Cloudflare Access Proof Blocker
+
+Date: 2026-04-19
+Branch: `issue-368-remote-mcp-cloudflare-access-blocker-20260419`
+Issue: [#368](https://github.com/NIBARGERB-HLDPRO/hldpro-governance/issues/368)
+Epic: [#109](https://github.com/NIBARGERB-HLDPRO/hldpro-governance/issues/109)
+
+## Plan
+
+Record the live Cloudflare boundary attempt for Remote MCP Stage D. The merged bridge and governance harness are ready, but the public Cloudflare hostname returned 403 before origin dispatch, so final #109 closure remains blocked outside the repository.
+
+## Do
+
+1. Confirm the active Cloudflare tunnel route for the available hostname.
+2. Start the real downstream Remote MCP Bridge on the routed local port with synthetic local keys.
+3. Run the Stage D proof harness through the public Cloudflare hostname.
+4. Attempt a temporary service-token policy path, then restore the original policy.
+5. Record non-secret validation and closeout evidence.
+
+## Check
+
+- Live tunnel harness attempt: `scripts/remote-mcp/stage_d_smoke.py --json` against `https://critic.hldpro.com`.
+- Cloudflare Access policy restore check: service-token policy include count returned to its original value.
+- `python3 scripts/overlord/validate_structured_agent_cycle_plan.py --root . --require-if-issue-branch --branch-name issue-368-remote-mcp-cloudflare-access-blocker-20260419`
+- `python3 scripts/overlord/assert_execution_scope.py --scope raw/execution-scopes/2026-04-19-issue-368-remote-mcp-cloudflare-access-blocker-implementation.json`
+- `tools/local-ci-gate/bin/hldpro-local-ci run --profile hldpro-governance --json`
+- GitHub Actions on the PR
+
+## Adjust
+
+Do not close #109 from this evidence. The request reached Cloudflare, but Cloudflare returned 403 before the Remote MCP origin received dispatchable traffic, so no live audit JSONL rows were generated.
+
+## Review
+
+Review must confirm no Cloudflare tunnel token, Access client secret, JWT, HMAC key, or raw PII is committed.

--- a/docs/plans/issue-368-remote-mcp-cloudflare-access-blocker-structured-agent-cycle-plan.json
+++ b/docs/plans/issue-368-remote-mcp-cloudflare-access-blocker-structured-agent-cycle-plan.json
@@ -1,0 +1,95 @@
+{
+  "session_id": "session-20260419-issue-368-cloudflare-access-blocker",
+  "issue_number": 368,
+  "objective": "Record the live Cloudflare Access blocker preventing final Remote MCP Stage D closure under epic #109.",
+  "tier": 2,
+  "scope_boundary": [
+    "Modify only issue #368 planning, validation, execution-scope, and closeout evidence.",
+    "Do not commit Cloudflare tokens, Access client secrets, JWTs, HMAC keys, or raw PII.",
+    "Do not close epic #109 because live Cloudflare proof did not reach the Remote MCP origin."
+  ],
+  "out_of_scope": [
+    "Changing Remote MCP bridge code.",
+    "Changing governance Stage D proof code.",
+    "Persisting new Cloudflare Access service tokens.",
+    "Changing Cloudflare policy state beyond a temporary proof attempt that is restored."
+  ],
+  "research_summary": "Epic #109 Stage A, B/C, Stage D harness, and local origin-boundary readiness evidence are merged. The active Cloudflare tunnel routes critic.hldpro.com to local port 18082, but Stage D proof through the public hostname returned Cloudflare 403 before origin dispatch. A temporary service token was created, attached for the proof attempt, then removed and the original policy restored; the request still returned 403.",
+  "research_artifacts": [
+    "https://github.com/NIBARGERB-HLDPRO/hldpro-governance/issues/109",
+    "https://github.com/NIBARGERB-HLDPRO/hldpro-governance/issues/368",
+    "https://github.com/NIBARGERB-HLDPRO/hldpro-governance/pull/365",
+    "https://github.com/NIBARGERB-HLDPRO/hldpro-governance/pull/367",
+    "docs/runbooks/remote-mcp-bridge.md"
+  ],
+  "sprints": [
+    {
+      "name": "Cloudflare boundary blocker evidence",
+      "goal": "Preserve the final live e2e blocker without exposing secrets or mutating source code.",
+      "tasks": [
+        "Record Cloudflare tunnel route status.",
+        "Record Stage D proof attempt result.",
+        "Record temporary service-token cleanup status.",
+        "Run governance validation and CI."
+      ],
+      "acceptance_criteria": [
+        "Evidence states authenticated ping failed with Cloudflare 403 before origin dispatch.",
+        "Evidence states anonymous and negative paths also returned Cloudflare 403 and therefore are not Remote MCP-origin proof.",
+        "Evidence states no audit rows were produced because the origin was not reached.",
+        "Evidence states the temporary Access policy mutation was restored.",
+        "Evidence contains no secrets.",
+        "Epic #109 remains open."
+      ],
+      "file_paths": [
+        "docs/plans/issue-368-remote-mcp-cloudflare-access-blocker-pdcar.md",
+        "docs/plans/issue-368-remote-mcp-cloudflare-access-blocker-structured-agent-cycle-plan.json",
+        "raw/execution-scopes/2026-04-19-issue-368-remote-mcp-cloudflare-access-blocker-implementation.json",
+        "raw/validation/2026-04-19-issue-368-remote-mcp-cloudflare-access-blocker.md",
+        "raw/closeouts/2026-04-19-issue-368-remote-mcp-cloudflare-access-blocker.md"
+      ]
+    }
+  ],
+  "specialist_reviews": [
+    {
+      "reviewer": "codex-self-review",
+      "role": "secret and scope review",
+      "focus": "Ensure no tokens, client secrets, JWTs, HMAC keys, or raw PII are committed.",
+      "status": "completed",
+      "summary": "Evidence files use redacted descriptions only and do not contain live credential values.",
+      "evidence": [
+        "raw/validation/2026-04-19-issue-368-remote-mcp-cloudflare-access-blocker.md"
+      ]
+    }
+  ],
+  "alternate_model_review": {
+    "required": false,
+    "reviewer": "not_required_for_blocker_evidence_only",
+    "model_family": "n/a",
+    "status": "not_required",
+    "summary": "This slice records a blocker and does not change executable code.",
+    "evidence": [
+      "raw/validation/2026-04-19-issue-368-remote-mcp-cloudflare-access-blocker.md"
+    ]
+  },
+  "execution_handoff": {
+    "session_agent": "Codex",
+    "execution_mode": "implementation_complete",
+    "approved_scope_summary": "Issue #368 may add only non-secret blocker evidence for the live Cloudflare Access proof attempt under epic #109.",
+    "next_execution_step": "Merge blocker evidence, then resolve Cloudflare Access/tunnel authorization outside repo before retrying final Stage D proof.",
+    "blocked_on": [
+      "Cloudflare Access/tunnel route returns 403 before origin dispatch for the available public hostname."
+    ]
+  },
+  "material_deviation_rules": [
+    "If Cloudflare Access begins forwarding to origin, rerun Stage D proof and record live audit evidence before closing #109.",
+    "If any credential value appears in evidence, remove it before commit.",
+    "If Cloudflare policy cleanup cannot be confirmed, do not merge this evidence until cleanup status is resolved."
+  ],
+  "approved": true,
+  "approved_by": [
+    "operator directive",
+    "issue #368 child blocker issue",
+    "issue #109 governing epic"
+  ],
+  "approved_at": "2026-04-19T22:00:00Z"
+}

--- a/raw/closeouts/2026-04-19-issue-368-remote-mcp-cloudflare-access-blocker.md
+++ b/raw/closeouts/2026-04-19-issue-368-remote-mcp-cloudflare-access-blocker.md
@@ -1,0 +1,20 @@
+# Closeout: Issue #368 Remote MCP Cloudflare Access Proof Blocker
+
+Date: 2026-04-19
+Branch: `issue-368-remote-mcp-cloudflare-access-blocker-20260419`
+Epic: hldpro-governance #109
+
+## Summary
+
+Recorded the live Cloudflare boundary blocker for final Remote MCP Stage D proof. The public hostname route exists and points to the expected local port, but Cloudflare returned 403 before requests reached the Remote MCP origin, even during a temporary service-token proof attempt.
+
+## Acceptance
+
+- Live tunnel attempt was made through the public Cloudflare hostname.
+- Temporary service-token policy mutation was restored.
+- No secrets or raw sensitive payloads are committed.
+- Evidence clearly states the proof did not reach origin and does not close #109.
+
+## Remaining Work
+
+Fix Cloudflare Access/tunnel authorization for the Remote MCP public hostname, then rerun the Stage D harness through the live endpoint. Close #109 only after the live run generates audit rows, strict audit verification passes, copied tamper verification fails, and local stdio MCP remains usable after tunnel stop.

--- a/raw/execution-scopes/2026-04-19-issue-368-remote-mcp-cloudflare-access-blocker-implementation.json
+++ b/raw/execution-scopes/2026-04-19-issue-368-remote-mcp-cloudflare-access-blocker-implementation.json
@@ -1,0 +1,51 @@
+{
+  "expected_execution_root": ".",
+  "expected_branch": "issue-368-remote-mcp-cloudflare-access-blocker-20260419",
+  "execution_mode": "implementation_complete",
+  "allowed_write_paths": [
+    "docs/plans/issue-368-remote-mcp-cloudflare-access-blocker-pdcar.md",
+    "docs/plans/issue-368-remote-mcp-cloudflare-access-blocker-structured-agent-cycle-plan.json",
+    "raw/execution-scopes/2026-04-19-issue-368-remote-mcp-cloudflare-access-blocker-implementation.json",
+    "raw/validation/2026-04-19-issue-368-remote-mcp-cloudflare-access-blocker.md",
+    "raw/closeouts/2026-04-19-issue-368-remote-mcp-cloudflare-access-blocker.md"
+  ],
+  "forbidden_roots": [
+    "/Users/bennibarger/Developer/HLDPRO/hldpro-governance",
+    "/Users/bennibarger/Developer/HLDPRO/local-ai-machine",
+    "/Users/bennibarger/Developer/HLDPRO/ai-integration-services",
+    "/Users/bennibarger/Developer/HLDPRO/knocktracker",
+    "/Users/bennibarger/Developer/HLDPRO/HealthcarePlatform"
+  ],
+  "active_parallel_roots": [
+    {
+      "path": "/Users/bennibarger/Developer/HLDPRO/hldpro-governance",
+      "reason": "primary governance checkout has pre-existing graphify changes; issue #368 uses an isolated worktree"
+    },
+    {
+      "path": "/Users/bennibarger/Developer/HLDPRO/local-ai-machine",
+      "reason": "primary LAM checkout has pre-existing unrelated dirty work; proof attempt used a clean detached origin/main worktree"
+    },
+    {
+      "path": "/Users/bennibarger/Developer/HLDPRO/ai-integration-services",
+      "reason": "sibling repo has pre-existing unrelated artifacts"
+    },
+    {
+      "path": "/Users/bennibarger/Developer/HLDPRO/knocktracker",
+      "reason": "sibling repo has pre-existing unrelated graphify/cache artifacts"
+    }
+  ],
+  "handoff_evidence": {
+    "status": "accepted",
+    "planner_model": "github-issue-368-under-epic-109",
+    "implementer_model": "codex-gpt-5",
+    "accepted_at": "2026-04-19T22:00:00Z",
+    "evidence_paths": [
+      "https://github.com/NIBARGERB-HLDPRO/hldpro-governance/issues/368",
+      "https://github.com/NIBARGERB-HLDPRO/hldpro-governance/issues/109",
+      "docs/plans/issue-368-remote-mcp-cloudflare-access-blocker-structured-agent-cycle-plan.json",
+      "docs/plans/issue-368-remote-mcp-cloudflare-access-blocker-pdcar.md"
+    ],
+    "active_exception_ref": null,
+    "active_exception_expires_at": null
+  }
+}

--- a/raw/validation/2026-04-19-issue-368-remote-mcp-cloudflare-access-blocker.md
+++ b/raw/validation/2026-04-19-issue-368-remote-mcp-cloudflare-access-blocker.md
@@ -1,0 +1,49 @@
+# Validation: Issue #368 Remote MCP Cloudflare Access Proof Blocker
+
+Date: 2026-04-19
+Branch: `issue-368-remote-mcp-cloudflare-access-blocker-20260419`
+Epic: hldpro-governance #109
+
+## Cloudflare Route
+
+Cloudflare API inspection found an active Access application for `critic.hldpro.com`. The active tunnel configuration routes that hostname to local service `http://127.0.0.1:18082`.
+
+## Live Proof Attempt
+
+The real downstream Remote MCP Bridge was started on `127.0.0.1:18082` from clean `local-ai-machine` `origin/main` commit `f44039dc197c43b3a847f0c7570f1dc1256e2763`.
+
+The merged governance Stage D harness was run against `https://critic.hldpro.com` with:
+
+- synthetic inner JWT signed by a synthetic local auth key,
+- synthetic local audit HMAC key,
+- direct Cloudflare Access identity headers,
+- temporary Cloudflare Access service-token client headers during the second attempt,
+- repo-local audit directory,
+- local stdio import proof command.
+
+Result:
+
+- `authenticated-ping`: failed with Cloudflare 403 before origin dispatch.
+- Negative request checks also returned Cloudflare 403 and therefore do not count as Remote MCP-origin negative proof.
+- `audit-valid`: passed only because the configured audit directory was empty.
+- `audit-tamper-negative`: failed because no audit JSONL files were generated.
+- `stdio-after-tunnel-stop`: passed for the local stdio import proof.
+
+The Remote MCP origin did not receive dispatchable traffic through the public hostname, so final #109 Stage D live proof remains blocked.
+
+## Temporary Access Token Cleanup
+
+A temporary Cloudflare Access service token was created for the proof attempt, added to the existing `Service tokens only` policy, then removed. The policy was restored to its original include count of two service tokens after cleanup.
+
+No temporary token value, client secret, Cloudflare tunnel token, JWT, or HMAC key is committed.
+
+## Governance Validation
+
+- Structured plan validation passed:
+  `python3 scripts/overlord/validate_structured_agent_cycle_plan.py --root . --require-if-issue-branch --branch-name issue-368-remote-mcp-cloudflare-access-blocker-20260419`
+- Execution scope validation passed:
+  `python3 scripts/overlord/assert_execution_scope.py --scope raw/execution-scopes/2026-04-19-issue-368-remote-mcp-cloudflare-access-blocker-implementation.json`
+
+## Remaining Epic Work
+
+Epic #109 remains open. Final closure requires Cloudflare Access/tunnel authorization that forwards the Stage D harness requests to the Remote MCP origin, copied live audit evidence with rows, strict verifier success, tamper-negative verifier failure on a copied sample, and stdio proof after tunnel stop.


### PR DESCRIPTION
## Summary\n- Records child issue #368 blocker evidence under epic #109.\n- Live Stage D harness attempt through the public Cloudflare hostname reached Cloudflare but returned 403 before Remote MCP origin dispatch.\n- Temporary service-token policy mutation was restored; no token/client secret/JWT/HMAC value is committed.\n\n## Validation\n- Cloudflare route inspected: active Access app for critic.hldpro.com routes to local 127.0.0.1:18082.\n- Stage D proof attempt through public hostname failed at Cloudflare 403 before origin audit rows were generated.\n- Service-token policy include count restored to original value.\n- python3 scripts/overlord/validate_structured_agent_cycle_plan.py --root . --require-if-issue-branch --branch-name issue-368-remote-mcp-cloudflare-access-blocker-20260419\n- python3 scripts/overlord/assert_execution_scope.py --scope raw/execution-scopes/2026-04-19-issue-368-remote-mcp-cloudflare-access-blocker-implementation.json\n- tools/local-ci-gate/bin/hldpro-local-ci run --profile hldpro-governance --json\n\n## Scope\nCloses #368. Does not close #109; final live e2e remains blocked until Cloudflare Access/tunnel authorization forwards proof traffic to the Remote MCP origin.