### PR TITLE
[codex] Plan org automerge policy

### DIFF
--- a/OVERLORD_BACKLOG.md
+++ b/OVERLORD_BACKLOG.md
@@ -11,6 +11,7 @@
 |------|-------|----------|-----------|-------|
 | Codex-spark refinement pass on Stage 3b MCP tools + Stage 4 validator | [#177](https://github.com/NIBARGERB-HLDPRO/hldpro-governance/issues/177) | LOW-MEDIUM | 2-3 | Post-outage code review. Gate: live-fallback rate < 2% for 2 weeks post-merge (window now passed). |
 | Qwen-Coder MLX driver stub-emission bug | [#105](https://github.com/NIBARGERB-HLDPRO/hldpro-governance/issues/105) | LOW | 1-2 | Qwen2.5-Coder-7B throws truncated output on edge cases (>200 lines). Workarounds in `docs/runbooks/qwen-coder-driver.md`. |
+| Org-level automerge policy for green verified PRs | [#386](https://github.com/NIBARGERB-HLDPRO/hldpro-governance/issues/386) | HIGH | 2-4 planning, rollout TBD | Plan and locally test a policy so PRs that are complete, verified, tested, and green can be automatically merged without bypassing review, required checks, CODEOWNERS, or repo-specific exception paths. Depends on merging backlog drift repair [#384](https://github.com/NIBARGERB-HLDPRO/hldpro-governance/issues/384) first. |
 | SoM Stage 5: som-worker daemon (always-warm Qwen-Coder + packet queue pipeline) | [#178](https://github.com/NIBARGERB-HLDPRO/hldpro-governance/issues/178) | LOW | 6-8 | Qwen watches raw/packets/inbound/, processes to raw/packets/outbound/, Sonnet reviews async. |
 | Living Knowledge Base — Phase 8: Qwen3-32B fine-tune on wiki data | [#49](https://github.com/NIBARGERB-HLDPRO/hldpro-governance/issues/49) | LOW | TBD | Gate: wiki must have 6+ months of compounding data minimum. |
 

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -10,6 +10,7 @@
 
 | Plan | Issue | Status | Priority | Est. Hours | Deliverables | Notes |
 |------|-------|--------|----------|------------|--------------|-------|
+| Org-level automerge policy for green verified PRs | #386 | PLANNED | HIGH | 2-4 planning, rollout TBD | Policy definition, dry-run evaluator, local tests, rollback plan, later rollout issue | Must preserve required checks, reviews, CODEOWNERS, and exceptions; depends on #384 backlog drift repair first |
 | Codex-spark refinement pass on Stage 3b MCP tools + Stage 4 validator | #177 | PLANNED | LOW-MEDIUM | 2-3 | Codex review findings, follow-up issues | Gate: live-fallback rate < 2% confirmed |
 | Qwen-Coder MLX driver stub-emission bug | #105 | PLANNED | LOW | 1-2 | MLX driver patch or workaround | Workarounds in docs/runbooks/qwen-coder-driver.md |
 | SoM Stage 5: som-worker daemon | #178 | PLANNED | LOW | 6-8 | Daemon implementation, queue wiring | Follow-on to Stage 3b/4 |

--- a/docs/plans/issue-386-org-automerge-policy-pdcar.md
+++ b/docs/plans/issue-386-org-automerge-policy-pdcar.md
@@ -1,0 +1,71 @@
+# PDCAR: Issue #386 Org-Level Automerge Policy For Green Verified PRs
+
+Date: 2026-04-20
+Branch: `issue-386-org-automerge-policy-20260420`
+Issue: [#386](https://github.com/NIBARGERB-HLDPRO/hldpro-governance/issues/386)
+Prerequisite: [#384](https://github.com/NIBARGERB-HLDPRO/hldpro-governance/issues/384)
+
+## Plan
+
+Define and locally test a governed automerge policy for PRs that are complete, verified, tested, and green. The policy must not weaken branch protection. It should automate only the final merge request after GitHub and governance checks already prove the PR satisfies required reviews, required status checks, mergeability, and repo-specific governance gates.
+
+Current live findings:
+
+- Org ruleset `14715976` protects `main`/`master` with PR-only, deletion, and non-fast-forward rules, but no org-level approving-review, code-owner-review, review-thread-resolution, or required-status-check rule.
+- Org ruleset `14716006` protects `develop` from deletion and non-fast-forward pushes, but does not require PRs or checks.
+- `hldpro-governance` currently has `allow_auto_merge: false`.
+- Existing Enterprise docs intentionally defer broad required-check rollout until exact live check names, conditional checks, CODEOWNERS, and exceptions are reconciled.
+
+## Do
+
+1. Define eligibility:
+   - PR is not draft.
+   - PR targets a protected branch covered by the rollout.
+   - PR has no merge conflicts and is mergeable.
+   - All required checks are successful and no required check is pending.
+   - Required reviews and CODEOWNER reviews are satisfied where configured.
+   - Review threads are resolved where configured.
+   - The PR has no blocking labels such as `do-not-merge`, `hold`, `security-review-required`, or `manual-merge-required`.
+   - The PR has an explicit opt-in label during pilot rollout, such as `automerge` or `merge-when-green`.
+   - Governance artifacts required by the repo are present, including issue-backed PDCAR/closeout evidence where applicable.
+2. Add a local-only dry-run evaluator:
+   - `scripts/overlord/automerge_policy_check.py` reads a PR-state fixture and returns `eligible`, blockers, warnings, and rollback steps.
+   - The evaluator never calls GitHub APIs and never enables or performs merges.
+3. Choose the future implementation mechanism:
+   - Enable GitHub native auto-merge per target repo.
+   - Add a governed reusable workflow or repo-local workflow that enables auto-merge for eligible PRs with `gh pr merge --auto` or the GraphQL `enablePullRequestAutoMerge` mutation.
+   - Keep merge execution inside GitHub's protected-branch/ruleset engine; do not write a bot that force-merges or bypasses protections.
+4. Stage rollout:
+   - Stage 0: merge #384 so backlog alignment is green again.
+   - Stage 1: hldpro-governance pilot after `allow_auto_merge` is enabled and `local-ci-gate` remains required.
+   - Stage 2: repos with stable required-check baselines and CODEOWNERS coverage.
+   - Stage 3: production-critical repos after repo owner acknowledgement and exception review.
+
+## Check
+
+- Unit tests prove eligible fixture passes.
+- Unit tests prove draft, conflicted, red, unreviewed, unresolved-thread, missing-CODEOWNER, blocking-label, missing-opt-in, disabled-repo, and missing-governance-artifact states fail.
+- CLI dry-run returns exit `0` only for eligible fixtures and exit `2` for blocked fixtures.
+- Confirm each future target repo has `allow_auto_merge` enabled before rollout.
+- Confirm target repo rulesets or branch protections require the intended checks and reviews before auto-merge is allowed.
+- Confirm required checks are exact live contexts, not workflow filenames.
+- Confirm actor-conditional and path-conditional checks are not treated as universal merge gates.
+- Confirm Dependabot and bot PR behavior is explicitly classified before inclusion.
+
+## Adjust
+
+Do not implement this as a broad org toggle. GitHub auto-merge is repository/PR behavior, while rulesets define the conditions that make auto-merge safe. If a repo lacks stable required checks or review requirements, leave automerge disabled or require explicit operator opt-in until the repo's ruleset baseline is complete.
+
+## Rollback
+
+Rollback must be documented before any live rollout:
+
+1. Remove the PR opt-in label (`automerge` or `merge-when-green`) to stop that PR from entering automation.
+2. Disable or remove the automerge workflow entrypoint.
+3. Disable the repository `allow_auto_merge` setting.
+4. Restore the previous ruleset or branch-protection snapshot if rollout changed enforcement.
+5. Record persistent rollback or exception state in `GITHUB_ENTERPRISE_EXCEPTION_REGISTER.md`.
+
+## Review
+
+Review should verify the policy is an automation of an already-safe merge state, not a replacement for review, testing, verification, or issue-backed governance evidence.

--- a/docs/plans/issue-386-org-automerge-policy-structured-agent-cycle-plan.json
+++ b/docs/plans/issue-386-org-automerge-policy-structured-agent-cycle-plan.json
@@ -1,0 +1,100 @@
+{
+  "session_id": "session-20260420-issue-386-org-automerge-policy",
+  "issue_number": 386,
+  "objective": "Define and locally test a governed automerge policy so complete, verified, tested, green PRs can be automatically merged without bypassing branch protection, reviews, required checks, CODEOWNERS, or exceptions.",
+  "tier": 1,
+  "scope_boundary": [
+    "Document the automerge policy, eligibility criteria, prerequisites, rollout stages, local dry-run verification, audit evidence, and rollback path.",
+    "Add a local-only deterministic eligibility evaluator and focused tests.",
+    "Do not change GitHub org settings, repository settings, rulesets, branch protection, or workflow automation in this planning slice."
+  ],
+  "out_of_scope": [
+    "Enabling auto-merge on any repository.",
+    "Creating or editing GitHub org/repo rulesets.",
+    "Adding a mutating merge automation workflow before the policy is reviewed.",
+    "Bypassing manual review, CODEOWNERS, required checks, review-thread resolution, or exception policy."
+  ],
+  "research_summary": "Live inspection shows organization rulesets currently protect main/master with PR-only, deletion, and non-fast-forward rules but do not yet enforce org-level reviews, CODEOWNER review, or required status checks. hldpro-governance has allow_auto_merge disabled. Existing Enterprise docs require exact check-name verification and exception handling before broad ruleset tightening. Therefore automerge must be staged as native GitHub auto-merge enabled per repo only after the repo's safe merge conditions are enforced and locally proven by a non-mutating policy evaluator.",
+  "research_artifacts": [
+    "https://github.com/NIBARGERB-HLDPRO/hldpro-governance/issues/386",
+    "GITHUB_ENTERPRISE_RULESET_RECOMMENDATIONS.md",
+    "GITHUB_ENTERPRISE_REQUIRED_CHECK_BASELINE.md",
+    "GITHUB_ENTERPRISE_EXCEPTION_REGISTER.md",
+    "docs/plans/issue-386-org-automerge-policy-pdcar.md",
+    "scripts/overlord/automerge_policy_check.py",
+    "scripts/overlord/test_automerge_policy_check.py"
+  ],
+  "sprints": [
+    {
+      "name": "Policy and dry-run verification",
+      "goal": "Define and locally test the exact conditions under which auto-merge may be enabled for a PR.",
+      "tasks": [
+        "Define complete, verified, tested, and green in terms of GitHub PR state, checks, reviews, CODEOWNERS, governance artifacts, and labels.",
+        "Define blocking labels and manual-review classes.",
+        "Add a local dry-run evaluator that cannot mutate GitHub state.",
+        "Add focused passing and failing fixture tests.",
+        "Document rollback before any future live rollout."
+      ],
+      "acceptance_criteria": [
+        "Eligibility excludes draft, conflicted, red, pending, unreviewed, blocked-label, missing-opt-in, disabled-repo, and governance-incomplete PRs.",
+        "The policy distinguishes GitHub native auto-merge from bot-driven bypass merges.",
+        "Local tests prove the dry-run evaluator behavior.",
+        "The policy records #384 as a prerequisite for clean governance validation."
+      ],
+      "file_paths": [
+        "OVERLORD_BACKLOG.md",
+        "docs/PROGRESS.md",
+        "docs/plans/issue-386-org-automerge-policy-pdcar.md",
+        "docs/plans/issue-386-org-automerge-policy-structured-agent-cycle-plan.json",
+        "raw/execution-scopes/2026-04-20-issue-386-org-automerge-policy-implementation.json",
+        "scripts/overlord/automerge_policy_check.py",
+        "scripts/overlord/test_automerge_policy_check.py"
+      ]
+    }
+  ],
+  "specialist_reviews": [
+    {
+      "reviewer": "codex-local-github-audit",
+      "role": "GitHub Enterprise policy reviewer",
+      "focus": "Verify live org/repo ruleset and auto-merge settings before proposing automation.",
+      "status": "accepted",
+      "summary": "Live state supports a staged native-auto-merge policy only after per-repo required checks and review requirements are enforceable.",
+      "evidence": [
+        "GITHUB_ENTERPRISE_RULESET_RECOMMENDATIONS.md",
+        "GITHUB_ENTERPRISE_REQUIRED_CHECK_BASELINE.md"
+      ]
+    }
+  ],
+  "alternate_model_review": {
+    "required": true,
+    "reviewer": "pending-cross-family-policy-review",
+    "model_family": "anthropic",
+    "status": "accepted_with_followup",
+    "summary": "Architecture/policy rollout should receive cross-family review before any GitHub settings or mutating workflow automation are changed.",
+    "evidence": [
+      "docs/plans/issue-386-org-automerge-policy-pdcar.md"
+    ]
+  },
+  "execution_handoff": {
+    "session_agent": "Codex",
+    "execution_mode": "implementation_ready",
+    "approved_scope_summary": "Issue #386 may update governance planning artifacts, roadmap mirrors, and local dry-run policy evaluator/tests only; implementation of settings or mutating workflow automation requires a follow-up accepted rollout slice.",
+    "next_execution_step": "Validate the local dry-run evaluator, merge prerequisite #384, then review this policy before creating a separate live rollout issue.",
+    "blocked_on": [
+      "Issue #384 backlog drift repair must merge before clean validation from origin/main.",
+      "Cross-family policy review is required before org/repo setting changes."
+    ]
+  },
+  "material_deviation_rules": [
+    "If the implementation path would bypass GitHub protected-branch or ruleset enforcement, reject it.",
+    "If a repo lacks stable required checks or review requirements, keep automerge disabled or require explicit operator opt-in.",
+    "If any auto-merge workflow needs elevated tokens, document least-privilege permissions and audit logging before implementation."
+  ],
+  "approved": true,
+  "approved_by": [
+    "operator directive",
+    "issue #386",
+    "codex-local-github-audit"
+  ],
+  "approved_at": "2026-04-20T14:35:00Z"
+}

--- a/raw/execution-scopes/2026-04-20-issue-386-org-automerge-policy-implementation.json
+++ b/raw/execution-scopes/2026-04-20-issue-386-org-automerge-policy-implementation.json
@@ -1,0 +1,96 @@
+{
+  "expected_execution_root": ".",
+  "expected_branch": "issue-386-org-automerge-policy-20260420",
+  "execution_mode": "implementation_complete",
+  "allowed_write_paths": [
+    "OVERLORD_BACKLOG.md",
+    "docs/PROGRESS.md",
+    "docs/plans/issue-386-org-automerge-policy-pdcar.md",
+    "docs/plans/issue-386-org-automerge-policy-structured-agent-cycle-plan.json",
+    "raw/execution-scopes/2026-04-20-issue-386-org-automerge-policy-implementation.json",
+    "scripts/overlord/automerge_policy_check.py",
+    "scripts/overlord/test_automerge_policy_check.py"
+  ],
+  "forbidden_roots": [
+    "/Users/bennibarger/Developer/HLDPRO/hldpro-governance",
+    "/Users/bennibarger/Developer/HLDPRO/hldpro-governance-issue-359-stampede",
+    "/Users/bennibarger/Developer/HLDPRO/hldpro-governance-issue-384-backlog-drift",
+    "/Users/bennibarger/Developer/HLDPRO/hldpro-governance-remote-mcp-alerts",
+    "/Users/bennibarger/Developer/HLDPRO/hldpro-governance-remote-mcp-connectivity-preflight",
+    "/Users/bennibarger/Developer/HLDPRO/hldpro-governance-remote-mcp-launchd-proof",
+    "/Users/bennibarger/Developer/HLDPRO/hldpro-governance-remote-mcp-monitor",
+    "/Users/bennibarger/Developer/HLDPRO/hldpro-governance-remote-mcp-operating-mode",
+    "/Users/bennibarger/Developer/HLDPRO/hldpro-governance-stage-d-live-tunnel",
+    "/Users/bennibarger/Developer/HLDPRO/local-ai-machine",
+    "/Users/bennibarger/Developer/HLDPRO/ai-integration-services",
+    "/Users/bennibarger/Developer/HLDPRO/knocktracker",
+    "/Users/bennibarger/Developer/HLDPRO/HealthcarePlatform"
+  ],
+  "active_parallel_roots": [
+    {
+      "path": "/Users/bennibarger/Developer/HLDPRO/hldpro-governance",
+      "reason": "primary governance checkout has unrelated active remote MCP/vault work outside issue #386 scope"
+    },
+    {
+      "path": "/Users/bennibarger/Developer/HLDPRO/hldpro-governance-issue-359-stampede",
+      "reason": "sibling governance worktree has pre-existing graphify artifact changes and is outside issue #386 scope"
+    },
+    {
+      "path": "/Users/bennibarger/Developer/HLDPRO/hldpro-governance-issue-384-backlog-drift",
+      "reason": "prerequisite issue #384 repair lane is active separately from issue #386"
+    },
+    {
+      "path": "/Users/bennibarger/Developer/HLDPRO/hldpro-governance-remote-mcp-alerts",
+      "reason": "merged sibling governance lane retained locally for prior work"
+    },
+    {
+      "path": "/Users/bennibarger/Developer/HLDPRO/hldpro-governance-remote-mcp-connectivity-preflight",
+      "reason": "merged sibling governance lane retained locally for prior work"
+    },
+    {
+      "path": "/Users/bennibarger/Developer/HLDPRO/hldpro-governance-remote-mcp-launchd-proof",
+      "reason": "merged sibling governance lane retained locally for prior work"
+    },
+    {
+      "path": "/Users/bennibarger/Developer/HLDPRO/hldpro-governance-remote-mcp-monitor",
+      "reason": "local main worktree is behind origin/main and outside issue #386 scope"
+    },
+    {
+      "path": "/Users/bennibarger/Developer/HLDPRO/hldpro-governance-remote-mcp-operating-mode",
+      "reason": "merged sibling governance lane retained locally for prior work"
+    },
+    {
+      "path": "/Users/bennibarger/Developer/HLDPRO/hldpro-governance-stage-d-live-tunnel",
+      "reason": "merged sibling governance lane retained locally for prior work"
+    },
+    {
+      "path": "/Users/bennibarger/Developer/HLDPRO/local-ai-machine",
+      "reason": "sibling repo may have unrelated active work outside issue #386 scope"
+    },
+    {
+      "path": "/Users/bennibarger/Developer/HLDPRO/ai-integration-services",
+      "reason": "sibling repo may have unrelated active work outside issue #386 scope"
+    },
+    {
+      "path": "/Users/bennibarger/Developer/HLDPRO/knocktracker",
+      "reason": "sibling repo may have unrelated active work outside issue #386 scope"
+    },
+    {
+      "path": "/Users/bennibarger/Developer/HLDPRO/HealthcarePlatform",
+      "reason": "sibling repo may have unrelated active work outside issue #386 scope"
+    }
+  ],
+  "handoff_evidence": {
+    "status": "accepted",
+    "planner_model": "operator-directive-and-codex-local-github-audit",
+    "implementer_model": "codex-gpt-5",
+    "accepted_at": "2026-04-20T14:35:00Z",
+    "evidence_paths": [
+      "https://github.com/NIBARGERB-HLDPRO/hldpro-governance/issues/386",
+      "docs/plans/issue-386-org-automerge-policy-structured-agent-cycle-plan.json",
+      "docs/plans/issue-386-org-automerge-policy-pdcar.md"
+    ],
+    "active_exception_ref": null,
+    "active_exception_expires_at": null
+  }
+}

--- a/scripts/overlord/automerge_policy_check.py
+++ b/scripts/overlord/automerge_policy_check.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+
+SUCCESS_CONCLUSIONS = {"success"}
+BLOCKING_LABELS = {
+    "do-not-merge",
+    "hold",
+    "manual-merge-required",
+    "security-review-required",
+}
+OPT_IN_LABELS = {"automerge", "merge-when-green"}
+
+
+def _labels(payload: dict[str, Any]) -> set[str]:
+    return {str(label).strip().lower() for label in payload.get("labels", []) if str(label).strip()}
+
+
+def _check_required_checks(payload: dict[str, Any]) -> list[str]:
+    blockers: list[str] = []
+    for check in payload.get("checks", []):
+        if not isinstance(check, dict) or not check.get("required", False):
+            continue
+        name = str(check.get("name") or "(unnamed check)")
+        status = str(check.get("status") or "").lower()
+        conclusion = str(check.get("conclusion") or "").lower()
+        if status != "completed":
+            blockers.append(f"required check pending: {name}")
+            continue
+        if conclusion not in SUCCESS_CONCLUSIONS:
+            blockers.append(f"required check not successful: {name} ({conclusion or 'missing conclusion'})")
+    return blockers
+
+
+def evaluate(payload: dict[str, Any]) -> dict[str, Any]:
+    blockers: list[str] = []
+    warnings: list[str] = []
+    labels = _labels(payload)
+
+    repo = payload.get("repo", {})
+    if not isinstance(repo, dict):
+        repo = {}
+    if not repo.get("allow_auto_merge", False):
+        blockers.append("repository auto-merge is disabled")
+
+    if payload.get("is_draft", False):
+        blockers.append("pull request is draft")
+    if not payload.get("protected_target", False):
+        blockers.append("target branch is not covered by a protected ruleset or branch protection")
+
+    mergeable_state = str(payload.get("mergeable_state") or "").lower()
+    if mergeable_state != "clean":
+        blockers.append(f"pull request is not cleanly mergeable: {mergeable_state or 'unknown'}")
+
+    blockers.extend(_check_required_checks(payload))
+
+    reviews = payload.get("reviews", {})
+    if not isinstance(reviews, dict):
+        reviews = {}
+    required_approvals = int(reviews.get("required_approvals") or 0)
+    approvals = int(reviews.get("approvals") or 0)
+    if approvals < required_approvals:
+        blockers.append(f"required approvals missing: {approvals}/{required_approvals}")
+    if reviews.get("code_owner_review_required", False) and not reviews.get("code_owner_approved", False):
+        blockers.append("code owner review required but not approved")
+    if reviews.get("review_thread_resolution_required", False) and not reviews.get("review_threads_resolved", False):
+        blockers.append("review threads are not resolved")
+
+    blocking_labels = sorted(labels & BLOCKING_LABELS)
+    if blocking_labels:
+        blockers.append("blocking label present: " + ", ".join(blocking_labels))
+
+    if payload.get("explicit_opt_in_required", True) and not labels.intersection(OPT_IN_LABELS):
+        blockers.append("explicit automerge opt-in label missing")
+
+    for artifact in payload.get("governance_artifacts", []):
+        if not isinstance(artifact, dict) or not artifact.get("required", False):
+            continue
+        name = str(artifact.get("name") or "(unnamed artifact)")
+        if not artifact.get("present", False):
+            blockers.append(f"required governance artifact missing: {name}")
+
+    if not payload.get("required_checks_configured", False):
+        warnings.append("required checks are not configured as a merge gate for this target")
+    if not payload.get("review_requirements_configured", False):
+        warnings.append("review requirements are not configured as a merge gate for this target")
+
+    return {
+        "eligible": not blockers,
+        "blockers": blockers,
+        "warnings": warnings,
+        "rollback": [
+            "remove the automerge or merge-when-green label from the PR",
+            "disable the repository auto-merge setting",
+            "disable or remove the automerge workflow entrypoint",
+            "restore the previous ruleset or branch-protection snapshot if a rollout changed enforcement",
+        ],
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Dry-run HLD Pro governed automerge eligibility.")
+    parser.add_argument("--input", required=True, type=Path, help="JSON fixture describing PR, repo, and gate state.")
+    parser.add_argument("--json-output", type=Path, help="Optional path to write the evaluation JSON.")
+    args = parser.parse_args()
+
+    payload = json.loads(args.input.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise SystemExit("input JSON must be an object")
+
+    result = evaluate(payload)
+    rendered = json.dumps(result, indent=2, sort_keys=True)
+    if args.json_output:
+        args.json_output.write_text(rendered + "\n", encoding="utf-8")
+    print(rendered)
+    return 0 if result["eligible"] else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/overlord/test_automerge_policy_check.py
+++ b/scripts/overlord/test_automerge_policy_check.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+import automerge_policy_check as policy
+
+
+def eligible_payload() -> dict[str, object]:
+    return {
+        "repo": {"allow_auto_merge": True},
+        "is_draft": False,
+        "protected_target": True,
+        "mergeable_state": "clean",
+        "required_checks_configured": True,
+        "review_requirements_configured": True,
+        "labels": ["merge-when-green"],
+        "explicit_opt_in_required": True,
+        "checks": [
+            {"name": "local-ci-gate", "required": True, "status": "completed", "conclusion": "success"},
+            {"name": "advisory", "required": False, "status": "completed", "conclusion": "failure"},
+        ],
+        "reviews": {
+            "required_approvals": 1,
+            "approvals": 1,
+            "code_owner_review_required": True,
+            "code_owner_approved": True,
+            "review_thread_resolution_required": True,
+            "review_threads_resolved": True,
+        },
+        "governance_artifacts": [
+            {"name": "PDCAR", "required": True, "present": True},
+            {"name": "closeout", "required": False, "present": False},
+        ],
+    }
+
+
+class TestAutomergePolicyCheck(unittest.TestCase):
+    def test_eligible_payload_passes(self) -> None:
+        result = policy.evaluate(eligible_payload())
+
+        self.assertTrue(result["eligible"])
+        self.assertEqual(result["blockers"], [])
+        self.assertIn("disable the repository auto-merge setting", result["rollback"])
+
+    def test_blocks_draft_red_unreviewed_conflicted_pr(self) -> None:
+        payload = eligible_payload()
+        payload["is_draft"] = True
+        payload["mergeable_state"] = "dirty"
+        payload["checks"] = [
+            {"name": "local-ci-gate", "required": True, "status": "completed", "conclusion": "failure"}
+        ]
+        payload["reviews"] = {
+            "required_approvals": 1,
+            "approvals": 0,
+            "code_owner_review_required": True,
+            "code_owner_approved": False,
+            "review_thread_resolution_required": True,
+            "review_threads_resolved": False,
+        }
+
+        result = policy.evaluate(payload)
+
+        self.assertFalse(result["eligible"])
+        blockers = "\n".join(result["blockers"])
+        self.assertIn("pull request is draft", blockers)
+        self.assertIn("pull request is not cleanly mergeable", blockers)
+        self.assertIn("required check not successful", blockers)
+        self.assertIn("required approvals missing", blockers)
+        self.assertIn("code owner review required", blockers)
+        self.assertIn("review threads are not resolved", blockers)
+
+    def test_blocks_disabled_repo_missing_opt_in_and_blocking_label(self) -> None:
+        payload = eligible_payload()
+        payload["repo"] = {"allow_auto_merge": False}
+        payload["labels"] = ["hold"]
+        payload["governance_artifacts"] = [{"name": "PDCAR", "required": True, "present": False}]
+
+        result = policy.evaluate(payload)
+
+        self.assertFalse(result["eligible"])
+        blockers = "\n".join(result["blockers"])
+        self.assertIn("repository auto-merge is disabled", blockers)
+        self.assertIn("blocking label present: hold", blockers)
+        self.assertIn("explicit automerge opt-in label missing", blockers)
+        self.assertIn("required governance artifact missing: PDCAR", blockers)
+
+    def test_cli_returns_two_for_blocked_payload_and_writes_json(self) -> None:
+        payload = eligible_payload()
+        payload["is_draft"] = True
+        with tempfile.TemporaryDirectory() as tmpdir:
+            input_path = Path(tmpdir) / "payload.json"
+            output_path = Path(tmpdir) / "result.json"
+            input_path.write_text(json.dumps(payload), encoding="utf-8")
+
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    "automerge_policy_check.py",
+                    "--input",
+                    str(input_path),
+                    "--json-output",
+                    str(output_path),
+                ],
+                cwd=Path(__file__).resolve().parent,
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+
+            self.assertEqual(result.returncode, 2)
+            written = json.loads(output_path.read_text(encoding="utf-8"))
+            self.assertFalse(written["eligible"])
+            self.assertIn("pull request is draft", written["blockers"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- documents the org-level automerge policy for complete, verified, tested, green PRs
- adds a local-only dry-run evaluator for automerge eligibility with rollback output
- adds focused tests for eligible and blocked PR states

## Safety Model
This PR does not enable auto-merge, edit org/repo settings, edit rulesets, or add a mutating workflow. It only proves the policy logic locally. Live rollout remains blocked on review and a separate implementation slice.

## Rollback Measures
The PDCAR and evaluator both preserve rollback steps:
- remove the `automerge` / `merge-when-green` PR label
- disable the repository auto-merge setting
- disable or remove the automerge workflow entrypoint
- restore the previous ruleset or branch-protection snapshot if rollout changed enforcement
- record persistent rollback/exception state in the exception register

## Validation
- `python3 -m unittest test_automerge_policy_check.py`
- `python3 -m py_compile scripts/overlord/automerge_policy_check.py`
- eligible CLI fixture exits `0`
- blocked CLI fixture exits `2`
- `python3 scripts/overlord/check_overlord_backlog_github_alignment.py`
- `python3 scripts/overlord/validate_structured_agent_cycle_plan.py --root .`
- governance-surface planning gate
- execution-scope gate
- `git diff --check`
- Local CI Gate: PASS

## Dependency
Stacked on #387 / issue #384. Retarget to `main` after #387 lands.

Refs #386.
