### PR TITLE
feat(governance): harden consumer verifier edge cases

### DIFF
--- a/OVERLORD_BACKLOG.md
+++ b/OVERLORD_BACKLOG.md
@@ -19,6 +19,7 @@
 
 | Item | Issue | Priority | Est. Hours | Notes |
 |------|-------|----------|-----------|-------|
+| Governance SSOT consumer verifier edge-case hardening | [#474](https://github.com/NIBARGERB-HLDPRO/hldpro-governance/issues/474) | HIGH | 1-2 | Port useful duplicate issue #454 verifier QA deltas into the merged v0.2 verifier without regressing the v0.2 contract. |
 
 ## Done
 

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -10,6 +10,7 @@
 
 | Plan | Issue | Status | Priority | Est. Hours | Deliverables | Notes |
 |------|-------|--------|----------|------------|--------------|-------|
+| Governance SSOT consumer verifier edge-case hardening | #474 | IN PROGRESS | HIGH | 1-2 | Workflow-ref mismatch checks, strict override metadata validation, forbidden override class checks, focused tests | Follow-up to duplicate issue #454 branch comparison |
 | Consumer-pulled governance adoption rollout | #403 | DONE | MEDIUM | 4-6 | Knocktracker pilot merged through downstream PRs #178 and #179; governance PR #406 records evidence | Uses knocktracker #177 as the first repo-side consumer-pull pilot |
 | Codex-spark refinement pass on Stage 3b MCP tools + Stage 4 validator | #177 | PLANNED | LOW-MEDIUM | 2-3 | Codex review findings, follow-up issues | Gate: live-fallback rate < 2% confirmed |
 | Qwen-Coder MLX driver stub-emission bug | #105 | PLANNED | LOW | 1-2 | MLX driver patch or workaround | Workarounds in docs/runbooks/qwen-coder-driver.md |

--- a/docs/plans/issue-474-structured-agent-cycle-plan.json
+++ b/docs/plans/issue-474-structured-agent-cycle-plan.json
@@ -1,0 +1,112 @@
+{
+  "session_id": "session-20260421-issue-474-verifier-hardening",
+  "issue_number": 474,
+  "objective": "Port the useful QA hardening from duplicate issue #454 verifier work into the merged v0.2 SSOT consumer verifier without regressing the merged package-v2 contract.",
+  "tier": 1,
+  "scope_boundary": [
+    "Governance repository only.",
+    "Keep origin/main issue #454 verifier implementation as the base.",
+    "Port workflow-ref, override metadata, forbidden override, and focused test hardening from the duplicate branch.",
+    "Preserve observed_overrides and v0.2 profile/local_overrides behavior."
+  ],
+  "out_of_scope": [
+    "Downstream consumer repo edits.",
+    "Changing governance package manifest semantics.",
+    "Replacing the deployer or consumer record schema.",
+    "Cleaning stale duplicate branches before the follow-up PR lands."
+  ],
+  "research_summary": "The duplicate issue-454 branch had stronger edge-case tests, but origin/main has the broader v0.2 verifier contract. This plan keeps origin/main as the base and ports the duplicate branch deltas that improve exact workflow SHA enforcement and override validation.",
+  "research_artifacts": [
+    "https://github.com/NIBARGERB-HLDPRO/hldpro-governance/issues/454",
+    "https://github.com/NIBARGERB-HLDPRO/hldpro-governance/issues/474",
+    "scripts/overlord/verify_governance_consumer.py",
+    "scripts/overlord/test_verify_governance_consumer.py",
+    "issue-454-ssot-verifier",
+    "origin/main"
+  ],
+  "sprints": [
+    {
+      "name": "Verifier hardening merge",
+      "goal": "Combine the duplicate branch's useful QA hardening into the merged v0.2 verifier.",
+      "tasks": [
+        "Add exact reusable workflow SHA mismatch checks against consumer governance_ref.",
+        "Require override metadata values to be non-empty strings.",
+        "Add forbidden override pattern checks for protected governance classes.",
+        "Add focused regression tests for workflow refs, override value validation, and forbidden override classes.",
+        "Record validation evidence and run deterministic gates."
+      ],
+      "acceptance_criteria": [
+        "Verifier rejects mutable workflow refs, tags, short SHAs, and valid SHA refs that differ from the consumer record governance_ref.",
+        "Verifier rejects override metadata fields that are missing, empty, or non-string.",
+        "Verifier rejects forbidden override reasons for protected HIPAA/PII/lane, plan-mode, LAM, package-core, CI gate, and dry-run evidence classes.",
+        "Merged v0.2 profile/local_overrides support remains intact.",
+        "Focused tests and Local CI Gate pass."
+      ],
+      "file_paths": [
+        "scripts/overlord/verify_governance_consumer.py",
+        "scripts/overlord/test_verify_governance_consumer.py",
+        "docs/plans/issue-474-verifier-hardening-pdcar.md",
+        "docs/plans/issue-474-structured-agent-cycle-plan.json",
+        "raw/execution-scopes/2026-04-21-issue-474-verifier-hardening-implementation.json",
+        "raw/handoffs/2026-04-21-issue-474-plan-to-implementation.json",
+        "raw/validation/2026-04-21-issue-474-verifier-hardening.md"
+      ]
+    }
+  ],
+  "specialist_reviews": [
+    {
+      "reviewer": "Codex QA",
+      "role": "qa",
+      "focus": "Duplicate branch comparison, verifier compatibility, and regression coverage.",
+      "status": "accepted",
+      "summary": "QA verified that the merged v0.2 contract remains the base and only non-conflicting duplicate hardening deltas are ported.",
+      "evidence": [
+        "raw/validation/2026-04-21-issue-474-verifier-hardening.md"
+      ]
+    }
+  ],
+  "alternate_model_review": {
+    "required": true,
+    "reviewer": "Codex QA",
+    "model_family": "openai",
+    "status": "accepted",
+    "summary": "Focused QA review accepted the branch-comparison decision and ported hardening tests.",
+    "evidence": [
+      "raw/validation/2026-04-21-issue-474-verifier-hardening.md"
+    ]
+  },
+  "execution_handoff": {
+    "session_agent": "Codex orchestrator",
+    "execution_mode": "implementation_ready",
+    "approved_scope_summary": "Implement issue #474 verifier hardening by porting useful duplicate branch checks into the merged v0.2 verifier.",
+    "next_execution_step": "Apply bounded verifier and test changes, then run focused validation and Local CI Gate.",
+    "blocked_on": [],
+    "handoff_package_ref": "raw/handoffs/2026-04-21-issue-474-plan-to-implementation.json",
+    "execution_scope_ref": "raw/execution-scopes/2026-04-21-issue-474-verifier-hardening-implementation.json",
+    "packet_ref": null,
+    "package_manifest_ref": null,
+    "validation_artifact_refs": [
+      "raw/validation/2026-04-21-issue-474-verifier-hardening.md"
+    ],
+    "review_artifact_refs": [],
+    "gate_artifact_refs": [],
+    "closeout_ref": null,
+    "next_role": "codex-qa",
+    "qa_gate_required": true,
+    "handoff_acceptance_criteria": [
+      "Only useful duplicate branch hardening deltas are ported.",
+      "Verifier output contract remains compatible with origin/main.",
+      "Local CI Gate passes before merge."
+    ]
+  },
+  "material_deviation_rules": [
+    "If duplicate branch behavior conflicts with origin/main v0.2 support, keep origin/main behavior.",
+    "If downstream consumer issues are discovered, record follow-up issues instead of editing downstream repos."
+  ],
+  "approved": true,
+  "approved_by": [
+    "operator instruction: compare duplicate branches and combine better code",
+    "Codex orchestrator"
+  ],
+  "approved_at": "2026-04-21T13:20:00-05:00"
+}

--- a/docs/plans/issue-474-verifier-hardening-pdcar.md
+++ b/docs/plans/issue-474-verifier-hardening-pdcar.md
@@ -1,0 +1,25 @@
+# Issue 474 PDCAR: SSOT Consumer Verifier Hardening
+
+## Plan
+
+Compare the duplicate `issue-454-ssot-verifier` branch with the merged issue #454 implementation on `origin/main`. Keep the merged v0.2 verifier as the base because it includes the broader package-v2 profile contract, managed-file checksum, `local_overrides`, and consumer-record compatibility work. Port only the duplicate branch hardening deltas that increase verifier coverage without regressing the merged contract.
+
+## Do
+
+- Harden reusable workflow reference checks so tags, short SHAs, and valid-but-mismatched SHAs fail.
+- Tighten override metadata validation so required fields must be non-empty strings.
+- Add forbidden override classes for HIPAA/PHI/PII/lane weakening, plan-mode disabling, LAM PII routing, package-core forks, CI-required gate disabling, and dry-run-as-live evidence.
+- Preserve the merged verifier output contract, including `observed_overrides`.
+- Add focused regression tests for the ported edge cases.
+
+## Check
+
+- Focused verifier unit tests.
+- Package deployer plus verifier unit suite.
+- Python compile check.
+- Structured plan, handoff package, and execution-scope validation.
+- Local CI Gate for `hldpro-governance`.
+
+## Adjust
+
+If the duplicate branch contains behavior that conflicts with the merged v0.2 contract, defer to `origin/main` and record the skipped behavior rather than reintroducing the narrower duplicate shape.

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,12 +1,12 @@
 # Graph Report - .  (2026-04-21)
 
 ## Corpus Check
-- 118 files · ~0 words
+- 120 files · ~0 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 1549 nodes · 3135 edges · 78 communities detected
-- Extraction: 48% EXTRACTED · 52% INFERRED · 0% AMBIGUOUS · INFERRED: 1643 edges (avg confidence: 0.5)
+- 1615 nodes · 3340 edges · 78 communities detected
+- Extraction: 47% EXTRACTED · 53% INFERRED · 0% AMBIGUOUS · INFERRED: 1784 edges (avg confidence: 0.5)
 - Token cost: 0 input · 0 output
 
 ## God Nodes (most connected - your core abstractions)
@@ -14,12 +14,12 @@
 2. `PiiDetectionError` - 44 edges
 3. `ModelNotAllowedError` - 44 edges
 4. `EndpointUnreachableError` - 44 edges
-5. `TestAssertExecutionScope` - 34 edges
-6. `_tier1_packet()` - 31 edges
-7. `RepoFixture` - 30 edges
-8. `AuditWriter` - 28 edges
-9. `TestGovernanceSurfacePlanGate` - 24 edges
-10. `TestLocalCiGate` - 22 edges
+5. `TestVerifyGovernanceConsumer` - 40 edges
+6. `TestAssertExecutionScope` - 34 edges
+7. `_tier1_packet()` - 31 edges
+8. `RepoFixture` - 30 edges
+9. `AuditWriter` - 28 edges
+10. `TestGovernanceSurfacePlanGate` - 24 edges
 
 ## Surprising Connections (you probably didn't know these)
 - `ValidateLocationTests` --uses--> `Finding`  [INFERRED]
@@ -44,116 +44,116 @@ Cohesion: 0.05
 Nodes (25): _dispatch_packet(), _make_parent_packet(), Cross-family independence violated: both planners are anthropic., anthropic + openai is fine., Parent file absent → warn, don't refuse., Sanity: the patterns file should be present in this worktree., Non-LAM role with PII artifact path must be refused., worker-lam role is allowed to handle PII artifacts. (+17 more)
 
 ### Community 2 - "Community 2"
-Cohesion: 0.06
-Nodes (24): BaseHTTPRequestHandler, build_parser(), build_payload(), _call_fixture(), _call_live(), Check, _fixture_server(), _FixtureMcpHandler (+16 more)
-
-### Community 3 - "Community 3"
 Cohesion: 0.05
 Nodes (47): Modify first_hash in manifest and verify fails., Test that truncated file (missing last line) breaks manifest., Delete last line and verify detects entry_count mismatch., Test that duplicate line (replay) breaks seq monotonicity., Duplicate a line and verify detects non-monotonic seq., Test that tampering with a line breaks the chain., Tamper with line N and verify fails at line N+1., Test that replacing entry_hmac with wrong value fails verification. (+39 more)
 
+### Community 3 - "Community 3"
+Cohesion: 0.06
+Nodes (23): BaseHTTPRequestHandler, build_parser(), build_payload(), _call_fixture(), _call_live(), Check, _fixture_server(), _FixtureMcpHandler (+15 more)
+
 ### Community 4 - "Community 4"
+Cohesion: 0.11
+Nodes (39): add_common_args(), apply(), _build_local_ci_plan(), build_plan(), _consumer_record(), _consumer_record_relpath(), _ensure_relative_to(), _fail() (+31 more)
+
+### Community 5 - "Community 5"
 Cohesion: 0.06
 Nodes (20): ABC, BaseAggregator, ArtifactWriter, RunManifest, BaseAggregator, BaseModel, SimulationEngine, PersonaLoader (+12 more)
 
-### Community 5 - "Community 5"
+### Community 6 - "Community 6"
 Cohesion: 0.09
 Nodes (39): _expand_home(), governed_repos(), GovernedRepo, load_registry(), repo_names_enabled_for(), repos_enabled_for(), repos_root(), build_payload() (+31 more)
 
-### Community 6 - "Community 6"
+### Community 7 - "Community 7"
 Cohesion: 0.1
 Nodes (34): append_fail_fast_block_entry(), append_fail_fast_candidate(), append_fail_fast_table_entry(), append_progress_candidate(), bounded_text(), build_parser(), build_review_context(), build_schema_file() (+26 more)
 
-### Community 7 - "Community 7"
+### Community 8 - "Community 8"
+Cohesion: 0.2
+Nodes (1): TestVerifyGovernanceConsumer
+
+### Community 9 - "Community 9"
 Cohesion: 0.2
 Nodes (4): _git(), RepoFixture, TestAssertExecutionScope, _working_directory()
 
-### Community 8 - "Community 8"
+### Community 10 - "Community 10"
+Cohesion: 0.12
+Nodes (20): append_audit(), _audit_path(), ensure_queue(), load_packet(), _load_plan(), QueueDecision, Replay audit events into logical latest states.      `latest_states` includes ac, replay_audit() (+12 more)
+
+### Community 11 - "Community 11"
 Cohesion: 0.12
 Nodes (38): _branch_issue_number(), build_argument_parser(), _build_summary(), _changed_files_from_git(), ChangedFiles, _check_exit_code(), _check_matches_changed_files(), CheckResult (+30 more)
 
-### Community 9 - "Community 9"
+### Community 12 - "Community 12"
 Cohesion: 0.11
 Nodes (33): _branch_issue_number(), _changed_paths(), _changed_paths_from_file(), check_scope(), _current_branch(), ExecutionScope, _format_path(), _git_root() (+25 more)
 
-### Community 10 - "Community 10"
-Cohesion: 0.13
-Nodes (23): _json(), TestValidateCloseout, _write(), build_parser(), _extract_repo_refs(), _load_json(), main(), _repo_rel() (+15 more)
-
-### Community 11 - "Community 11"
-Cohesion: 0.11
-Nodes (22): build_parser(), _env_has_live_markers(), main(), _run_fixture(), _run_live(), _scan_evidence_dir(), _stage_d_args(), _build_fixture_server() (+14 more)
-
-### Community 12 - "Community 12"
-Cohesion: 0.15
-Nodes (26): atomic_write_yaml(), build_report(), _date_from_text(), duplicate_counts(), enrich_packet(), _entry_id(), LearningEntry, LearningMatch (+18 more)
-
 ### Community 13 - "Community 13"
 Cohesion: 0.12
-Nodes (28): _load(), test_duplicate_reply_cannot_produce_instruction(), test_expired_reply_cannot_produce_instruction(), test_low_confidence_clarify_decision_passes_without_instruction(), test_low_confidence_non_clarify_decision_fails_closed(), test_pii_external_channel_fails_closed(), test_response_requires_notification_and_response_ids(), test_session_instruction_requires_matching_target_session() (+20 more)
+Nodes (35): build_parser(), _consumer_record_relpath(), ConsumerRecord, ConsumerVerifyError, _expected_checksum(), _expected_managed_paths(), _fail(), _forbidden_override_failures() (+27 more)
 
 ### Community 14 - "Community 14"
 Cohesion: 0.13
-Nodes (19): add_common_args(), build_plan(), build_refresh_command(), execute_refresh(), find_target(), git_hook_paths(), HelperError, HookPlan (+11 more)
+Nodes (23): _json(), TestValidateCloseout, _write(), build_parser(), _extract_repo_refs(), _load_json(), main(), _repo_rel() (+15 more)
 
 ### Community 15 - "Community 15"
+Cohesion: 0.15
+Nodes (26): atomic_write_yaml(), build_report(), _date_from_text(), duplicate_counts(), enrich_packet(), _entry_id(), LearningEntry, LearningMatch (+18 more)
+
+### Community 16 - "Community 16"
+Cohesion: 0.13
+Nodes (19): add_common_args(), build_plan(), build_refresh_command(), execute_refresh(), find_target(), git_hook_paths(), HelperError, HookPlan (+11 more)
+
+### Community 17 - "Community 17"
+Cohesion: 0.12
+Nodes (28): _load(), test_duplicate_reply_cannot_produce_instruction(), test_expired_reply_cannot_produce_instruction(), test_low_confidence_clarify_decision_passes_without_instruction(), test_low_confidence_non_clarify_decision_fails_closed(), test_pii_external_channel_fails_closed(), test_response_requires_notification_and_response_ids(), test_session_instruction_requires_matching_target_session() (+20 more)
+
+### Community 18 - "Community 18"
 Cohesion: 0.1
 Nodes (30): _find_packet_file(), _load_packet(), load_pii_patterns(), _load_schema(), Load and compile PII patterns from pii-patterns.yml., Enforce cross-family independence for tier-1 dual-planner packets.      When pri, Refuse if any consecutive pair in the parent chain shares model_id across differ, Enforce expected handoff sequence with no tier jumps. (+22 more)
 
-### Community 16 - "Community 16"
+### Community 19 - "Community 19"
+Cohesion: 0.13
+Nodes (22): build_parser(), _env_has_live_markers(), main(), _run_fixture(), _run_live(), _scan_evidence_dir(), _stage_d_args(), _build_fixture_server() (+14 more)
+
+### Community 20 - "Community 20"
 Cohesion: 0.19
 Nodes (28): append_audit(), atomic_write_json(), _base_packet(), _build_decision_packet(), _build_instruction_packet(), build_request(), _build_response_packet(), _build_resume_packet() (+20 more)
 
-### Community 17 - "Community 17"
+### Community 21 - "Community 21"
 Cohesion: 0.16
 Nodes (28): aggregate_file_scores(), augment_workflow_doc_candidates(), baseline_results(), build_summary(), build_trace(), emit_usage_events(), estimate_tokens(), evaluate_relevance() (+20 more)
 
-### Community 18 - "Community 18"
-Cohesion: 0.18
-Nodes (24): add_common_args(), apply(), _build_local_ci_plan(), build_plan(), _consumer_record(), _consumer_record_relpath(), _ensure_relative_to(), _fail() (+16 more)
-
-### Community 19 - "Community 19"
+### Community 22 - "Community 22"
 Cohesion: 0.11
 Nodes (14): _all_executable_lines(), _all_run_commands(), check_contract(), _contains_main_branch(), _executable_lines(), _failures_for_text(), _has_executable_line_starting_with(), _load_workflow() (+6 more)
 
-### Community 20 - "Community 20"
+### Community 23 - "Community 23"
 Cohesion: 0.15
 Nodes (2): _plan(), TestGovernanceSurfacePlanGate
 
-### Community 21 - "Community 21"
+### Community 24 - "Community 24"
 Cohesion: 0.09
 Nodes (1): TestLocalCiGate
 
-### Community 22 - "Community 22"
+### Community 25 - "Community 25"
 Cohesion: 0.15
 Nodes (11): apply_policy(), classifier_match(), _contains_term(), decide(), deterministic_match(), GateDecision, _load_classifier(), load_rules() (+3 more)
 
-### Community 23 - "Community 23"
+### Community 26 - "Community 26"
 Cohesion: 0.19
 Nodes (21): build(), category_for(), describe_file(), esc(), FileInfo, first_comment(), first_heading(), frontmatter_field() (+13 more)
 
-### Community 24 - "Community 24"
-Cohesion: 0.2
-Nodes (18): append_audit(), _audit_path(), ensure_queue(), load_packet(), _load_plan(), QueueDecision, Replay audit events into logical latest states.      `latest_states` includes ac, replay_audit() (+10 more)
-
-### Community 25 - "Community 25"
+### Community 27 - "Community 27"
 Cohesion: 0.21
 Nodes (12): _actual_workflows(), check_inventory(), _command_file_candidates(), _load_inventory(), main(), _normalize_path(), _validate_coverage(), _validate_required_snippets() (+4 more)
 
-### Community 26 - "Community 26"
-Cohesion: 0.2
-Nodes (20): build_parser(), _consumer_record_relpath(), ConsumerRecord, ConsumerVerifyError, _expected_managed_paths(), _fail(), _git_root(), _initial_package_version() (+12 more)
-
-### Community 27 - "Community 27"
+### Community 28 - "Community 28"
 Cohesion: 0.32
 Nodes (1): TestDeployGovernanceTooling
 
-### Community 28 - "Community 28"
+### Community 29 - "Community 29"
 Cohesion: 0.14
 Nodes (10): check_github_issue_open(), collect_section_lines(), fail(), issue_column_index(), issue_numbers(), main(), parse_markdown_row(), validate_section() (+2 more)
-
-### Community 29 - "Community 29"
-Cohesion: 0.29
-Nodes (2): _packet(), TestPacketQueue
 
 ### Community 30 - "Community 30"
 Cohesion: 0.36
@@ -161,19 +161,19 @@ Nodes (6): _handoff(), _plan(), _scope(), TestValidateHandoffPackage, _write_jso
 
 ### Community 31 - "Community 31"
 Cohesion: 0.27
-Nodes (14): add_common_args(), build_plan(), _common_preview_payload(), DeployError, DeployPlan, _existing_shim_state(), _fail(), _is_relative_to() (+6 more)
-
-### Community 32 - "Community 32"
-Cohesion: 0.27
 Nodes (1): TestDeployLocalCIGate
 
-### Community 33 - "Community 33"
+### Community 32 - "Community 32"
 Cohesion: 0.23
 Nodes (10): build_parser(), build_payload(), _call_fixture(), _call_live(), Check, _fixture_request(), _latest_live_instruction(), main() (+2 more)
 
-### Community 34 - "Community 34"
+### Community 33 - "Community 33"
 Cohesion: 0.28
 Nodes (14): compare_inventory(), _default_branch_name(), _inventory_rows_from_payload(), InventoryDrift, load_inventory_file(), _load_json(), load_live_inventory(), main() (+6 more)
+
+### Community 34 - "Community 34"
+Cohesion: 0.23
+Nodes (12): backlog_issues(), build_summary(), collect_active_issue_refs(), current_repo_slug(), fail(), gh_json(), IssueRef, main() (+4 more)
 
 ### Community 35 - "Community 35"
 Cohesion: 0.38
@@ -184,100 +184,100 @@ Cohesion: 0.23
 Nodes (14): build_alert(), build_parser(), _contains_sensitive(), _load_payload(), main(), _now(), render_markdown(), _safe_text() (+6 more)
 
 ### Community 37 - "Community 37"
-Cohesion: 0.23
-Nodes (12): backlog_issues(), build_summary(), collect_active_issue_refs(), current_repo_slug(), fail(), gh_json(), IssueRef, main() (+4 more)
-
-### Community 38 - "Community 38"
 Cohesion: 0.14
 Nodes (2): FakeResponse, TestRuntimeInventory
 
-### Community 39 - "Community 39"
-Cohesion: 0.3
-Nodes (1): TestVerifyGovernanceConsumer
-
-### Community 40 - "Community 40"
+### Community 38 - "Community 38"
 Cohesion: 0.26
 Nodes (1): GovernedReposValidationTests
 
-### Community 41 - "Community 41"
+### Community 39 - "Community 39"
 Cohesion: 0.31
 Nodes (13): _branch_issue_number(), _display_path(), _find_plan_files(), _is_governance_surface(), _load_json_safe(), main(), _matching_execution_scopes(), _matching_plan_payloads() (+5 more)
 
-### Community 42 - "Community 42"
+### Community 40 - "Community 40"
 Cohesion: 0.19
 Nodes (8): build_governance(), emit_dispatch_packet(), emit_packet(), main(), Emit a dispatch-ready packet that includes a complete governance block., Emit a minimal or dispatch-ready packet YAML file. Returns path to written file., Build a governance block dict for inclusion in a dispatch-ready packet., TestPacketEmitter
 
-### Community 43 - "Community 43"
-Cohesion: 0.42
-Nodes (12): _registry(), _repo(), _run(), test_execute_runs_tracked_runner(), test_fresh_report_does_not_trigger(), test_markdown_records_same_source_root_for_dashboard_consumers(), test_missing_report_skips_with_missing_token(), test_missing_runner_is_explicit_when_token_exists() (+4 more)
-
-### Community 44 - "Community 44"
+### Community 41 - "Community 41"
 Cohesion: 0.51
 Nodes (1): TestOrgRepoInventory
 
-### Community 45 - "Community 45"
+### Community 42 - "Community 42"
+Cohesion: 0.42
+Nodes (12): _registry(), _repo(), _run(), test_execute_runs_tracked_runner(), test_fresh_report_does_not_trigger(), test_markdown_records_same_source_root_for_dashboard_consumers(), test_missing_report_skips_with_missing_token(), test_missing_runner_is_explicit_when_token_exists() (+4 more)
+
+### Community 43 - "Community 43"
 Cohesion: 0.29
 Nodes (12): check(), main(), Exercise vault discovery from sibling governance worktrees., Exercise vault discovery from HLDPRO/var/worktrees/* governance worktrees., Exercise Seek/Ponder bootstrap aliases without leaking synthetic values., Exercise Stampede bootstrap with production Tradier mapping and redaction., Exercise lam bootstrap with command-like vault values and missing optional keys., run_nested_var_worktree_lam_bootstrap() (+4 more)
 
-### Community 46 - "Community 46"
+### Community 44 - "Community 44"
 Cohesion: 0.32
 Nodes (11): append_jsonl(), AttemptResult, build_command(), event_paths(), kill_group(), main(), parse_args(), session_id() (+3 more)
 
-### Community 47 - "Community 47"
+### Community 45 - "Community 45"
 Cohesion: 0.27
 Nodes (6): _check_required_checks(), evaluate(), _labels(), main(), eligible_payload(), TestAutomergePolicyCheck
 
-### Community 48 - "Community 48"
+### Community 46 - "Community 46"
+Cohesion: 0.3
+Nodes (2): run_helper(), TestLaneBootstrap
+
+### Community 47 - "Community 47"
 Cohesion: 0.38
 Nodes (10): build_graph(), _community_label(), _derive_path_phrase(), _derive_path_tokens(), infer_community_labels(), main(), _normalize_phrase(), _sanitize_markdown_artifacts() (+2 more)
+
+### Community 48 - "Community 48"
+Cohesion: 0.45
+Nodes (10): _process(), _request(), test_ambiguous_response_produces_clarification_and_no_instruction(), test_expired_response_fails_closed_to_dead_letter(), test_invalid_packet_lands_in_dead_letter_with_validation_errors(), test_local_cli_checkpoint_fixture_creates_valid_hitl_request(), test_replay_reconstructs_decision_path(), test_request_changes_response_preserves_feedback_path_without_approval() (+2 more)
 
 ### Community 49 - "Community 49"
 Cohesion: 0.45
 Nodes (10): _payload(), _run_hook(), test_hook_allows_read_even_when_text_matches_owned_work(), test_hook_blocks_agent_owned_work_before_file_path_logic(), test_hook_blocks_task_tool_owned_work(), test_hook_bypass_allows_and_logs(), test_hook_configured_mcp_endpoint_fails_open_on_unavailable_gate(), test_hook_preserves_new_code_file_block_for_common_extensions() (+2 more)
 
 ### Community 50 - "Community 50"
-Cohesion: 0.45
-Nodes (10): _process(), _request(), test_ambiguous_response_produces_clarification_and_no_instruction(), test_expired_response_fails_closed_to_dead_letter(), test_invalid_packet_lands_in_dead_letter_with_validation_errors(), test_local_cli_checkpoint_fixture_creates_valid_hitl_request(), test_replay_reconstructs_decision_path(), test_request_changes_response_preserves_feedback_path_without_approval() (+2 more)
+Cohesion: 0.35
+Nodes (10): cleanup_advice(), infer_repo_slug(), LanePolicy, load_policy(), main(), _match(), normalize_slug(), parse_args() (+2 more)
 
 ### Community 51 - "Community 51"
 Cohesion: 0.33
-Nodes (2): _run(), TestPlanPreflight
+Nodes (2): run_hook(), TestBranchSwitchGuard
 
 ### Community 52 - "Community 52"
+Cohesion: 0.33
+Nodes (2): _run(), TestPlanPreflight
+
+### Community 53 - "Community 53"
 Cohesion: 0.42
 Nodes (3): _payload(), _run_hook(), TestSchemaGuardHook
 
-### Community 53 - "Community 53"
+### Community 54 - "Community 54"
 Cohesion: 0.56
 Nodes (10): events(), run_supervisor(), test_intermittent_output_avoids_idle_timeout(), test_nonzero_failure_is_recorded_without_retry(), test_retry_halts_after_one_additional_timeout(), test_retry_once_can_recover_from_timeout(), test_silent_stall_hits_idle_timeout_and_kills_process(), test_success_event_captures_stdout_and_schema_fields() (+2 more)
 
-### Community 54 - "Community 54"
+### Community 55 - "Community 55"
 Cohesion: 0.2
 Nodes (0): 
 
-### Community 55 - "Community 55"
+### Community 56 - "Community 56"
 Cohesion: 0.38
 Nodes (9): filtered_targets(), find_target(), load_manifest(), main(), print_json(), print_shell(), print_stage_paths(), print_tsv() (+1 more)
 
-### Community 56 - "Community 56"
+### Community 57 - "Community 57"
 Cohesion: 0.4
 Nodes (9): build_inventory(), import_available(), local_runtime(), mac_hardware(), main(), memory_budget(), pii_guardrail(), _run() (+1 more)
 
-### Community 57 - "Community 57"
+### Community 58 - "Community 58"
 Cohesion: 0.49
 Nodes (9): check(), fail(), main(), read_text(), repos_for_static_checkout(), validate_docs_surfaces(), validate_runtime_registry_consumers(), validate_static_checkout_workflow() (+1 more)
 
-### Community 58 - "Community 58"
+### Community 59 - "Community 59"
 Cohesion: 0.61
 Nodes (8): check(), main(), run_command(), test_logger_backwards_compatible(), test_logger_query_trace_fields(), test_measurement_falls_back_from_stale_governance_repo_path(), test_measurement_outputs_query_traces(), test_schema_shape()
 
-### Community 59 - "Community 59"
+### Community 60 - "Community 60"
 Cohesion: 0.42
 Nodes (7): check_memory_exists(), inspect_repo(), load_memory_lines(), main(), memory_dir_for_repo(), parse_pointer_filenames(), validate_frontmatter()
-
-### Community 60 - "Community 60"
-Cohesion: 0.39
-Nodes (2): run_hook(), TestBranchSwitchGuard
 
 ### Community 61 - "Community 61"
 Cohesion: 0.5
@@ -362,7 +362,9 @@ Nodes (1): Build a client from well-known environment variables.
 ## Suggested Questions
 _Questions this graph is uniquely positioned to answer:_
 
-- **Why does `GateError` connect `Community 8` to `Community 2`?**
+- **Why does `GateError` connect `Community 11` to `Community 4`?**
+  _High betweenness centrality (0.008) - this node is a cross-community bridge._
+- **Why does `SomClientError` connect `Community 3` to `Community 4`?**
   _High betweenness centrality (0.008) - this node is a cross-community bridge._
 - **Are the 39 inferred relationships involving `WindowsOllamaSubmitter` (e.g. with `main()` and `AuditWriter`) actually correct?**
   _`WindowsOllamaSubmitter` has 39 INFERRED edges - model-reasoned connections that need verification._
@@ -374,5 +376,3 @@ _Questions this graph is uniquely positioned to answer:_
   _`EndpointUnreachableError` has 39 INFERRED edges - model-reasoned connections that need verification._
 - **What connects `Load persona JSON files. Resolves local-first, shared fallback.`, `Convenience: load shared dir from bundled package personas/.`, `Subprocess-backed provider using codex exec --ephemeral.` to the rest of the system?**
   _78 weakly-connected nodes found - possible documentation gaps or missing edges._
-- **Should `Community 0` be split into smaller, more focused modules?**
-  _Cohesion score 0.04 - nodes in this community are weakly interconnected._

--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -9,7 +9,7 @@
       "source_file": "scripts/windows-ollama/tests/__init__.py",
       "source_location": "L1",
       "id": "init",
-      "community": 4
+      "community": 5
     },
     {
       "label": "aggregator.py",
@@ -17,7 +17,7 @@
       "source_file": "packages/hldpro-sim/hldprosim/aggregator.py",
       "source_location": "L1",
       "id": "aggregator",
-      "community": 4
+      "community": 5
     },
     {
       "label": "BaseAggregator",
@@ -25,7 +25,7 @@
       "source_file": "packages/hldpro-sim/hldprosim/aggregator.py",
       "source_location": "L8",
       "id": "aggregator_baseaggregator",
-      "community": 4
+      "community": 5
     },
     {
       "label": "ABC",
@@ -33,7 +33,7 @@
       "source_file": "",
       "source_location": "",
       "id": "abc",
-      "community": 4
+      "community": 5
     },
     {
       "label": "aggregate()",
@@ -41,7 +41,7 @@
       "source_file": "packages/hldpro-sim/hldprosim/aggregator.py",
       "source_location": "L10",
       "id": "aggregator_aggregate",
-      "community": 4
+      "community": 5
     },
     {
       "label": "artifacts.py",
@@ -49,7 +49,7 @@
       "source_file": "packages/hldpro-sim/hldprosim/artifacts.py",
       "source_location": "L1",
       "id": "artifacts",
-      "community": 4
+      "community": 5
     },
     {
       "label": "RunManifest",
@@ -57,7 +57,7 @@
       "source_file": "packages/hldpro-sim/hldprosim/artifacts.py",
       "source_location": "L10",
       "id": "artifacts_runmanifest",
-      "community": 4
+      "community": 5
     },
     {
       "label": "_git_commit()",
@@ -65,7 +65,7 @@
       "source_file": "packages/hldpro-sim/hldprosim/artifacts.py",
       "source_location": "L21",
       "id": "artifacts_git_commit",
-      "community": 4
+      "community": 5
     },
     {
       "label": "ArtifactWriter",
@@ -73,7 +73,7 @@
       "source_file": "packages/hldpro-sim/hldprosim/artifacts.py",
       "source_location": "L33",
       "id": "artifacts_artifactwriter",
-      "community": 4
+      "community": 5
     },
     {
       "label": ".__init__()",
@@ -81,7 +81,7 @@
       "source_file": "packages/hldpro-sim/hldprosim/artifacts.py",
       "source_location": "L34",
       "id": "artifacts_artifactwriter_init",
-      "community": 4
+      "community": 5
     },
     {
       "label": ".write()",
@@ -89,7 +89,7 @@
       "source_file": "packages/hldpro-sim/hldprosim/artifacts.py",
       "source_location": "L37",
       "id": "artifacts_artifactwriter_write",
-      "community": 4
+      "community": 5
     },
     {
       "label": "engine.py",
@@ -97,7 +97,7 @@
       "source_file": "packages/hldpro-sim/hldprosim/engine.py",
       "source_location": "L1",
       "id": "engine",
-      "community": 4
+      "community": 5
     },
     {
       "label": "SimulationEngine",
@@ -105,7 +105,7 @@
       "source_file": "packages/hldpro-sim/hldprosim/engine.py",
       "source_location": "L7",
       "id": "engine_simulationengine",
-      "community": 4
+      "community": 5
     },
     {
       "label": ".__init__()",
@@ -113,7 +113,7 @@
       "source_file": "packages/hldpro-sim/hldprosim/engine.py",
       "source_location": "L8",
       "id": "engine_simulationengine_init",
-      "community": 4
+      "community": 5
     },
     {
       "label": ".run()",
@@ -121,7 +121,7 @@
       "source_file": "packages/hldpro-sim/hldprosim/engine.py",
       "source_location": "L20",
       "id": "engine_simulationengine_run",
-      "community": 4
+      "community": 5
     },
     {
       "label": "personas.py",
@@ -129,7 +129,7 @@
       "source_file": "packages/hldpro-sim/hldprosim/personas.py",
       "source_location": "L1",
       "id": "personas",
-      "community": 4
+      "community": 5
     },
     {
       "label": "PersonaLoader",
@@ -137,7 +137,7 @@
       "source_file": "packages/hldpro-sim/hldprosim/personas.py",
       "source_location": "L6",
       "id": "personas_personaloader",
-      "community": 4
+      "community": 5
     },
     {
       "label": ".__init__()",
@@ -145,7 +145,7 @@
       "source_file": "packages/hldpro-sim/hldprosim/personas.py",
       "source_location": "L9",
       "id": "personas_personaloader_init",
-      "community": 4
+      "community": 5
     },
     {
       "label": ".load()",
@@ -153,7 +153,7 @@
       "source_file": "packages/hldpro-sim/hldprosim/personas.py",
       "source_location": "L13",
       "id": "personas_personaloader_load",
-      "community": 4
+      "community": 5
     },
     {
       "label": "from_package()",
@@ -161,7 +161,7 @@
       "source_file": "packages/hldpro-sim/hldprosim/personas.py",
       "source_location": "L23",
       "id": "personas_from_package",
-      "community": 4
+      "community": 5
     },
     {
       "label": "Load persona JSON files. Resolves local-first, shared fallback.",
@@ -169,7 +169,7 @@
       "source_file": "packages/hldpro-sim/hldprosim/personas.py",
       "source_location": "L7",
       "id": "personas_rationale_7",
-      "community": 4
+      "community": 5
     },
     {
       "label": "Convenience: load shared dir from bundled package personas/.",
@@ -185,7 +185,7 @@
       "source_file": "packages/hldpro-sim/hldprosim/providers.py",
       "source_location": "L1",
       "id": "providers",
-      "community": 4
+      "community": 5
     },
     {
       "label": "BaseProvider",
@@ -193,7 +193,7 @@
       "source_file": "packages/hldpro-sim/hldprosim/providers.py",
       "source_location": "L10",
       "id": "providers_baseprovider",
-      "community": 4
+      "community": 5
     },
     {
       "label": "Protocol",
@@ -201,7 +201,7 @@
       "source_file": "",
       "source_location": "",
       "id": "protocol",
-      "community": 4
+      "community": 5
     },
     {
       "label": ".complete()",
@@ -209,7 +209,7 @@
       "source_file": "packages/hldpro-sim/hldprosim/providers.py",
       "source_location": "L11",
       "id": "providers_baseprovider_complete",
-      "community": 4
+      "community": 5
     },
     {
       "label": "CodexCliProvider",
@@ -217,7 +217,7 @@
       "source_file": "packages/hldpro-sim/hldprosim/providers.py",
       "source_location": "L14",
       "id": "providers_codexcliprovider",
-      "community": 4
+      "community": 5
     },
     {
       "label": ".__init__()",
@@ -225,7 +225,7 @@
       "source_file": "packages/hldpro-sim/hldprosim/providers.py",
       "source_location": "L17",
       "id": "providers_codexcliprovider_init",
-      "community": 4
+      "community": 5
     },
     {
       "label": ".complete()",
@@ -233,7 +233,7 @@
       "source_file": "packages/hldpro-sim/hldprosim/providers.py",
       "source_location": "L21",
       "id": "providers_codexcliprovider_complete",
-      "community": 4
+      "community": 5
     },
     {
       "label": "AnthropicApiProvider",
@@ -241,7 +241,7 @@
       "source_file": "packages/hldpro-sim/hldprosim/providers.py",
       "source_location": "L69",
       "id": "providers_anthropicapiprovider",
-      "community": 4
+      "community": 5
     },
     {
       "label": ".complete()",
@@ -249,7 +249,7 @@
       "source_file": "packages/hldpro-sim/hldprosim/providers.py",
       "source_location": "L72",
       "id": "providers_anthropicapiprovider_complete",
-      "community": 4
+      "community": 5
     },
     {
       "label": "Subprocess-backed provider using codex exec --ephemeral.",
@@ -257,7 +257,7 @@
       "source_file": "packages/hldpro-sim/hldprosim/providers.py",
       "source_location": "L15",
       "id": "providers_rationale_15",
-      "community": 4
+      "community": 5
     },
     {
       "label": "Cloud stub \u2014 not implemented until API keys are provisioned.",
@@ -265,7 +265,7 @@
       "source_file": "packages/hldpro-sim/hldprosim/providers.py",
       "source_location": "L70",
       "id": "providers_rationale_70",
-      "community": 4
+      "community": 5
     },
     {
       "label": "runner.py",
@@ -273,7 +273,7 @@
       "source_file": "packages/hldpro-sim/hldprosim/runner.py",
       "source_location": "L1",
       "id": "runner",
-      "community": 4
+      "community": 5
     },
     {
       "label": "Runner",
@@ -281,7 +281,7 @@
       "source_file": "packages/hldpro-sim/hldprosim/runner.py",
       "source_location": "L6",
       "id": "runner_runner",
-      "community": 4
+      "community": 5
     },
     {
       "label": ".__init__()",
@@ -289,7 +289,7 @@
       "source_file": "packages/hldpro-sim/hldprosim/runner.py",
       "source_location": "L7",
       "id": "runner_runner_init",
-      "community": 4
+      "community": 5
     },
     {
       "label": ".run_n()",
@@ -297,7 +297,7 @@
       "source_file": "packages/hldpro-sim/hldprosim/runner.py",
       "source_location": "L10",
       "id": "runner_runner_run_n",
-      "community": 4
+      "community": 5
     },
     {
       "label": "stampede_consumer.py",
@@ -305,7 +305,7 @@
       "source_file": "packages/hldpro-sim/tests/fixtures/stampede_consumer.py",
       "source_location": "L1",
       "id": "stampede_consumer",
-      "community": 4
+      "community": 5
     },
     {
       "label": "NarrativeOutcome",
@@ -313,7 +313,7 @@
       "source_file": "packages/hldpro-sim/tests/fixtures/stampede_consumer.py",
       "source_location": "L8",
       "id": "stampede_consumer_narrativeoutcome",
-      "community": 4
+      "community": 5
     },
     {
       "label": "BaseModel",
@@ -321,7 +321,7 @@
       "source_file": "",
       "source_location": "",
       "id": "basemodel",
-      "community": 4
+      "community": 5
     },
     {
       "label": "NarrativeAggregator",
@@ -329,7 +329,7 @@
       "source_file": "packages/hldpro-sim/tests/fixtures/stampede_consumer.py",
       "source_location": "L17",
       "id": "stampede_consumer_narrativeaggregator",
-      "community": 4
+      "community": 5
     },
     {
       "label": "BaseAggregator",
@@ -337,7 +337,7 @@
       "source_file": "",
       "source_location": "",
       "id": "baseaggregator",
-      "community": 4
+      "community": 5
     },
     {
       "label": ".aggregate()",
@@ -345,7 +345,7 @@
       "source_file": "packages/hldpro-sim/tests/fixtures/stampede_consumer.py",
       "source_location": "L18",
       "id": "stampede_consumer_narrativeaggregator_aggregate",
-      "community": 4
+      "community": 5
     },
     {
       "label": "test_artifacts.py",
@@ -385,7 +385,7 @@
       "source_file": "packages/hldpro-sim/tests/test_providers.py",
       "source_location": "L1",
       "id": "test_providers",
-      "community": 54
+      "community": 55
     },
     {
       "label": "_write_output_from_call()",
@@ -393,7 +393,7 @@
       "source_file": "packages/hldpro-sim/tests/test_providers.py",
       "source_location": "L15",
       "id": "test_providers_write_output_from_call",
-      "community": 54
+      "community": 55
     },
     {
       "label": "test_codex_provider_builds_expected_subprocess_args()",
@@ -401,7 +401,7 @@
       "source_file": "packages/hldpro-sim/tests/test_providers.py",
       "source_location": "L23",
       "id": "test_providers_test_codex_provider_builds_expected_subprocess_args",
-      "community": 54
+      "community": 55
     },
     {
       "label": "test_codex_provider_injects_additional_properties_false_when_missing()",
@@ -409,7 +409,7 @@
       "source_file": "packages/hldpro-sim/tests/test_providers.py",
       "source_location": "L42",
       "id": "test_providers_test_codex_provider_injects_additional_properties_false_when_missing",
-      "community": 54
+      "community": 55
     },
     {
       "label": "test_codex_provider_passes_prompt_as_positional_arg_only()",
@@ -417,7 +417,7 @@
       "source_file": "packages/hldpro-sim/tests/test_providers.py",
       "source_location": "L54",
       "id": "test_providers_test_codex_provider_passes_prompt_as_positional_arg_only",
-      "community": 54
+      "community": 55
     },
     {
       "label": "test_anthropic_provider_not_implemented()",
@@ -425,7 +425,7 @@
       "source_file": "packages/hldpro-sim/tests/test_providers.py",
       "source_location": "L64",
       "id": "test_providers_test_anthropic_provider_not_implemented",
-      "community": 54
+      "community": 55
     },
     {
       "label": "test_codex_provider_raises_on_nonzero_exit_code()",
@@ -433,7 +433,7 @@
       "source_file": "packages/hldpro-sim/tests/test_providers.py",
       "source_location": "L76",
       "id": "test_providers_test_codex_provider_raises_on_nonzero_exit_code",
-      "community": 54
+      "community": 55
     },
     {
       "label": "test_persona_loader_prefers_local_file()",
@@ -441,7 +441,7 @@
       "source_file": "packages/hldpro-sim/tests/test_providers.py",
       "source_location": "L88",
       "id": "test_providers_test_persona_loader_prefers_local_file",
-      "community": 54
+      "community": 55
     },
     {
       "label": "test_persona_loader_falls_back_to_shared_file()",
@@ -449,7 +449,7 @@
       "source_file": "packages/hldpro-sim/tests/test_providers.py",
       "source_location": "L100",
       "id": "test_providers_test_persona_loader_falls_back_to_shared_file",
-      "community": 54
+      "community": 55
     },
     {
       "label": "test_persona_loader_raises_when_missing()",
@@ -457,7 +457,7 @@
       "source_file": "packages/hldpro-sim/tests/test_providers.py",
       "source_location": "L110",
       "id": "test_providers_test_persona_loader_raises_when_missing",
-      "community": 54
+      "community": 55
     },
     {
       "label": "test_runner.py",
@@ -489,7 +489,7 @@
       "source_file": "packages/hldpro-sim/tests/test_stampede_consumer_proof.py",
       "source_location": "L1",
       "id": "test_stampede_consumer_proof",
-      "community": 4
+      "community": 5
     },
     {
       "label": "MockProvider",
@@ -497,7 +497,7 @@
       "source_file": "packages/hldpro-sim/tests/test_stampede_consumer_proof.py",
       "source_location": "L37",
       "id": "test_stampede_consumer_proof_mockprovider",
-      "community": 4
+      "community": 5
     },
     {
       "label": ".complete()",
@@ -505,7 +505,7 @@
       "source_file": "packages/hldpro-sim/tests/test_stampede_consumer_proof.py",
       "source_location": "L38",
       "id": "test_stampede_consumer_proof_mockprovider_complete",
-      "community": 4
+      "community": 5
     },
     {
       "label": "test_stampede_e2e()",
@@ -513,7 +513,7 @@
       "source_file": "packages/hldpro-sim/tests/test_stampede_consumer_proof.py",
       "source_location": "L42",
       "id": "test_stampede_consumer_proof_test_stampede_e2e",
-      "community": 4
+      "community": 5
     },
     {
       "label": "cli_session_supervisor.py",
@@ -521,7 +521,7 @@
       "source_file": "scripts/cli_session_supervisor.py",
       "source_location": "L1",
       "id": "cli_session_supervisor",
-      "community": 46
+      "community": 44
     },
     {
       "label": "AttemptResult",
@@ -529,7 +529,7 @@
       "source_file": "scripts/cli_session_supervisor.py",
       "source_location": "L25",
       "id": "cli_session_supervisor_attemptresult",
-      "community": 46
+      "community": 44
     },
     {
       "label": "utcnow()",
@@ -537,7 +537,7 @@
       "source_file": "scripts/cli_session_supervisor.py",
       "source_location": "L30",
       "id": "cli_session_supervisor_utcnow",
-      "community": 46
+      "community": 44
     },
     {
       "label": "session_id()",
@@ -545,7 +545,7 @@
       "source_file": "scripts/cli_session_supervisor.py",
       "source_location": "L34",
       "id": "cli_session_supervisor_session_id",
-      "community": 46
+      "community": 44
     },
     {
       "label": "sha256_bytes()",
@@ -553,7 +553,7 @@
       "source_file": "scripts/cli_session_supervisor.py",
       "source_location": "L39",
       "id": "cli_session_supervisor_sha256_bytes",
-      "community": 46
+      "community": 44
     },
     {
       "label": "event_paths()",
@@ -561,7 +561,7 @@
       "source_file": "scripts/cli_session_supervisor.py",
       "source_location": "L43",
       "id": "cli_session_supervisor_event_paths",
-      "community": 46
+      "community": 44
     },
     {
       "label": "append_jsonl()",
@@ -569,7 +569,7 @@
       "source_file": "scripts/cli_session_supervisor.py",
       "source_location": "L50",
       "id": "cli_session_supervisor_append_jsonl",
-      "community": 46
+      "community": 44
     },
     {
       "label": "kill_group()",
@@ -577,7 +577,7 @@
       "source_file": "scripts/cli_session_supervisor.py",
       "source_location": "L56",
       "id": "cli_session_supervisor_kill_group",
-      "community": 46
+      "community": 44
     },
     {
       "label": "build_command()",
@@ -585,7 +585,7 @@
       "source_file": "scripts/cli_session_supervisor.py",
       "source_location": "L79",
       "id": "cli_session_supervisor_build_command",
-      "community": 46
+      "community": 44
     },
     {
       "label": "stream_attempt()",
@@ -593,7 +593,7 @@
       "source_file": "scripts/cli_session_supervisor.py",
       "source_location": "L122",
       "id": "cli_session_supervisor_stream_attempt",
-      "community": 46
+      "community": 44
     },
     {
       "label": "parse_args()",
@@ -601,7 +601,7 @@
       "source_file": "scripts/cli_session_supervisor.py",
       "source_location": "L265",
       "id": "cli_session_supervisor_parse_args",
-      "community": 46
+      "community": 44
     },
     {
       "label": "main()",
@@ -609,7 +609,7 @@
       "source_file": "scripts/cli_session_supervisor.py",
       "source_location": "L308",
       "id": "cli_session_supervisor_main",
-      "community": 46
+      "community": 44
     },
     {
       "label": "build_graph.py",
@@ -617,7 +617,7 @@
       "source_file": "scripts/knowledge_base/build_graph.py",
       "source_location": "L1",
       "id": "build_graph",
-      "community": 48
+      "community": 47
     },
     {
       "label": "_split_words()",
@@ -625,7 +625,7 @@
       "source_file": "scripts/knowledge_base/build_graph.py",
       "source_location": "L78",
       "id": "build_graph_split_words",
-      "community": 48
+      "community": 47
     },
     {
       "label": "_normalize_phrase()",
@@ -633,7 +633,7 @@
       "source_file": "scripts/knowledge_base/build_graph.py",
       "source_location": "L84",
       "id": "build_graph_normalize_phrase",
-      "community": 48
+      "community": 47
     },
     {
       "label": "_derive_path_phrase()",
@@ -641,7 +641,7 @@
       "source_file": "scripts/knowledge_base/build_graph.py",
       "source_location": "L91",
       "id": "build_graph_derive_path_phrase",
-      "community": 48
+      "community": 47
     },
     {
       "label": "_derive_path_tokens()",
@@ -649,7 +649,7 @@
       "source_file": "scripts/knowledge_base/build_graph.py",
       "source_location": "L123",
       "id": "build_graph_derive_path_tokens",
-      "community": 48
+      "community": 47
     },
     {
       "label": "_community_label()",
@@ -657,7 +657,7 @@
       "source_file": "scripts/knowledge_base/build_graph.py",
       "source_location": "L137",
       "id": "build_graph_community_label",
-      "community": 48
+      "community": 47
     },
     {
       "label": "infer_community_labels()",
@@ -665,7 +665,7 @@
       "source_file": "scripts/knowledge_base/build_graph.py",
       "source_location": "L168",
       "id": "build_graph_infer_community_labels",
-      "community": 48
+      "community": 47
     },
     {
       "label": "_sanitize_text_paths()",
@@ -673,7 +673,7 @@
       "source_file": "scripts/knowledge_base/build_graph.py",
       "source_location": "L172",
       "id": "build_graph_sanitize_text_paths",
-      "community": 48
+      "community": 47
     },
     {
       "label": "_sanitize_markdown_artifacts()",
@@ -681,7 +681,7 @@
       "source_file": "scripts/knowledge_base/build_graph.py",
       "source_location": "L179",
       "id": "build_graph_sanitize_markdown_artifacts",
-      "community": 48
+      "community": 47
     },
     {
       "label": "build_graph()",
@@ -689,7 +689,7 @@
       "source_file": "scripts/knowledge_base/build_graph.py",
       "source_location": "L191",
       "id": "build_graph_build_graph",
-      "community": 48
+      "community": 47
     },
     {
       "label": "main()",
@@ -697,7 +697,7 @@
       "source_file": "scripts/knowledge_base/build_graph.py",
       "source_location": "L277",
       "id": "build_graph_main",
-      "community": 48
+      "community": 47
     },
     {
       "label": "graphify_hook_helper.py",
@@ -705,7 +705,7 @@
       "source_file": "scripts/knowledge_base/graphify_hook_helper.py",
       "source_location": "L1",
       "id": "graphify_hook_helper",
-      "community": 14
+      "community": 16
     },
     {
       "label": "HelperError",
@@ -713,7 +713,7 @@
       "source_file": "scripts/knowledge_base/graphify_hook_helper.py",
       "source_location": "L18",
       "id": "graphify_hook_helper_helpererror",
-      "community": 14
+      "community": 16
     },
     {
       "label": "RuntimeError",
@@ -721,7 +721,7 @@
       "source_file": "",
       "source_location": "",
       "id": "runtimeerror",
-      "community": 2
+      "community": 4
     },
     {
       "label": "HookPlan",
@@ -729,7 +729,7 @@
       "source_file": "scripts/knowledge_base/graphify_hook_helper.py",
       "source_location": "L23",
       "id": "graphify_hook_helper_hookplan",
-      "community": 14
+      "community": 16
     },
     {
       "label": ".to_json()",
@@ -737,7 +737,7 @@
       "source_file": "scripts/knowledge_base/graphify_hook_helper.py",
       "source_location": "L32",
       "id": "graphify_hook_helper_hookplan_to_json",
-      "community": 14
+      "community": 16
     },
     {
       "label": "load_manifest()",
@@ -745,7 +745,7 @@
       "source_file": "scripts/knowledge_base/graphify_hook_helper.py",
       "source_location": "L44",
       "id": "graphify_hook_helper_load_manifest",
-      "community": 14
+      "community": 16
     },
     {
       "label": "target_rows()",
@@ -753,7 +753,7 @@
       "source_file": "scripts/knowledge_base/graphify_hook_helper.py",
       "source_location": "L54",
       "id": "graphify_hook_helper_target_rows",
-      "community": 14
+      "community": 16
     },
     {
       "label": "find_target()",
@@ -761,7 +761,7 @@
       "source_file": "scripts/knowledge_base/graphify_hook_helper.py",
       "source_location": "L61",
       "id": "graphify_hook_helper_find_target",
-      "community": 14
+      "community": 16
     },
     {
       "label": "infer_repo_slug()",
@@ -769,7 +769,7 @@
       "source_file": "scripts/knowledge_base/graphify_hook_helper.py",
       "source_location": "L68",
       "id": "graphify_hook_helper_infer_repo_slug",
-      "community": 14
+      "community": 16
     },
     {
       "label": "resolve_under()",
@@ -777,7 +777,7 @@
       "source_file": "scripts/knowledge_base/graphify_hook_helper.py",
       "source_location": "L80",
       "id": "graphify_hook_helper_resolve_under",
-      "community": 14
+      "community": 16
     },
     {
       "label": "git_hook_paths()",
@@ -785,7 +785,7 @@
       "source_file": "scripts/knowledge_base/graphify_hook_helper.py",
       "source_location": "L89",
       "id": "graphify_hook_helper_git_hook_paths",
-      "community": 14
+      "community": 16
     },
     {
       "label": "build_plan()",
@@ -793,7 +793,7 @@
       "source_file": "scripts/knowledge_base/graphify_hook_helper.py",
       "source_location": "L103",
       "id": "graphify_hook_helper_build_plan",
-      "community": 14
+      "community": 16
     },
     {
       "label": "is_relative_to()",
@@ -801,7 +801,7 @@
       "source_file": "scripts/knowledge_base/graphify_hook_helper.py",
       "source_location": "L122",
       "id": "graphify_hook_helper_is_relative_to",
-      "community": 14
+      "community": 16
     },
     {
       "label": "preflight_safe_output()",
@@ -809,7 +809,7 @@
       "source_file": "scripts/knowledge_base/graphify_hook_helper.py",
       "source_location": "L130",
       "id": "graphify_hook_helper_preflight_safe_output",
-      "community": 14
+      "community": 16
     },
     {
       "label": "build_refresh_command()",
@@ -817,7 +817,7 @@
       "source_file": "scripts/knowledge_base/graphify_hook_helper.py",
       "source_location": "L139",
       "id": "graphify_hook_helper_build_refresh_command",
-      "community": 14
+      "community": 16
     },
     {
       "label": "managed_hook_body()",
@@ -825,7 +825,7 @@
       "source_file": "scripts/knowledge_base/graphify_hook_helper.py",
       "source_location": "L157",
       "id": "graphify_hook_helper_managed_hook_body",
-      "community": 14
+      "community": 16
     },
     {
       "label": "install_hooks()",
@@ -833,7 +833,7 @@
       "source_file": "scripts/knowledge_base/graphify_hook_helper.py",
       "source_location": "L171",
       "id": "graphify_hook_helper_install_hooks",
-      "community": 14
+      "community": 16
     },
     {
       "label": "execute_refresh()",
@@ -841,7 +841,7 @@
       "source_file": "scripts/knowledge_base/graphify_hook_helper.py",
       "source_location": "L187",
       "id": "graphify_hook_helper_execute_refresh",
-      "community": 14
+      "community": 16
     },
     {
       "label": "print_json()",
@@ -849,7 +849,7 @@
       "source_file": "scripts/knowledge_base/graphify_hook_helper.py",
       "source_location": "L192",
       "id": "graphify_hook_helper_print_json",
-      "community": 14
+      "community": 16
     },
     {
       "label": "add_common_args()",
@@ -857,7 +857,7 @@
       "source_file": "scripts/knowledge_base/graphify_hook_helper.py",
       "source_location": "L197",
       "id": "graphify_hook_helper_add_common_args",
-      "community": 14
+      "community": 16
     },
     {
       "label": "main()",
@@ -865,7 +865,7 @@
       "source_file": "scripts/knowledge_base/graphify_hook_helper.py",
       "source_location": "L204",
       "id": "graphify_hook_helper_main",
-      "community": 14
+      "community": 16
     },
     {
       "label": "graphify_targets.py",
@@ -873,7 +873,7 @@
       "source_file": "scripts/knowledge_base/graphify_targets.py",
       "source_location": "L1",
       "id": "graphify_targets",
-      "community": 55
+      "community": 56
     },
     {
       "label": "load_manifest()",
@@ -881,7 +881,7 @@
       "source_file": "scripts/knowledge_base/graphify_targets.py",
       "source_location": "L14",
       "id": "graphify_targets_load_manifest",
-      "community": 55
+      "community": 56
     },
     {
       "label": "target_rows()",
@@ -889,7 +889,7 @@
       "source_file": "scripts/knowledge_base/graphify_targets.py",
       "source_location": "L24",
       "id": "graphify_targets_target_rows",
-      "community": 55
+      "community": 56
     },
     {
       "label": "filtered_targets()",
@@ -897,7 +897,7 @@
       "source_file": "scripts/knowledge_base/graphify_targets.py",
       "source_location": "L30",
       "id": "graphify_targets_filtered_targets",
-      "community": 55
+      "community": 56
     },
     {
       "label": "find_target()",
@@ -905,7 +905,7 @@
       "source_file": "scripts/knowledge_base/graphify_targets.py",
       "source_location": "L39",
       "id": "graphify_targets_find_target",
-      "community": 55
+      "community": 56
     },
     {
       "label": "print_json()",
@@ -913,7 +913,7 @@
       "source_file": "scripts/knowledge_base/graphify_targets.py",
       "source_location": "L46",
       "id": "graphify_targets_print_json",
-      "community": 55
+      "community": 56
     },
     {
       "label": "print_tsv()",
@@ -921,7 +921,7 @@
       "source_file": "scripts/knowledge_base/graphify_targets.py",
       "source_location": "L51",
       "id": "graphify_targets_print_tsv",
-      "community": 55
+      "community": 56
     },
     {
       "label": "print_shell()",
@@ -929,7 +929,7 @@
       "source_file": "scripts/knowledge_base/graphify_targets.py",
       "source_location": "L67",
       "id": "graphify_targets_print_shell",
-      "community": 55
+      "community": 56
     },
     {
       "label": "print_stage_paths()",
@@ -937,7 +937,7 @@
       "source_file": "scripts/knowledge_base/graphify_targets.py",
       "source_location": "L74",
       "id": "graphify_targets_print_stage_paths",
-      "community": 55
+      "community": 56
     },
     {
       "label": "main()",
@@ -945,7 +945,7 @@
       "source_file": "scripts/knowledge_base/graphify_targets.py",
       "source_location": "L84",
       "id": "graphify_targets_main",
-      "community": 55
+      "community": 56
     },
     {
       "label": "log_graphify_usage.py",
@@ -993,7 +993,7 @@
       "source_file": "scripts/knowledge_base/measure_graphify_usage.py",
       "source_location": "L1",
       "id": "measure_graphify_usage",
-      "community": 17
+      "community": 21
     },
     {
       "label": "Scenario",
@@ -1001,7 +1001,7 @@
       "source_file": "scripts/knowledge_base/measure_graphify_usage.py",
       "source_location": "L72",
       "id": "measure_graphify_usage_scenario",
-      "community": 17
+      "community": 21
     },
     {
       "label": "GraphData",
@@ -1009,7 +1009,7 @@
       "source_file": "scripts/knowledge_base/measure_graphify_usage.py",
       "source_location": "L86",
       "id": "measure_graphify_usage_graphdata",
-      "community": 17
+      "community": 21
     },
     {
       "label": "estimate_tokens()",
@@ -1017,7 +1017,7 @@
       "source_file": "scripts/knowledge_base/measure_graphify_usage.py",
       "source_location": "L93",
       "id": "measure_graphify_usage_estimate_tokens",
-      "community": 17
+      "community": 21
     },
     {
       "label": "normalize_tokens()",
@@ -1025,7 +1025,7 @@
       "source_file": "scripts/knowledge_base/measure_graphify_usage.py",
       "source_location": "L97",
       "id": "measure_graphify_usage_normalize_tokens",
-      "community": 17
+      "community": 21
     },
     {
       "label": "parse_args()",
@@ -1033,7 +1033,7 @@
       "source_file": "scripts/knowledge_base/measure_graphify_usage.py",
       "source_location": "L108",
       "id": "measure_graphify_usage_parse_args",
-      "community": 17
+      "community": 21
     },
     {
       "label": "load_scenarios()",
@@ -1041,7 +1041,7 @@
       "source_file": "scripts/knowledge_base/measure_graphify_usage.py",
       "source_location": "L120",
       "id": "measure_graphify_usage_load_scenarios",
-      "community": 17
+      "community": 21
     },
     {
       "label": "resolve_graph_path()",
@@ -1049,7 +1049,7 @@
       "source_file": "scripts/knowledge_base/measure_graphify_usage.py",
       "source_location": "L125",
       "id": "measure_graphify_usage_resolve_graph_path",
-      "community": 17
+      "community": 21
     },
     {
       "label": "resolve_label_path()",
@@ -1057,7 +1057,7 @@
       "source_file": "scripts/knowledge_base/measure_graphify_usage.py",
       "source_location": "L134",
       "id": "measure_graphify_usage_resolve_label_path",
-      "community": 17
+      "community": 21
     },
     {
       "label": "load_graph()",
@@ -1065,7 +1065,7 @@
       "source_file": "scripts/knowledge_base/measure_graphify_usage.py",
       "source_location": "L139",
       "id": "measure_graphify_usage_load_graph",
-      "community": 17
+      "community": 21
     },
     {
       "label": "resolve_repo_root()",
@@ -1073,7 +1073,7 @@
       "source_file": "scripts/knowledge_base/measure_graphify_usage.py",
       "source_location": "L151",
       "id": "measure_graphify_usage_resolve_repo_root",
-      "community": 17
+      "community": 21
     },
     {
       "label": "relativize_source_file()",
@@ -1081,7 +1081,7 @@
       "source_file": "scripts/knowledge_base/measure_graphify_usage.py",
       "source_location": "L163",
       "id": "measure_graphify_usage_relativize_source_file",
-      "community": 17
+      "community": 21
     },
     {
       "label": "score_text()",
@@ -1089,7 +1089,7 @@
       "source_file": "scripts/knowledge_base/measure_graphify_usage.py",
       "source_location": "L180",
       "id": "measure_graphify_usage_score_text",
-      "community": 17
+      "community": 21
     },
     {
       "label": "aggregate_file_scores()",
@@ -1097,7 +1097,7 @@
       "source_file": "scripts/knowledge_base/measure_graphify_usage.py",
       "source_location": "L195",
       "id": "measure_graphify_usage_aggregate_file_scores",
-      "community": 17
+      "community": 21
     },
     {
       "label": "matched_terms()",
@@ -1105,7 +1105,7 @@
       "source_file": "scripts/knowledge_base/measure_graphify_usage.py",
       "source_location": "L202",
       "id": "measure_graphify_usage_matched_terms",
-      "community": 17
+      "community": 21
     },
     {
       "label": "is_workflow_doc_scenario()",
@@ -1113,7 +1113,7 @@
       "source_file": "scripts/knowledge_base/measure_graphify_usage.py",
       "source_location": "L213",
       "id": "measure_graphify_usage_is_workflow_doc_scenario",
-      "community": 17
+      "community": 21
     },
     {
       "label": "is_workflow_doc_candidate()",
@@ -1121,7 +1121,7 @@
       "source_file": "scripts/knowledge_base/measure_graphify_usage.py",
       "source_location": "L217",
       "id": "measure_graphify_usage_is_workflow_doc_candidate",
-      "community": 17
+      "community": 21
     },
     {
       "label": "workflow_doc_path_boost()",
@@ -1129,7 +1129,7 @@
       "source_file": "scripts/knowledge_base/measure_graphify_usage.py",
       "source_location": "L221",
       "id": "measure_graphify_usage_workflow_doc_path_boost",
-      "community": 17
+      "community": 21
     },
     {
       "label": "workflow_doc_priority_multiplier()",
@@ -1137,7 +1137,7 @@
       "source_file": "scripts/knowledge_base/measure_graphify_usage.py",
       "source_location": "L250",
       "id": "measure_graphify_usage_workflow_doc_priority_multiplier",
-      "community": 17
+      "community": 21
     },
     {
       "label": "augment_workflow_doc_candidates()",
@@ -1145,7 +1145,7 @@
       "source_file": "scripts/knowledge_base/measure_graphify_usage.py",
       "source_location": "L262",
       "id": "measure_graphify_usage_augment_workflow_doc_candidates",
-      "community": 17
+      "community": 21
     },
     {
       "label": "evaluate_relevance()",
@@ -1153,7 +1153,7 @@
       "source_file": "scripts/knowledge_base/measure_graphify_usage.py",
       "source_location": "L292",
       "id": "measure_graphify_usage_evaluate_relevance",
-      "community": 17
+      "community": 21
     },
     {
       "label": "graphify_results()",
@@ -1161,7 +1161,7 @@
       "source_file": "scripts/knowledge_base/measure_graphify_usage.py",
       "source_location": "L307",
       "id": "measure_graphify_usage_graphify_results",
-      "community": 17
+      "community": 21
     },
     {
       "label": "iter_repo_text_files()",
@@ -1169,7 +1169,7 @@
       "source_file": "scripts/knowledge_base/measure_graphify_usage.py",
       "source_location": "L396",
       "id": "measure_graphify_usage_iter_repo_text_files",
-      "community": 17
+      "community": 21
     },
     {
       "label": "baseline_results()",
@@ -1177,7 +1177,7 @@
       "source_file": "scripts/knowledge_base/measure_graphify_usage.py",
       "source_location": "L409",
       "id": "measure_graphify_usage_baseline_results",
-      "community": 17
+      "community": 21
     },
     {
       "label": "build_summary()",
@@ -1185,7 +1185,7 @@
       "source_file": "scripts/knowledge_base/measure_graphify_usage.py",
       "source_location": "L447",
       "id": "measure_graphify_usage_build_summary",
-      "community": 17
+      "community": 21
     },
     {
       "label": "build_trace()",
@@ -1193,7 +1193,7 @@
       "source_file": "scripts/knowledge_base/measure_graphify_usage.py",
       "source_location": "L475",
       "id": "measure_graphify_usage_build_trace",
-      "community": 17
+      "community": 21
     },
     {
       "label": "emit_usage_events()",
@@ -1201,7 +1201,7 @@
       "source_file": "scripts/knowledge_base/measure_graphify_usage.py",
       "source_location": "L484",
       "id": "measure_graphify_usage_emit_usage_events",
-      "community": 17
+      "community": 21
     },
     {
       "label": "write_outputs()",
@@ -1209,7 +1209,7 @@
       "source_file": "scripts/knowledge_base/measure_graphify_usage.py",
       "source_location": "L519",
       "id": "measure_graphify_usage_write_outputs",
-      "community": 17
+      "community": 21
     },
     {
       "label": "main()",
@@ -1217,7 +1217,7 @@
       "source_file": "scripts/knowledge_base/measure_graphify_usage.py",
       "source_location": "L579",
       "id": "measure_graphify_usage_main",
-      "community": 17
+      "community": 21
     },
     {
       "label": "push_graph_to_neo4j.py",
@@ -1281,7 +1281,7 @@
       "source_file": "scripts/knowledge_base/test_graphify_hook_helper.py",
       "source_location": "L1",
       "id": "test_graphify_hook_helper",
-      "community": 14
+      "community": 16
     },
     {
       "label": "TestGraphifyHookHelper",
@@ -1289,7 +1289,7 @@
       "source_file": "scripts/knowledge_base/test_graphify_hook_helper.py",
       "source_location": "L14",
       "id": "test_graphify_hook_helper_testgraphifyhookhelper",
-      "community": 14
+      "community": 16
     },
     {
       "label": ".setUp()",
@@ -1297,7 +1297,7 @@
       "source_file": "scripts/knowledge_base/test_graphify_hook_helper.py",
       "source_location": "L15",
       "id": "test_graphify_hook_helper_testgraphifyhookhelper_setup",
-      "community": 14
+      "community": 16
     },
     {
       "label": ".tearDown()",
@@ -1305,7 +1305,7 @@
       "source_file": "scripts/knowledge_base/test_graphify_hook_helper.py",
       "source_location": "L46",
       "id": "test_graphify_hook_helper_testgraphifyhookhelper_teardown",
-      "community": 14
+      "community": 16
     },
     {
       "label": ".write_manifest()",
@@ -1313,7 +1313,7 @@
       "source_file": "scripts/knowledge_base/test_graphify_hook_helper.py",
       "source_location": "L49",
       "id": "test_graphify_hook_helper_testgraphifyhookhelper_write_manifest",
-      "community": 14
+      "community": 16
     },
     {
       "label": ".args()",
@@ -1321,7 +1321,7 @@
       "source_file": "scripts/knowledge_base/test_graphify_hook_helper.py",
       "source_location": "L52",
       "id": "test_graphify_hook_helper_testgraphifyhookhelper_args",
-      "community": 14
+      "community": 16
     },
     {
       "label": ".test_infers_repo_slug_and_resolves_manifest_paths_from_governance_root()",
@@ -1329,7 +1329,7 @@
       "source_file": "scripts/knowledge_base/test_graphify_hook_helper.py",
       "source_location": "L62",
       "id": "test_graphify_hook_helper_testgraphifyhookhelper_test_infers_repo_slug_and_resolves_manifest_paths_from_governance_root",
-      "community": 14
+      "community": 16
     },
     {
       "label": ".test_accepts_explicit_knocktracker_slug()",
@@ -1337,7 +1337,7 @@
       "source_file": "scripts/knowledge_base/test_graphify_hook_helper.py",
       "source_location": "L73",
       "id": "test_graphify_hook_helper_testgraphifyhookhelper_test_accepts_explicit_knocktracker_slug",
-      "community": 14
+      "community": 16
     },
     {
       "label": ".test_unsafe_product_repo_output_aborts_before_builder_call()",
@@ -1345,7 +1345,7 @@
       "source_file": "scripts/knowledge_base/test_graphify_hook_helper.py",
       "source_location": "L83",
       "id": "test_graphify_hook_helper_testgraphifyhookhelper_test_unsafe_product_repo_output_aborts_before_builder_call",
-      "community": 14
+      "community": 16
     },
     {
       "label": ".test_install_refuses_unmanaged_existing_hooks()",
@@ -1353,7 +1353,7 @@
       "source_file": "scripts/knowledge_base/test_graphify_hook_helper.py",
       "source_location": "L99",
       "id": "test_graphify_hook_helper_testgraphifyhookhelper_test_install_refuses_unmanaged_existing_hooks",
-      "community": 14
+      "community": 16
     },
     {
       "label": ".test_install_backs_up_unmanaged_hook_and_writes_managed_body()",
@@ -1361,7 +1361,7 @@
       "source_file": "scripts/knowledge_base/test_graphify_hook_helper.py",
       "source_location": "L110",
       "id": "test_graphify_hook_helper_testgraphifyhookhelper_test_install_backs_up_unmanaged_hook_and_writes_managed_body",
-      "community": 14
+      "community": 16
     },
     {
       "label": ".test_dry_run_payload_includes_command_and_hook_targets()",
@@ -1369,7 +1369,7 @@
       "source_file": "scripts/knowledge_base/test_graphify_hook_helper.py",
       "source_location": "L126",
       "id": "test_graphify_hook_helper_testgraphifyhookhelper_test_dry_run_payload_includes_command_and_hook_targets",
-      "community": 14
+      "community": 16
     },
     {
       "label": "test_graphify_usage_logging_contract.py",
@@ -1377,7 +1377,7 @@
       "source_file": "scripts/knowledge_base/test_graphify_usage_logging_contract.py",
       "source_location": "L1",
       "id": "test_graphify_usage_logging_contract",
-      "community": 58
+      "community": 59
     },
     {
       "label": "check()",
@@ -1385,7 +1385,7 @@
       "source_file": "scripts/knowledge_base/test_graphify_usage_logging_contract.py",
       "source_location": "L19",
       "id": "test_graphify_usage_logging_contract_check",
-      "community": 58
+      "community": 59
     },
     {
       "label": "run_command()",
@@ -1393,7 +1393,7 @@
       "source_file": "scripts/knowledge_base/test_graphify_usage_logging_contract.py",
       "source_location": "L27",
       "id": "test_graphify_usage_logging_contract_run_command",
-      "community": 58
+      "community": 59
     },
     {
       "label": "test_schema_shape()",
@@ -1401,7 +1401,7 @@
       "source_file": "scripts/knowledge_base/test_graphify_usage_logging_contract.py",
       "source_location": "L31",
       "id": "test_graphify_usage_logging_contract_test_schema_shape",
-      "community": 58
+      "community": 59
     },
     {
       "label": "test_logger_backwards_compatible()",
@@ -1409,7 +1409,7 @@
       "source_file": "scripts/knowledge_base/test_graphify_usage_logging_contract.py",
       "source_location": "L42",
       "id": "test_graphify_usage_logging_contract_test_logger_backwards_compatible",
-      "community": 58
+      "community": 59
     },
     {
       "label": "test_logger_query_trace_fields()",
@@ -1417,7 +1417,7 @@
       "source_file": "scripts/knowledge_base/test_graphify_usage_logging_contract.py",
       "source_location": "L74",
       "id": "test_graphify_usage_logging_contract_test_logger_query_trace_fields",
-      "community": 58
+      "community": 59
     },
     {
       "label": "test_measurement_outputs_query_traces()",
@@ -1425,7 +1425,7 @@
       "source_file": "scripts/knowledge_base/test_graphify_usage_logging_contract.py",
       "source_location": "L128",
       "id": "test_graphify_usage_logging_contract_test_measurement_outputs_query_traces",
-      "community": 58
+      "community": 59
     },
     {
       "label": "test_measurement_falls_back_from_stale_governance_repo_path()",
@@ -1433,7 +1433,7 @@
       "source_file": "scripts/knowledge_base/test_graphify_usage_logging_contract.py",
       "source_location": "L193",
       "id": "test_graphify_usage_logging_contract_test_measurement_falls_back_from_stale_governance_repo_path",
-      "community": 58
+      "community": 59
     },
     {
       "label": "main()",
@@ -1441,7 +1441,7 @@
       "source_file": "scripts/knowledge_base/test_graphify_usage_logging_contract.py",
       "source_location": "L247",
       "id": "test_graphify_usage_logging_contract_main",
-      "community": 58
+      "community": 59
     },
     {
       "label": "update_knowledge_index.py",
@@ -1481,7 +1481,7 @@
       "source_file": "scripts/lam/runtime_inventory.py",
       "source_location": "L1",
       "id": "runtime_inventory",
-      "community": 56
+      "community": 57
     },
     {
       "label": "_run()",
@@ -1489,7 +1489,7 @@
       "source_file": "scripts/lam/runtime_inventory.py",
       "source_location": "L25",
       "id": "runtime_inventory_run",
-      "community": 56
+      "community": 57
     },
     {
       "label": "mac_hardware()",
@@ -1497,7 +1497,7 @@
       "source_file": "scripts/lam/runtime_inventory.py",
       "source_location": "L29",
       "id": "runtime_inventory_mac_hardware",
-      "community": 56
+      "community": 57
     },
     {
       "label": "import_available()",
@@ -1505,7 +1505,7 @@
       "source_file": "scripts/lam/runtime_inventory.py",
       "source_location": "L48",
       "id": "runtime_inventory_import_available",
-      "community": 56
+      "community": 57
     },
     {
       "label": "local_runtime()",
@@ -1513,7 +1513,7 @@
       "source_file": "scripts/lam/runtime_inventory.py",
       "source_location": "L53",
       "id": "runtime_inventory_local_runtime",
-      "community": 56
+      "community": 57
     },
     {
       "label": "windows_ollama()",
@@ -1521,7 +1521,7 @@
       "source_file": "scripts/lam/runtime_inventory.py",
       "source_location": "L62",
       "id": "runtime_inventory_windows_ollama",
-      "community": 56
+      "community": 57
     },
     {
       "label": "pii_guardrail()",
@@ -1529,7 +1529,7 @@
       "source_file": "scripts/lam/runtime_inventory.py",
       "source_location": "L97",
       "id": "runtime_inventory_pii_guardrail",
-      "community": 56
+      "community": 57
     },
     {
       "label": "memory_budget()",
@@ -1537,7 +1537,7 @@
       "source_file": "scripts/lam/runtime_inventory.py",
       "source_location": "L126",
       "id": "runtime_inventory_memory_budget",
-      "community": 56
+      "community": 57
     },
     {
       "label": "build_inventory()",
@@ -1545,7 +1545,7 @@
       "source_file": "scripts/lam/runtime_inventory.py",
       "source_location": "L159",
       "id": "runtime_inventory_build_inventory",
-      "community": 56
+      "community": 57
     },
     {
       "label": "main()",
@@ -1553,7 +1553,7 @@
       "source_file": "scripts/lam/runtime_inventory.py",
       "source_location": "L186",
       "id": "runtime_inventory_main",
-      "community": 56
+      "community": 57
     },
     {
       "label": "test_runtime_inventory.py",
@@ -1561,7 +1561,7 @@
       "source_file": "scripts/lam/test_runtime_inventory.py",
       "source_location": "L1",
       "id": "test_runtime_inventory",
-      "community": 38
+      "community": 37
     },
     {
       "label": "FakeResponse",
@@ -1569,7 +1569,7 @@
       "source_file": "scripts/lam/test_runtime_inventory.py",
       "source_location": "L23",
       "id": "test_runtime_inventory_fakeresponse",
-      "community": 38
+      "community": 37
     },
     {
       "label": ".__init__()",
@@ -1577,7 +1577,7 @@
       "source_file": "scripts/lam/test_runtime_inventory.py",
       "source_location": "L24",
       "id": "test_runtime_inventory_fakeresponse_init",
-      "community": 38
+      "community": 37
     },
     {
       "label": ".__enter__()",
@@ -1585,7 +1585,7 @@
       "source_file": "scripts/lam/test_runtime_inventory.py",
       "source_location": "L27",
       "id": "test_runtime_inventory_fakeresponse_enter",
-      "community": 38
+      "community": 37
     },
     {
       "label": ".__exit__()",
@@ -1593,7 +1593,7 @@
       "source_file": "scripts/lam/test_runtime_inventory.py",
       "source_location": "L30",
       "id": "test_runtime_inventory_fakeresponse_exit",
-      "community": 38
+      "community": 37
     },
     {
       "label": ".read()",
@@ -1601,7 +1601,7 @@
       "source_file": "scripts/lam/test_runtime_inventory.py",
       "source_location": "L33",
       "id": "test_runtime_inventory_fakeresponse_read",
-      "community": 38
+      "community": 37
     },
     {
       "label": "TestRuntimeInventory",
@@ -1609,7 +1609,7 @@
       "source_file": "scripts/lam/test_runtime_inventory.py",
       "source_location": "L37",
       "id": "test_runtime_inventory_testruntimeinventory",
-      "community": 38
+      "community": 37
     },
     {
       "label": ".test_windows_timeout_reports_unreachable_without_payloads()",
@@ -1617,7 +1617,7 @@
       "source_file": "scripts/lam/test_runtime_inventory.py",
       "source_location": "L38",
       "id": "test_runtime_inventory_testruntimeinventory_test_windows_timeout_reports_unreachable_without_payloads",
-      "community": 38
+      "community": 37
     },
     {
       "label": ".test_windows_tags_lists_models_without_payloads()",
@@ -1625,7 +1625,7 @@
       "source_file": "scripts/lam/test_runtime_inventory.py",
       "source_location": "L46",
       "id": "test_runtime_inventory_testruntimeinventory_test_windows_tags_lists_models_without_payloads",
-      "community": 38
+      "community": 37
     },
     {
       "label": ".test_pii_guardrail_missing_patterns_fails_closed()",
@@ -1633,7 +1633,7 @@
       "source_file": "scripts/lam/test_runtime_inventory.py",
       "source_location": "L55",
       "id": "test_runtime_inventory_testruntimeinventory_test_pii_guardrail_missing_patterns_fails_closed",
-      "community": 38
+      "community": 37
     },
     {
       "label": ".test_pii_guardrail_happy_path_detects_email_and_allows_clean_probe()",
@@ -1641,7 +1641,7 @@
       "source_file": "scripts/lam/test_runtime_inventory.py",
       "source_location": "L61",
       "id": "test_runtime_inventory_testruntimeinventory_test_pii_guardrail_happy_path_detects_email_and_allows_clean_probe",
-      "community": 38
+      "community": 37
     },
     {
       "label": ".test_inventory_has_no_payload_routing()",
@@ -1649,7 +1649,7 @@
       "source_file": "scripts/lam/test_runtime_inventory.py",
       "source_location": "L68",
       "id": "test_runtime_inventory_testruntimeinventory_test_inventory_has_no_payload_routing",
-      "community": 38
+      "community": 37
     },
     {
       "label": ".test_qwen36_large_worker_is_mac_mlx_on_demand_only()",
@@ -1657,7 +1657,7 @@
       "source_file": "scripts/lam/test_runtime_inventory.py",
       "source_location": "L86",
       "id": "test_runtime_inventory_testruntimeinventory_test_qwen36_large_worker_is_mac_mlx_on_demand_only",
-      "community": 38
+      "community": 37
     },
     {
       "label": ".test_qwen36_config_and_inventory_budget_stay_aligned()",
@@ -1665,7 +1665,7 @@
       "source_file": "scripts/lam/test_runtime_inventory.py",
       "source_location": "L95",
       "id": "test_runtime_inventory_testruntimeinventory_test_qwen36_config_and_inventory_budget_stay_aligned",
-      "community": 38
+      "community": 37
     },
     {
       "label": ".test_local_qwen_ladder_and_gemma_shadow_policy_are_explicit()",
@@ -1673,7 +1673,7 @@
       "source_file": "scripts/lam/test_runtime_inventory.py",
       "source_location": "L103",
       "id": "test_runtime_inventory_testruntimeinventory_test_local_qwen_ladder_and_gemma_shadow_policy_are_explicit",
-      "community": 38
+      "community": 37
     },
     {
       "label": "delegation_gate.py",
@@ -1681,7 +1681,7 @@
       "source_file": "scripts/orchestrator/delegation_gate.py",
       "source_location": "L1",
       "id": "delegation_gate",
-      "community": 22
+      "community": 25
     },
     {
       "label": "OwnerRule",
@@ -1689,7 +1689,7 @@
       "source_file": "scripts/orchestrator/delegation_gate.py",
       "source_location": "L24",
       "id": "delegation_gate_ownerrule",
-      "community": 22
+      "community": 25
     },
     {
       "label": "GateDecision",
@@ -1697,7 +1697,7 @@
       "source_file": "scripts/orchestrator/delegation_gate.py",
       "source_location": "L32",
       "id": "delegation_gate_gatedecision",
-      "community": 22
+      "community": 25
     },
     {
       "label": ".as_dict()",
@@ -1705,7 +1705,7 @@
       "source_file": "scripts/orchestrator/delegation_gate.py",
       "source_location": "L39",
       "id": "delegation_gate_gatedecision_as_dict",
-      "community": 22
+      "community": 25
     },
     {
       "label": "_normalize()",
@@ -1713,7 +1713,7 @@
       "source_file": "scripts/orchestrator/delegation_gate.py",
       "source_location": "L49",
       "id": "delegation_gate_normalize",
-      "community": 22
+      "community": 25
     },
     {
       "label": "_contains_term()",
@@ -1721,7 +1721,7 @@
       "source_file": "scripts/orchestrator/delegation_gate.py",
       "source_location": "L53",
       "id": "delegation_gate_contains_term",
-      "community": 22
+      "community": 25
     },
     {
       "label": "load_rules()",
@@ -1729,7 +1729,7 @@
       "source_file": "scripts/orchestrator/delegation_gate.py",
       "source_location": "L60",
       "id": "delegation_gate_load_rules",
-      "community": 22
+      "community": 25
     },
     {
       "label": "deterministic_match()",
@@ -1737,7 +1737,7 @@
       "source_file": "scripts/orchestrator/delegation_gate.py",
       "source_location": "L93",
       "id": "delegation_gate_deterministic_match",
-      "community": 22
+      "community": 25
     },
     {
       "label": "classifier_match()",
@@ -1745,7 +1745,7 @@
       "source_file": "scripts/orchestrator/delegation_gate.py",
       "source_location": "L118",
       "id": "delegation_gate_classifier_match",
-      "community": 22
+      "community": 25
     },
     {
       "label": "apply_policy()",
@@ -1753,7 +1753,7 @@
       "source_file": "scripts/orchestrator/delegation_gate.py",
       "source_location": "L132",
       "id": "delegation_gate_apply_policy",
-      "community": 22
+      "community": 25
     },
     {
       "label": "decide()",
@@ -1761,7 +1761,7 @@
       "source_file": "scripts/orchestrator/delegation_gate.py",
       "source_location": "L159",
       "id": "delegation_gate_decide",
-      "community": 22
+      "community": 25
     },
     {
       "label": "_load_classifier()",
@@ -1769,7 +1769,7 @@
       "source_file": "scripts/orchestrator/delegation_gate.py",
       "source_location": "L174",
       "id": "delegation_gate_load_classifier",
-      "community": 22
+      "community": 25
     },
     {
       "label": "_run_cli()",
@@ -1777,7 +1777,7 @@
       "source_file": "scripts/orchestrator/delegation_gate.py",
       "source_location": "L183",
       "id": "delegation_gate_run_cli",
-      "community": 22
+      "community": 25
     },
     {
       "label": "hitl_relay_queue.py",
@@ -1785,7 +1785,7 @@
       "source_file": "scripts/orchestrator/hitl_relay_queue.py",
       "source_location": "L1",
       "id": "hitl_relay_queue",
-      "community": 16
+      "community": 20
     },
     {
       "label": "QueueResult",
@@ -1793,7 +1793,7 @@
       "source_file": "scripts/orchestrator/hitl_relay_queue.py",
       "source_location": "L38",
       "id": "hitl_relay_queue_queueresult",
-      "community": 16
+      "community": 20
     },
     {
       "label": "utc_now()",
@@ -1801,7 +1801,7 @@
       "source_file": "scripts/orchestrator/hitl_relay_queue.py",
       "source_location": "L46",
       "id": "hitl_relay_queue_utc_now",
-      "community": 16
+      "community": 20
     },
     {
       "label": "ensure_queue()",
@@ -1809,7 +1809,7 @@
       "source_file": "scripts/orchestrator/hitl_relay_queue.py",
       "source_location": "L50",
       "id": "hitl_relay_queue_ensure_queue",
-      "community": 16
+      "community": 20
     },
     {
       "label": "packet_uuid()",
@@ -1817,7 +1817,7 @@
       "source_file": "scripts/orchestrator/hitl_relay_queue.py",
       "source_location": "L55",
       "id": "hitl_relay_queue_packet_uuid",
-      "community": 16
+      "community": 20
     },
     {
       "label": "atomic_write_json()",
@@ -1825,7 +1825,7 @@
       "source_file": "scripts/orchestrator/hitl_relay_queue.py",
       "source_location": "L59",
       "id": "hitl_relay_queue_atomic_write_json",
-      "community": 16
+      "community": 20
     },
     {
       "label": "append_audit()",
@@ -1833,7 +1833,7 @@
       "source_file": "scripts/orchestrator/hitl_relay_queue.py",
       "source_location": "L67",
       "id": "hitl_relay_queue_append_audit",
-      "community": 16
+      "community": 20
     },
     {
       "label": "load_packet()",
@@ -1841,7 +1841,7 @@
       "source_file": "scripts/orchestrator/hitl_relay_queue.py",
       "source_location": "L74",
       "id": "hitl_relay_queue_load_packet",
-      "community": 16
+      "community": 20
     },
     {
       "label": "_base_packet()",
@@ -1849,7 +1849,7 @@
       "source_file": "scripts/orchestrator/hitl_relay_queue.py",
       "source_location": "L81",
       "id": "hitl_relay_queue_base_packet",
-      "community": 16
+      "community": 20
     },
     {
       "label": "build_request()",
@@ -1857,7 +1857,7 @@
       "source_file": "scripts/orchestrator/hitl_relay_queue.py",
       "source_location": "L108",
       "id": "hitl_relay_queue_build_request",
-      "community": 16
+      "community": 20
     },
     {
       "label": "enqueue_request()",
@@ -1865,7 +1865,7 @@
       "source_file": "scripts/orchestrator/hitl_relay_queue.py",
       "source_location": "L147",
       "id": "hitl_relay_queue_enqueue_request",
-      "community": 16
+      "community": 20
     },
     {
       "label": "process_response()",
@@ -1873,7 +1873,7 @@
       "source_file": "scripts/orchestrator/hitl_relay_queue.py",
       "source_location": "L152",
       "id": "hitl_relay_queue_process_response",
-      "community": 16
+      "community": 20
     },
     {
       "label": "_build_response_packet()",
@@ -1881,7 +1881,7 @@
       "source_file": "scripts/orchestrator/hitl_relay_queue.py",
       "source_location": "L244",
       "id": "hitl_relay_queue_build_response_packet",
-      "community": 16
+      "community": 20
     },
     {
       "label": "_build_decision_packet()",
@@ -1889,7 +1889,7 @@
       "source_file": "scripts/orchestrator/hitl_relay_queue.py",
       "source_location": "L291",
       "id": "hitl_relay_queue_build_decision_packet",
-      "community": 16
+      "community": 20
     },
     {
       "label": "_build_instruction_packet()",
@@ -1897,7 +1897,7 @@
       "source_file": "scripts/orchestrator/hitl_relay_queue.py",
       "source_location": "L307",
       "id": "hitl_relay_queue_build_instruction_packet",
-      "community": 16
+      "community": 20
     },
     {
       "label": "_build_resume_packet()",
@@ -1905,7 +1905,7 @@
       "source_file": "scripts/orchestrator/hitl_relay_queue.py",
       "source_location": "L326",
       "id": "hitl_relay_queue_build_resume_packet",
-      "community": 16
+      "community": 20
     },
     {
       "label": "_validated_write()",
@@ -1913,7 +1913,7 @@
       "source_file": "scripts/orchestrator/hitl_relay_queue.py",
       "source_location": "L346",
       "id": "hitl_relay_queue_validated_write",
-      "community": 16
+      "community": 20
     },
     {
       "label": "_dead_letter()",
@@ -1921,7 +1921,7 @@
       "source_file": "scripts/orchestrator/hitl_relay_queue.py",
       "source_location": "L366",
       "id": "hitl_relay_queue_dead_letter",
-      "community": 16
+      "community": 20
     },
     {
       "label": "replay_audit()",
@@ -1929,7 +1929,7 @@
       "source_file": "scripts/orchestrator/hitl_relay_queue.py",
       "source_location": "L384",
       "id": "hitl_relay_queue_replay_audit",
-      "community": 16
+      "community": 20
     },
     {
       "label": "_run_cli()",
@@ -1937,7 +1937,7 @@
       "source_file": "scripts/orchestrator/hitl_relay_queue.py",
       "source_location": "L400",
       "id": "hitl_relay_queue_run_cli",
-      "community": 16
+      "community": 20
     },
     {
       "label": "packet_queue.py",
@@ -1945,7 +1945,7 @@
       "source_file": "scripts/orchestrator/packet_queue.py",
       "source_location": "L1",
       "id": "packet_queue",
-      "community": 24
+      "community": 10
     },
     {
       "label": "_load_packet_validator()",
@@ -1953,7 +1953,7 @@
       "source_file": "scripts/orchestrator/packet_queue.py",
       "source_location": "L33",
       "id": "packet_queue_load_packet_validator",
-      "community": 24
+      "community": 10
     },
     {
       "label": "QueueDecision",
@@ -1961,7 +1961,7 @@
       "source_file": "scripts/orchestrator/packet_queue.py",
       "source_location": "L47",
       "id": "packet_queue_queuedecision",
-      "community": 24
+      "community": 10
     },
     {
       "label": "utc_now()",
@@ -1969,7 +1969,7 @@
       "source_file": "scripts/orchestrator/packet_queue.py",
       "source_location": "L53",
       "id": "packet_queue_utc_now",
-      "community": 24
+      "community": 10
     },
     {
       "label": "sha256_file()",
@@ -1977,7 +1977,7 @@
       "source_file": "scripts/orchestrator/packet_queue.py",
       "source_location": "L57",
       "id": "packet_queue_sha256_file",
-      "community": 24
+      "community": 10
     },
     {
       "label": "ensure_queue()",
@@ -1985,7 +1985,7 @@
       "source_file": "scripts/orchestrator/packet_queue.py",
       "source_location": "L65",
       "id": "packet_queue_ensure_queue",
-      "community": 24
+      "community": 10
     },
     {
       "label": "load_packet()",
@@ -1993,7 +1993,7 @@
       "source_file": "scripts/orchestrator/packet_queue.py",
       "source_location": "L71",
       "id": "packet_queue_load_packet",
-      "community": 24
+      "community": 10
     },
     {
       "label": "atomic_write_packet()",
@@ -2001,7 +2001,7 @@
       "source_file": "scripts/orchestrator/packet_queue.py",
       "source_location": "L81",
       "id": "packet_queue_atomic_write_packet",
-      "community": 24
+      "community": 10
     },
     {
       "label": "_repo_relative_path()",
@@ -2009,7 +2009,7 @@
       "source_file": "scripts/orchestrator/packet_queue.py",
       "source_location": "L89",
       "id": "packet_queue_repo_relative_path",
-      "community": 24
+      "community": 10
     },
     {
       "label": "_load_plan()",
@@ -2017,7 +2017,7 @@
       "source_file": "scripts/orchestrator/packet_queue.py",
       "source_location": "L100",
       "id": "packet_queue_load_plan",
-      "community": 24
+      "community": 10
     },
     {
       "label": "_validate_fallback_ref()",
@@ -2025,7 +2025,7 @@
       "source_file": "scripts/orchestrator/packet_queue.py",
       "source_location": "L113",
       "id": "packet_queue_validate_fallback_ref",
-      "community": 24
+      "community": 10
     },
     {
       "label": "_validate_execution_scope_ref()",
@@ -2033,7 +2033,7 @@
       "source_file": "scripts/orchestrator/packet_queue.py",
       "source_location": "L124",
       "id": "packet_queue_validate_execution_scope_ref",
-      "community": 24
+      "community": 10
     },
     {
       "label": "_validate_local_refs()",
@@ -2041,7 +2041,7 @@
       "source_file": "scripts/orchestrator/packet_queue.py",
       "source_location": "L147",
       "id": "packet_queue_validate_local_refs",
-      "community": 24
+      "community": 10
     },
     {
       "label": "validate_for_dispatch()",
@@ -2049,7 +2049,7 @@
       "source_file": "scripts/orchestrator/packet_queue.py",
       "source_location": "L156",
       "id": "packet_queue_validate_for_dispatch",
-      "community": 24
+      "community": 10
     },
     {
       "label": "_audit_path()",
@@ -2057,7 +2057,7 @@
       "source_file": "scripts/orchestrator/packet_queue.py",
       "source_location": "L218",
       "id": "packet_queue_audit_path",
-      "community": 24
+      "community": 10
     },
     {
       "label": "append_audit()",
@@ -2065,7 +2065,7 @@
       "source_file": "scripts/orchestrator/packet_queue.py",
       "source_location": "L222",
       "id": "packet_queue_append_audit",
-      "community": 24
+      "community": 10
     },
     {
       "label": "transition_packet()",
@@ -2073,7 +2073,7 @@
       "source_file": "scripts/orchestrator/packet_queue.py",
       "source_location": "L228",
       "id": "packet_queue_transition_packet",
-      "community": 24
+      "community": 10
     },
     {
       "label": "_write_transition_audit()",
@@ -2081,7 +2081,7 @@
       "source_file": "scripts/orchestrator/packet_queue.py",
       "source_location": "L287",
       "id": "packet_queue_write_transition_audit",
-      "community": 24
+      "community": 10
     },
     {
       "label": "replay_audit()",
@@ -2089,7 +2089,7 @@
       "source_file": "scripts/orchestrator/packet_queue.py",
       "source_location": "L316",
       "id": "packet_queue_replay_audit",
-      "community": 24
+      "community": 10
     },
     {
       "label": "_run_cli()",
@@ -2097,7 +2097,7 @@
       "source_file": "scripts/orchestrator/packet_queue.py",
       "source_location": "L348",
       "id": "packet_queue_run_cli",
-      "community": 24
+      "community": 10
     },
     {
       "label": "Replay audit events into logical latest states.      `latest_states` includes ac",
@@ -2105,7 +2105,7 @@
       "source_file": "scripts/orchestrator/packet_queue.py",
       "source_location": "L317",
       "id": "packet_queue_rationale_317",
-      "community": 24
+      "community": 10
     },
     {
       "label": "read_only_observer.py",
@@ -2113,7 +2113,7 @@
       "source_file": "scripts/orchestrator/read_only_observer.py",
       "source_location": "L1",
       "id": "read_only_observer",
-      "community": 5
+      "community": 6
     },
     {
       "label": "ArtifactStatus",
@@ -2121,7 +2121,7 @@
       "source_file": "scripts/orchestrator/read_only_observer.py",
       "source_location": "L33",
       "id": "read_only_observer_artifactstatus",
-      "community": 5
+      "community": 6
     },
     {
       "label": "RepoReport",
@@ -2129,7 +2129,7 @@
       "source_file": "scripts/orchestrator/read_only_observer.py",
       "source_location": "L41",
       "id": "read_only_observer_reporeport",
-      "community": 5
+      "community": 6
     },
     {
       "label": "_run_git()",
@@ -2137,7 +2137,7 @@
       "source_file": "scripts/orchestrator/read_only_observer.py",
       "source_location": "L53",
       "id": "read_only_observer_run_git",
-      "community": 5
+      "community": 6
     },
     {
       "label": "_git_commit()",
@@ -2145,7 +2145,7 @@
       "source_file": "scripts/orchestrator/read_only_observer.py",
       "source_location": "L57",
       "id": "read_only_observer_git_commit",
-      "community": 5
+      "community": 6
     },
     {
       "label": "_sha256_file()",
@@ -2153,7 +2153,7 @@
       "source_file": "scripts/orchestrator/read_only_observer.py",
       "source_location": "L66",
       "id": "read_only_observer_sha256_file",
-      "community": 5
+      "community": 6
     },
     {
       "label": "_artifact()",
@@ -2161,7 +2161,7 @@
       "source_file": "scripts/orchestrator/read_only_observer.py",
       "source_location": "L77",
       "id": "read_only_observer_artifact",
-      "community": 5
+      "community": 6
     },
     {
       "label": "_count_open_issue_metadata()",
@@ -2169,7 +2169,7 @@
       "source_file": "scripts/orchestrator/read_only_observer.py",
       "source_location": "L92",
       "id": "read_only_observer_count_open_issue_metadata",
-      "community": 5
+      "community": 6
     },
     {
       "label": "_repo_path()",
@@ -2177,7 +2177,7 @@
       "source_file": "scripts/orchestrator/read_only_observer.py",
       "source_location": "L103",
       "id": "read_only_observer_repo_path",
-      "community": 5
+      "community": 6
     },
     {
       "label": "_latest_raw_issue_file()",
@@ -2185,7 +2185,7 @@
       "source_file": "scripts/orchestrator/read_only_observer.py",
       "source_location": "L109",
       "id": "read_only_observer_latest_raw_issue_file",
-      "community": 5
+      "community": 6
     },
     {
       "label": "_planning_gate()",
@@ -2193,7 +2193,7 @@
       "source_file": "scripts/orchestrator/read_only_observer.py",
       "source_location": "L118",
       "id": "read_only_observer_planning_gate",
-      "community": 5
+      "community": 6
     },
     {
       "label": "_daemon_readiness()",
@@ -2201,7 +2201,7 @@
       "source_file": "scripts/orchestrator/read_only_observer.py",
       "source_location": "L129",
       "id": "read_only_observer_daemon_readiness",
-      "community": 5
+      "community": 6
     },
     {
       "label": "_repo_report()",
@@ -2209,7 +2209,7 @@
       "source_file": "scripts/orchestrator/read_only_observer.py",
       "source_location": "L141",
       "id": "read_only_observer_repo_report",
-      "community": 5
+      "community": 6
     },
     {
       "label": "_report_to_json()",
@@ -2217,7 +2217,7 @@
       "source_file": "scripts/orchestrator/read_only_observer.py",
       "source_location": "L182",
       "id": "read_only_observer_report_to_json",
-      "community": 5
+      "community": 6
     },
     {
       "label": "_write_markdown()",
@@ -2225,7 +2225,7 @@
       "source_file": "scripts/orchestrator/read_only_observer.py",
       "source_location": "L188",
       "id": "read_only_observer_write_markdown",
-      "community": 5
+      "community": 6
     },
     {
       "label": "write_reports()",
@@ -2233,7 +2233,7 @@
       "source_file": "scripts/orchestrator/read_only_observer.py",
       "source_location": "L229",
       "id": "read_only_observer_write_reports",
-      "community": 5
+      "community": 6
     },
     {
       "label": "build_reports()",
@@ -2241,7 +2241,7 @@
       "source_file": "scripts/orchestrator/read_only_observer.py",
       "source_location": "L242",
       "id": "read_only_observer_build_reports",
-      "community": 5
+      "community": 6
     },
     {
       "label": "main()",
@@ -2249,7 +2249,7 @@
       "source_file": "scripts/orchestrator/read_only_observer.py",
       "source_location": "L250",
       "id": "read_only_observer_main",
-      "community": 5
+      "community": 6
     },
     {
       "label": "self_learning.py",
@@ -2257,7 +2257,7 @@
       "source_file": "scripts/orchestrator/self_learning.py",
       "source_location": "L1",
       "id": "self_learning",
-      "community": 12
+      "community": 15
     },
     {
       "label": "LearningEntry",
@@ -2265,7 +2265,7 @@
       "source_file": "scripts/orchestrator/self_learning.py",
       "source_location": "L26",
       "id": "self_learning_learningentry",
-      "community": 12
+      "community": 15
     },
     {
       "label": "LearningMatch",
@@ -2273,7 +2273,7 @@
       "source_file": "scripts/orchestrator/self_learning.py",
       "source_location": "L38",
       "id": "self_learning_learningmatch",
-      "community": 12
+      "community": 15
     },
     {
       "label": "utc_now()",
@@ -2281,7 +2281,7 @@
       "source_file": "scripts/orchestrator/self_learning.py",
       "source_location": "L47",
       "id": "self_learning_utc_now",
-      "community": 12
+      "community": 15
     },
     {
       "label": "tokenize()",
@@ -2289,7 +2289,7 @@
       "source_file": "scripts/orchestrator/self_learning.py",
       "source_location": "L51",
       "id": "self_learning_tokenize",
-      "community": 12
+      "community": 15
     },
     {
       "label": "_rel()",
@@ -2297,7 +2297,7 @@
       "source_file": "scripts/orchestrator/self_learning.py",
       "source_location": "L59",
       "id": "self_learning_rel",
-      "community": 12
+      "community": 15
     },
     {
       "label": "_entry_id()",
@@ -2305,7 +2305,7 @@
       "source_file": "scripts/orchestrator/self_learning.py",
       "source_location": "L66",
       "id": "self_learning_entry_id",
-      "community": 12
+      "community": 15
     },
     {
       "label": "_date_from_text()",
@@ -2313,7 +2313,7 @@
       "source_file": "scripts/orchestrator/self_learning.py",
       "source_location": "L70",
       "id": "self_learning_date_from_text",
-      "community": 12
+      "community": 15
     },
     {
       "label": "load_fail_fast()",
@@ -2321,7 +2321,7 @@
       "source_file": "scripts/orchestrator/self_learning.py",
       "source_location": "L75",
       "id": "self_learning_load_fail_fast",
-      "community": 12
+      "community": 15
     },
     {
       "label": "load_error_patterns()",
@@ -2329,7 +2329,7 @@
       "source_file": "scripts/orchestrator/self_learning.py",
       "source_location": "L108",
       "id": "self_learning_load_error_patterns",
-      "community": 12
+      "community": 15
     },
     {
       "label": "_section()",
@@ -2337,7 +2337,7 @@
       "source_file": "scripts/orchestrator/self_learning.py",
       "source_location": "L138",
       "id": "self_learning_section",
-      "community": 12
+      "community": 15
     },
     {
       "label": "load_closeouts()",
@@ -2345,7 +2345,7 @@
       "source_file": "scripts/orchestrator/self_learning.py",
       "source_location": "L149",
       "id": "self_learning_load_closeouts",
-      "community": 12
+      "community": 15
     },
     {
       "label": "load_operator_context()",
@@ -2353,7 +2353,7 @@
       "source_file": "scripts/orchestrator/self_learning.py",
       "source_location": "L176",
       "id": "self_learning_load_operator_context",
-      "community": 12
+      "community": 15
     },
     {
       "label": "load_compendium_attention()",
@@ -2361,7 +2361,7 @@
       "source_file": "scripts/orchestrator/self_learning.py",
       "source_location": "L199",
       "id": "self_learning_load_compendium_attention",
-      "community": 12
+      "community": 15
     },
     {
       "label": "load_graph_attention()",
@@ -2369,7 +2369,7 @@
       "source_file": "scripts/orchestrator/self_learning.py",
       "source_location": "L206",
       "id": "self_learning_load_graph_attention",
-      "community": 12
+      "community": 15
     },
     {
       "label": "load_entries()",
@@ -2377,7 +2377,7 @@
       "source_file": "scripts/orchestrator/self_learning.py",
       "source_location": "L213",
       "id": "self_learning_load_entries",
-      "community": 12
+      "community": 15
     },
     {
       "label": "duplicate_counts()",
@@ -2385,7 +2385,7 @@
       "source_file": "scripts/orchestrator/self_learning.py",
       "source_location": "L222",
       "id": "self_learning_duplicate_counts",
-      "community": 12
+      "community": 15
     },
     {
       "label": "lookup_patterns()",
@@ -2393,7 +2393,7 @@
       "source_file": "scripts/orchestrator/self_learning.py",
       "source_location": "L231",
       "id": "self_learning_lookup_patterns",
-      "community": 12
+      "community": 15
     },
     {
       "label": "query_from_packet()",
@@ -2401,7 +2401,7 @@
       "source_file": "scripts/orchestrator/self_learning.py",
       "source_location": "L259",
       "id": "self_learning_query_from_packet",
-      "community": 12
+      "community": 15
     },
     {
       "label": "enrich_packet()",
@@ -2409,7 +2409,7 @@
       "source_file": "scripts/orchestrator/self_learning.py",
       "source_location": "L272",
       "id": "self_learning_enrich_packet",
-      "community": 12
+      "community": 15
     },
     {
       "label": "atomic_write_yaml()",
@@ -2417,7 +2417,7 @@
       "source_file": "scripts/orchestrator/self_learning.py",
       "source_location": "L289",
       "id": "self_learning_atomic_write_yaml",
-      "community": 12
+      "community": 15
     },
     {
       "label": "record_failure()",
@@ -2425,7 +2425,7 @@
       "source_file": "scripts/orchestrator/self_learning.py",
       "source_location": "L296",
       "id": "self_learning_record_failure",
-      "community": 12
+      "community": 15
     },
     {
       "label": "build_report()",
@@ -2433,7 +2433,7 @@
       "source_file": "scripts/orchestrator/self_learning.py",
       "source_location": "L328",
       "id": "self_learning_build_report",
-      "community": 12
+      "community": 15
     },
     {
       "label": "report_markdown()",
@@ -2441,7 +2441,7 @@
       "source_file": "scripts/orchestrator/self_learning.py",
       "source_location": "L352",
       "id": "self_learning_report_markdown",
-      "community": 12
+      "community": 15
     },
     {
       "label": "_run_cli()",
@@ -2449,7 +2449,7 @@
       "source_file": "scripts/orchestrator/self_learning.py",
       "source_location": "L374",
       "id": "self_learning_run_cli",
-      "community": 12
+      "community": 15
     },
     {
       "label": "test_delegation_gate.py",
@@ -2457,7 +2457,7 @@
       "source_file": "scripts/orchestrator/test_delegation_gate.py",
       "source_location": "L1",
       "id": "test_delegation_gate",
-      "community": 22
+      "community": 25
     },
     {
       "label": "test_rules_cover_all_da_delegation_task_types()",
@@ -2465,7 +2465,7 @@
       "source_file": "scripts/orchestrator/test_delegation_gate.py",
       "source_location": "L13",
       "id": "test_delegation_gate_test_rules_cover_all_da_delegation_task_types",
-      "community": 22
+      "community": 25
     },
     {
       "label": "test_high_confidence_agent_owned_work_blocks()",
@@ -2473,7 +2473,7 @@
       "source_file": "scripts/orchestrator/test_delegation_gate.py",
       "source_location": "L29",
       "id": "test_delegation_gate_test_high_confidence_agent_owned_work_blocks",
-      "community": 22
+      "community": 25
     },
     {
       "label": "test_high_confidence_bash_owned_work_blocks()",
@@ -2481,7 +2481,7 @@
       "source_file": "scripts/orchestrator/test_delegation_gate.py",
       "source_location": "L40",
       "id": "test_delegation_gate_test_high_confidence_bash_owned_work_blocks",
-      "community": 22
+      "community": 25
     },
     {
       "label": "test_explore_is_warn_only_for_implementation_scoped_owned_work()",
@@ -2489,7 +2489,7 @@
       "source_file": "scripts/orchestrator/test_delegation_gate.py",
       "source_location": "L50",
       "id": "test_delegation_gate_test_explore_is_warn_only_for_implementation_scoped_owned_work",
-      "community": 22
+      "community": 25
     },
     {
       "label": "test_explore_allows_non_implementation_routing_context()",
@@ -2497,7 +2497,7 @@
       "source_file": "scripts/orchestrator/test_delegation_gate.py",
       "source_location": "L61",
       "id": "test_delegation_gate_test_explore_allows_non_implementation_routing_context",
-      "community": 22
+      "community": 25
     },
     {
       "label": "test_read_is_never_gated()",
@@ -2505,7 +2505,7 @@
       "source_file": "scripts/orchestrator/test_delegation_gate.py",
       "source_location": "L70",
       "id": "test_delegation_gate_test_read_is_never_gated",
-      "community": 22
+      "community": 25
     },
     {
       "label": "test_bypass_flag_allows_and_records_source()",
@@ -2513,7 +2513,7 @@
       "source_file": "scripts/orchestrator/test_delegation_gate.py",
       "source_location": "L80",
       "id": "test_delegation_gate_test_bypass_flag_allows_and_records_source",
-      "community": 22
+      "community": 25
     },
     {
       "label": "test_classifier_fallback_warns_when_rules_are_inconclusive()",
@@ -2521,7 +2521,7 @@
       "source_file": "scripts/orchestrator/test_delegation_gate.py",
       "source_location": "L91",
       "id": "test_delegation_gate_test_classifier_fallback_warns_when_rules_are_inconclusive",
-      "community": 22
+      "community": 25
     },
     {
       "label": "test_delegation_hook.py",
@@ -2617,7 +2617,7 @@
       "source_file": "scripts/orchestrator/test_hitl_relay_final_e2e.py",
       "source_location": "L1",
       "id": "test_hitl_relay_final_e2e",
-      "community": 16
+      "community": 20
     },
     {
       "label": "_final_request()",
@@ -2625,7 +2625,7 @@
       "source_file": "scripts/orchestrator/test_hitl_relay_final_e2e.py",
       "source_location": "L20",
       "id": "test_hitl_relay_final_e2e_final_request",
-      "community": 16
+      "community": 20
     },
     {
       "label": "_process()",
@@ -2633,7 +2633,7 @@
       "source_file": "scripts/orchestrator/test_hitl_relay_final_e2e.py",
       "source_location": "L48",
       "id": "test_hitl_relay_final_e2e_process",
-      "community": 16
+      "community": 20
     },
     {
       "label": "_load()",
@@ -2641,7 +2641,7 @@
       "source_file": "scripts/orchestrator/test_hitl_relay_final_e2e.py",
       "source_location": "L79",
       "id": "test_hitl_relay_final_e2e_load",
-      "community": 16
+      "community": 20
     },
     {
       "label": "test_final_e2e_approval_path_preserves_full_identity_chain()",
@@ -2649,7 +2649,7 @@
       "source_file": "scripts/orchestrator/test_hitl_relay_final_e2e.py",
       "source_location": "L83",
       "id": "test_hitl_relay_final_e2e_test_final_e2e_approval_path_preserves_full_identity_chain",
-      "community": 16
+      "community": 20
     },
     {
       "label": "test_final_e2e_request_changes_is_not_treated_as_approval()",
@@ -2657,7 +2657,7 @@
       "source_file": "scripts/orchestrator/test_hitl_relay_final_e2e.py",
       "source_location": "L127",
       "id": "test_hitl_relay_final_e2e_test_final_e2e_request_changes_is_not_treated_as_approval",
-      "community": 16
+      "community": 20
     },
     {
       "label": "test_final_e2e_ambiguous_response_requests_clarification_without_instruction()",
@@ -2665,7 +2665,7 @@
       "source_file": "scripts/orchestrator/test_hitl_relay_final_e2e.py",
       "source_location": "L147",
       "id": "test_hitl_relay_final_e2e_test_final_e2e_ambiguous_response_requests_clarification_without_instruction",
-      "community": 16
+      "community": 20
     },
     {
       "label": "test_final_e2e_stale_session_creates_resume_instead_of_instruction()",
@@ -2673,7 +2673,7 @@
       "source_file": "scripts/orchestrator/test_hitl_relay_final_e2e.py",
       "source_location": "L166",
       "id": "test_hitl_relay_final_e2e_test_final_e2e_stale_session_creates_resume_instead_of_instruction",
-      "community": 16
+      "community": 20
     },
     {
       "label": "test_final_e2e_duplicate_replay_and_expired_replies_fail_closed()",
@@ -2681,7 +2681,7 @@
       "source_file": "scripts/orchestrator/test_hitl_relay_final_e2e.py",
       "source_location": "L189",
       "id": "test_hitl_relay_final_e2e_test_final_e2e_duplicate_replay_and_expired_replies_fail_closed",
-      "community": 16
+      "community": 20
     },
     {
       "label": "test_final_e2e_external_channel_pii_is_refused_without_instruction()",
@@ -2689,7 +2689,7 @@
       "source_file": "scripts/orchestrator/test_hitl_relay_final_e2e.py",
       "source_location": "L225",
       "id": "test_hitl_relay_final_e2e_test_final_e2e_external_channel_pii_is_refused_without_instruction",
-      "community": 16
+      "community": 20
     },
     {
       "label": "test_hitl_relay_queue.py",
@@ -2697,7 +2697,7 @@
       "source_file": "scripts/orchestrator/test_hitl_relay_queue.py",
       "source_location": "L1",
       "id": "test_hitl_relay_queue",
-      "community": 50
+      "community": 48
     },
     {
       "label": "_request()",
@@ -2705,7 +2705,7 @@
       "source_file": "scripts/orchestrator/test_hitl_relay_queue.py",
       "source_location": "L15",
       "id": "test_hitl_relay_queue_request",
-      "community": 50
+      "community": 48
     },
     {
       "label": "_process()",
@@ -2713,7 +2713,7 @@
       "source_file": "scripts/orchestrator/test_hitl_relay_queue.py",
       "source_location": "L34",
       "id": "test_hitl_relay_queue_process",
-      "community": 50
+      "community": 48
     },
     {
       "label": "test_local_cli_checkpoint_fixture_creates_valid_hitl_request()",
@@ -2721,7 +2721,7 @@
       "source_file": "scripts/orchestrator/test_hitl_relay_queue.py",
       "source_location": "L59",
       "id": "test_hitl_relay_queue_test_local_cli_checkpoint_fixture_creates_valid_hitl_request",
-      "community": 50
+      "community": 48
     },
     {
       "label": "test_valid_approval_response_produces_bounded_session_instruction()",
@@ -2729,7 +2729,7 @@
       "source_file": "scripts/orchestrator/test_hitl_relay_queue.py",
       "source_location": "L72",
       "id": "test_hitl_relay_queue_test_valid_approval_response_produces_bounded_session_instruction",
-      "community": 50
+      "community": 48
     },
     {
       "label": "test_request_changes_response_preserves_feedback_path_without_approval()",
@@ -2737,7 +2737,7 @@
       "source_file": "scripts/orchestrator/test_hitl_relay_queue.py",
       "source_location": "L92",
       "id": "test_hitl_relay_queue_test_request_changes_response_preserves_feedback_path_without_approval",
-      "community": 50
+      "community": 48
     },
     {
       "label": "test_ambiguous_response_produces_clarification_and_no_instruction()",
@@ -2745,7 +2745,7 @@
       "source_file": "scripts/orchestrator/test_hitl_relay_queue.py",
       "source_location": "L107",
       "id": "test_hitl_relay_queue_test_ambiguous_response_produces_clarification_and_no_instruction",
-      "community": 50
+      "community": 48
     },
     {
       "label": "test_stale_session_fixture_produces_resume_packet()",
@@ -2753,7 +2753,7 @@
       "source_file": "scripts/orchestrator/test_hitl_relay_queue.py",
       "source_location": "L121",
       "id": "test_hitl_relay_queue_test_stale_session_fixture_produces_resume_packet",
-      "community": 50
+      "community": 48
     },
     {
       "label": "test_invalid_packet_lands_in_dead_letter_with_validation_errors()",
@@ -2761,7 +2761,7 @@
       "source_file": "scripts/orchestrator/test_hitl_relay_queue.py",
       "source_location": "L137",
       "id": "test_hitl_relay_queue_test_invalid_packet_lands_in_dead_letter_with_validation_errors",
-      "community": 50
+      "community": 48
     },
     {
       "label": "test_expired_response_fails_closed_to_dead_letter()",
@@ -2769,7 +2769,7 @@
       "source_file": "scripts/orchestrator/test_hitl_relay_queue.py",
       "source_location": "L151",
       "id": "test_hitl_relay_queue_test_expired_response_fails_closed_to_dead_letter",
-      "community": 50
+      "community": 48
     },
     {
       "label": "test_replay_reconstructs_decision_path()",
@@ -2777,7 +2777,7 @@
       "source_file": "scripts/orchestrator/test_hitl_relay_queue.py",
       "source_location": "L164",
       "id": "test_hitl_relay_queue_test_replay_reconstructs_decision_path",
-      "community": 50
+      "community": 48
     },
     {
       "label": "test_packet_queue.py",
@@ -2785,7 +2785,7 @@
       "source_file": "scripts/orchestrator/test_packet_queue.py",
       "source_location": "L1",
       "id": "test_packet_queue",
-      "community": 29
+      "community": 10
     },
     {
       "label": "_packet()",
@@ -2793,7 +2793,7 @@
       "source_file": "scripts/orchestrator/test_packet_queue.py",
       "source_location": "L20",
       "id": "test_packet_queue_packet",
-      "community": 29
+      "community": 10
     },
     {
       "label": "TestPacketQueue",
@@ -2801,7 +2801,7 @@
       "source_file": "scripts/orchestrator/test_packet_queue.py",
       "source_location": "L60",
       "id": "test_packet_queue_testpacketqueue",
-      "community": 29
+      "community": 10
     },
     {
       "label": "._write_inbound()",
@@ -2809,7 +2809,7 @@
       "source_file": "scripts/orchestrator/test_packet_queue.py",
       "source_location": "L61",
       "id": "test_packet_queue_testpacketqueue_write_inbound",
-      "community": 29
+      "community": 10
     },
     {
       "label": "._write_execution_scope()",
@@ -2817,7 +2817,7 @@
       "source_file": "scripts/orchestrator/test_packet_queue.py",
       "source_location": "L68",
       "id": "test_packet_queue_testpacketqueue_write_execution_scope",
-      "community": 29
+      "community": 10
     },
     {
       "label": ".test_valid_packet_dry_run_replays_through_queue_without_moving()",
@@ -2825,7 +2825,7 @@
       "source_file": "scripts/orchestrator/test_packet_queue.py",
       "source_location": "L86",
       "id": "test_packet_queue_testpacketqueue_test_valid_packet_dry_run_replays_through_queue_without_moving",
-      "community": 29
+      "community": 10
     },
     {
       "label": ".test_valid_packet_real_dispatch_moves_file()",
@@ -2833,7 +2833,7 @@
       "source_file": "scripts/orchestrator/test_packet_queue.py",
       "source_location": "L116",
       "id": "test_packet_queue_testpacketqueue_test_valid_packet_real_dispatch_moves_file",
-      "community": 29
+      "community": 10
     },
     {
       "label": ".test_invalid_packet_fails_schema_before_dispatch()",
@@ -2841,7 +2841,7 @@
       "source_file": "scripts/orchestrator/test_packet_queue.py",
       "source_location": "L136",
       "id": "test_packet_queue_testpacketqueue_test_invalid_packet_fails_schema_before_dispatch",
-      "community": 29
+      "community": 10
     },
     {
       "label": ".test_pii_packet_halts_before_non_lam_dispatch()",
@@ -2849,7 +2849,7 @@
       "source_file": "scripts/orchestrator/test_packet_queue.py",
       "source_location": "L157",
       "id": "test_packet_queue_testpacketqueue_test_pii_packet_halts_before_non_lam_dispatch",
-      "community": 29
+      "community": 10
     },
     {
       "label": ".test_repeated_known_failure_context_halts_dispatch()",
@@ -2857,7 +2857,7 @@
       "source_file": "scripts/orchestrator/test_packet_queue.py",
       "source_location": "L179",
       "id": "test_packet_queue_testpacketqueue_test_repeated_known_failure_context_halts_dispatch",
-      "community": 29
+      "community": 10
     },
     {
       "label": ".test_pii_halt_reason_takes_precedence_over_known_failure_halt()",
@@ -2865,7 +2865,7 @@
       "source_file": "scripts/orchestrator/test_packet_queue.py",
       "source_location": "L212",
       "id": "test_packet_queue_testpacketqueue_test_pii_halt_reason_takes_precedence_over_known_failure_halt",
-      "community": 29
+      "community": 10
     },
     {
       "label": ".test_dispatch_requires_approved_issue_backed_plan()",
@@ -2873,7 +2873,7 @@
       "source_file": "scripts/orchestrator/test_packet_queue.py",
       "source_location": "L246",
       "id": "test_packet_queue_testpacketqueue_test_dispatch_requires_approved_issue_backed_plan",
-      "community": 29
+      "community": 10
     },
     {
       "label": ".test_dispatch_refuses_schema_valid_packet_without_governance()",
@@ -2881,7 +2881,7 @@
       "source_file": "scripts/orchestrator/test_packet_queue.py",
       "source_location": "L267",
       "id": "test_packet_queue_testpacketqueue_test_dispatch_refuses_schema_valid_packet_without_governance",
-      "community": 29
+      "community": 10
     },
     {
       "label": ".test_dispatch_requires_local_review_artifact_refs_to_exist()",
@@ -2889,7 +2889,7 @@
       "source_file": "scripts/orchestrator/test_packet_queue.py",
       "source_location": "L287",
       "id": "test_packet_queue_testpacketqueue_test_dispatch_requires_local_review_artifact_refs_to_exist",
-      "community": 29
+      "community": 10
     },
     {
       "label": ".test_dispatch_refuses_markdown_execution_scope_ref()",
@@ -2897,7 +2897,7 @@
       "source_file": "scripts/orchestrator/test_packet_queue.py",
       "source_location": "L308",
       "id": "test_packet_queue_testpacketqueue_test_dispatch_refuses_markdown_execution_scope_ref",
-      "community": 29
+      "community": 10
     },
     {
       "label": ".test_dispatch_accepts_json_execution_scope_ref()",
@@ -2905,7 +2905,7 @@
       "source_file": "scripts/orchestrator/test_packet_queue.py",
       "source_location": "L329",
       "id": "test_packet_queue_testpacketqueue_test_dispatch_accepts_json_execution_scope_ref",
-      "community": 29
+      "community": 10
     },
     {
       "label": ".test_replay_counts_refused_events_deterministically()",
@@ -2913,7 +2913,7 @@
       "source_file": "scripts/orchestrator/test_packet_queue.py",
       "source_location": "L360",
       "id": "test_packet_queue_testpacketqueue_test_replay_counts_refused_events_deterministically",
-      "community": 29
+      "community": 10
     },
     {
       "label": ".test_dry_run_authorization_does_not_allow_real_dispatch()",
@@ -2921,7 +2921,7 @@
       "source_file": "scripts/orchestrator/test_packet_queue.py",
       "source_location": "L379",
       "id": "test_packet_queue_testpacketqueue_test_dry_run_authorization_does_not_allow_real_dispatch",
-      "community": 29
+      "community": 10
     },
     {
       "label": "test_read_only_observer.py",
@@ -2985,7 +2985,7 @@
       "source_file": "scripts/orchestrator/test_self_learning.py",
       "source_location": "L1",
       "id": "test_self_learning",
-      "community": 12
+      "community": 15
     },
     {
       "label": "_write_fixture()",
@@ -2993,7 +2993,7 @@
       "source_file": "scripts/orchestrator/test_self_learning.py",
       "source_location": "L17",
       "id": "test_self_learning_write_fixture",
-      "community": 12
+      "community": 15
     },
     {
       "label": "TestSelfLearning",
@@ -3001,7 +3001,7 @@
       "source_file": "scripts/orchestrator/test_self_learning.py",
       "source_location": "L68",
       "id": "test_self_learning_testselflearning",
-      "community": 12
+      "community": 15
     },
     {
       "label": ".test_lookup_returns_cited_prior_patterns()",
@@ -3009,7 +3009,7 @@
       "source_file": "scripts/orchestrator/test_self_learning.py",
       "source_location": "L69",
       "id": "test_self_learning_testselflearning_test_lookup_returns_cited_prior_patterns",
-      "community": 12
+      "community": 15
     },
     {
       "label": ".test_enrich_packet_injects_known_failure_context()",
@@ -3017,7 +3017,7 @@
       "source_file": "scripts/orchestrator/test_self_learning.py",
       "source_location": "L81",
       "id": "test_self_learning_testselflearning_test_enrich_packet_injects_known_failure_context",
-      "community": 12
+      "community": 15
     },
     {
       "label": ".test_record_failure_is_append_only_and_issue_backed()",
@@ -3025,7 +3025,7 @@
       "source_file": "scripts/orchestrator/test_self_learning.py",
       "source_location": "L99",
       "id": "test_self_learning_testselflearning_test_record_failure_is_append_only_and_issue_backed",
-      "community": 12
+      "community": 15
     },
     {
       "label": ".test_record_failure_rejects_out_of_range_issue_numbers()",
@@ -3033,7 +3033,7 @@
       "source_file": "scripts/orchestrator/test_self_learning.py",
       "source_location": "L124",
       "id": "test_self_learning_testselflearning_test_record_failure_rejects_out_of_range_issue_numbers",
-      "community": 12
+      "community": 15
     },
     {
       "label": ".test_report_flags_duplicates_and_graphify_attention_only()",
@@ -3041,7 +3041,7 @@
       "source_file": "scripts/orchestrator/test_self_learning.py",
       "source_location": "L146",
       "id": "test_self_learning_testselflearning_test_report_flags_duplicates_and_graphify_attention_only",
-      "community": 12
+      "community": 15
     },
     {
       "label": "assert_execution_scope.py",
@@ -3049,7 +3049,7 @@
       "source_file": "scripts/overlord/assert_execution_scope.py",
       "source_location": "L1",
       "id": "assert_execution_scope",
-      "community": 9
+      "community": 12
     },
     {
       "label": "LaneClaim",
@@ -3057,7 +3057,7 @@
       "source_file": "scripts/overlord/assert_execution_scope.py",
       "source_location": "L16",
       "id": "assert_execution_scope_laneclaim",
-      "community": 9
+      "community": 12
     },
     {
       "label": "HandoffEvidence",
@@ -3065,7 +3065,7 @@
       "source_file": "scripts/overlord/assert_execution_scope.py",
       "source_location": "L24",
       "id": "assert_execution_scope_handoffevidence",
-      "community": 9
+      "community": 12
     },
     {
       "label": "ExecutionScope",
@@ -3073,7 +3073,7 @@
       "source_file": "scripts/overlord/assert_execution_scope.py",
       "source_location": "L35",
       "id": "assert_execution_scope_executionscope",
-      "community": 9
+      "community": 12
     },
     {
       "label": "_run_git()",
@@ -3081,7 +3081,7 @@
       "source_file": "scripts/overlord/assert_execution_scope.py",
       "source_location": "L46",
       "id": "assert_execution_scope_run_git",
-      "community": 9
+      "community": 12
     },
     {
       "label": "_normalize_repo_path()",
@@ -3089,7 +3089,7 @@
       "source_file": "scripts/overlord/assert_execution_scope.py",
       "source_location": "L56",
       "id": "assert_execution_scope_normalize_repo_path",
-      "community": 9
+      "community": 12
     },
     {
       "label": "_normalize_repo_relative_file_path()",
@@ -3097,7 +3097,7 @@
       "source_file": "scripts/overlord/assert_execution_scope.py",
       "source_location": "L62",
       "id": "assert_execution_scope_normalize_repo_relative_file_path",
-      "community": 9
+      "community": 12
     },
     {
       "label": "_normalize_active_exception_ref()",
@@ -3105,7 +3105,7 @@
       "source_file": "scripts/overlord/assert_execution_scope.py",
       "source_location": "L79",
       "id": "assert_execution_scope_normalize_active_exception_ref",
-      "community": 9
+      "community": 12
     },
     {
       "label": "_parse_iso8601_timestamp()",
@@ -3113,7 +3113,7 @@
       "source_file": "scripts/overlord/assert_execution_scope.py",
       "source_location": "L93",
       "id": "assert_execution_scope_parse_iso8601_timestamp",
-      "community": 9
+      "community": 12
     },
     {
       "label": "_load_handoff_evidence()",
@@ -3121,7 +3121,7 @@
       "source_file": "scripts/overlord/assert_execution_scope.py",
       "source_location": "L108",
       "id": "assert_execution_scope_load_handoff_evidence",
-      "community": 9
+      "community": 12
     },
     {
       "label": "_load_lane_claim()",
@@ -3129,7 +3129,7 @@
       "source_file": "scripts/overlord/assert_execution_scope.py",
       "source_location": "L171",
       "id": "assert_execution_scope_load_lane_claim",
-      "community": 9
+      "community": 12
     },
     {
       "label": "_load_scope()",
@@ -3137,7 +3137,7 @@
       "source_file": "scripts/overlord/assert_execution_scope.py",
       "source_location": "L197",
       "id": "assert_execution_scope_load_scope",
-      "community": 9
+      "community": 12
     },
     {
       "label": "_git_root()",
@@ -3145,7 +3145,7 @@
       "source_file": "scripts/overlord/assert_execution_scope.py",
       "source_location": "L278",
       "id": "assert_execution_scope_git_root",
-      "community": 9
+      "community": 12
     },
     {
       "label": "_current_branch()",
@@ -3153,7 +3153,7 @@
       "source_file": "scripts/overlord/assert_execution_scope.py",
       "source_location": "L285",
       "id": "assert_execution_scope_current_branch",
-      "community": 9
+      "community": 12
     },
     {
       "label": "_branch_issue_number()",
@@ -3161,7 +3161,7 @@
       "source_file": "scripts/overlord/assert_execution_scope.py",
       "source_location": "L295",
       "id": "assert_execution_scope_branch_issue_number",
-      "community": 9
+      "community": 12
     },
     {
       "label": "_changed_paths()",
@@ -3169,7 +3169,7 @@
       "source_file": "scripts/overlord/assert_execution_scope.py",
       "source_location": "L300",
       "id": "assert_execution_scope_changed_paths",
-      "community": 9
+      "community": 12
     },
     {
       "label": "_changed_paths_from_file()",
@@ -3177,7 +3177,7 @@
       "source_file": "scripts/overlord/assert_execution_scope.py",
       "source_location": "L328",
       "id": "assert_execution_scope_changed_paths_from_file",
-      "community": 9
+      "community": 12
     },
     {
       "label": "_path_allowed()",
@@ -3185,7 +3185,7 @@
       "source_file": "scripts/overlord/assert_execution_scope.py",
       "source_location": "L339",
       "id": "assert_execution_scope_path_allowed",
-      "community": 9
+      "community": 12
     },
     {
       "label": "_model_family()",
@@ -3193,7 +3193,7 @@
       "source_file": "scripts/overlord/assert_execution_scope.py",
       "source_location": "L343",
       "id": "assert_execution_scope_model_family",
-      "community": 9
+      "community": 12
     },
     {
       "label": "_same_model_or_family()",
@@ -3201,7 +3201,7 @@
       "source_file": "scripts/overlord/assert_execution_scope.py",
       "source_location": "L364",
       "id": "assert_execution_scope_same_model_or_family",
-      "community": 9
+      "community": 12
     },
     {
       "label": "_validate_execution_mode()",
@@ -3209,7 +3209,7 @@
       "source_file": "scripts/overlord/assert_execution_scope.py",
       "source_location": "L370",
       "id": "assert_execution_scope_validate_execution_mode",
-      "community": 9
+      "community": 12
     },
     {
       "label": "_format_path()",
@@ -3217,7 +3217,7 @@
       "source_file": "scripts/overlord/assert_execution_scope.py",
       "source_location": "L400",
       "id": "assert_execution_scope_format_path",
-      "community": 9
+      "community": 12
     },
     {
       "label": "_resolve_expected_execution_root()",
@@ -3225,7 +3225,7 @@
       "source_file": "scripts/overlord/assert_execution_scope.py",
       "source_location": "L404",
       "id": "assert_execution_scope_resolve_expected_execution_root",
-      "community": 9
+      "community": 12
     },
     {
       "label": "_validate_active_exception_ref()",
@@ -3233,7 +3233,7 @@
       "source_file": "scripts/overlord/assert_execution_scope.py",
       "source_location": "L410",
       "id": "assert_execution_scope_validate_active_exception_ref",
-      "community": 9
+      "community": 12
     },
     {
       "label": "_validate_lane_claim()",
@@ -3241,7 +3241,7 @@
       "source_file": "scripts/overlord/assert_execution_scope.py",
       "source_location": "L425",
       "id": "assert_execution_scope_validate_lane_claim",
-      "community": 9
+      "community": 12
     },
     {
       "label": "check_scope()",
@@ -3249,7 +3249,7 @@
       "source_file": "scripts/overlord/assert_execution_scope.py",
       "source_location": "L453",
       "id": "assert_execution_scope_check_scope",
-      "community": 9
+      "community": 12
     },
     {
       "label": "main()",
@@ -3257,7 +3257,7 @@
       "source_file": "scripts/overlord/assert_execution_scope.py",
       "source_location": "L537",
       "id": "assert_execution_scope_main",
-      "community": 9
+      "community": 12
     },
     {
       "label": "automerge_policy_check.py",
@@ -3265,7 +3265,7 @@
       "source_file": "scripts/overlord/automerge_policy_check.py",
       "source_location": "L1",
       "id": "automerge_policy_check",
-      "community": 47
+      "community": 45
     },
     {
       "label": "_labels()",
@@ -3273,7 +3273,7 @@
       "source_file": "scripts/overlord/automerge_policy_check.py",
       "source_location": "L20",
       "id": "automerge_policy_check_labels",
-      "community": 47
+      "community": 45
     },
     {
       "label": "_check_required_checks()",
@@ -3281,7 +3281,7 @@
       "source_file": "scripts/overlord/automerge_policy_check.py",
       "source_location": "L24",
       "id": "automerge_policy_check_check_required_checks",
-      "community": 47
+      "community": 45
     },
     {
       "label": "evaluate()",
@@ -3289,7 +3289,7 @@
       "source_file": "scripts/overlord/automerge_policy_check.py",
       "source_location": "L40",
       "id": "automerge_policy_check_evaluate",
-      "community": 47
+      "community": 45
     },
     {
       "label": "main()",
@@ -3297,7 +3297,7 @@
       "source_file": "scripts/overlord/automerge_policy_check.py",
       "source_location": "L106",
       "id": "automerge_policy_check_main",
-      "community": 47
+      "community": 45
     },
     {
       "label": "build_effectiveness_metrics.py",
@@ -3369,7 +3369,7 @@
       "source_file": "scripts/overlord/build_org_governance_compendium.py",
       "source_location": "L1",
       "id": "build_org_governance_compendium",
-      "community": 23
+      "community": 26
     },
     {
       "label": "RepoInfo",
@@ -3377,7 +3377,7 @@
       "source_file": "scripts/overlord/build_org_governance_compendium.py",
       "source_location": "L94",
       "id": "build_org_governance_compendium_repoinfo",
-      "community": 23
+      "community": 26
     },
     {
       "label": "FileInfo",
@@ -3385,7 +3385,7 @@
       "source_file": "scripts/overlord/build_org_governance_compendium.py",
       "source_location": "L102",
       "id": "build_org_governance_compendium_fileinfo",
-      "community": 23
+      "community": 26
     },
     {
       "label": "run()",
@@ -3393,7 +3393,7 @@
       "source_file": "scripts/overlord/build_org_governance_compendium.py",
       "source_location": "L110",
       "id": "build_org_governance_compendium_run",
-      "community": 23
+      "community": 26
     },
     {
       "label": "tracked_files()",
@@ -3401,7 +3401,7 @@
       "source_file": "scripts/overlord/build_org_governance_compendium.py",
       "source_location": "L117",
       "id": "build_org_governance_compendium_tracked_files",
-      "community": 23
+      "community": 26
     },
     {
       "label": "is_rule_file()",
@@ -3409,7 +3409,7 @@
       "source_file": "scripts/overlord/build_org_governance_compendium.py",
       "source_location": "L124",
       "id": "build_org_governance_compendium_is_rule_file",
-      "community": 23
+      "community": 26
     },
     {
       "label": "read_text()",
@@ -3417,7 +3417,7 @@
       "source_file": "scripts/overlord/build_org_governance_compendium.py",
       "source_location": "L136",
       "id": "build_org_governance_compendium_read_text",
-      "community": 23
+      "community": 26
     },
     {
       "label": "category_for()",
@@ -3425,7 +3425,7 @@
       "source_file": "scripts/overlord/build_org_governance_compendium.py",
       "source_location": "L143",
       "id": "build_org_governance_compendium_category_for",
-      "community": 23
+      "community": 26
     },
     {
       "label": "first_heading()",
@@ -3433,7 +3433,7 @@
       "source_file": "scripts/overlord/build_org_governance_compendium.py",
       "source_location": "L163",
       "id": "build_org_governance_compendium_first_heading",
-      "community": 23
+      "community": 26
     },
     {
       "label": "frontmatter_field()",
@@ -3441,7 +3441,7 @@
       "source_file": "scripts/overlord/build_org_governance_compendium.py",
       "source_location": "L171",
       "id": "build_org_governance_compendium_frontmatter_field",
-      "community": 23
+      "community": 26
     },
     {
       "label": "first_comment()",
@@ -3449,7 +3449,7 @@
       "source_file": "scripts/overlord/build_org_governance_compendium.py",
       "source_location": "L183",
       "id": "build_org_governance_compendium_first_comment",
-      "community": 23
+      "community": 26
     },
     {
       "label": "workflow_logic()",
@@ -3457,7 +3457,7 @@
       "source_file": "scripts/overlord/build_org_governance_compendium.py",
       "source_location": "L195",
       "id": "build_org_governance_compendium_workflow_logic",
-      "community": 23
+      "community": 26
     },
     {
       "label": "settings_logic()",
@@ -3465,7 +3465,7 @@
       "source_file": "scripts/overlord/build_org_governance_compendium.py",
       "source_location": "L221",
       "id": "build_org_governance_compendium_settings_logic",
-      "community": 23
+      "community": 26
     },
     {
       "label": "script_logic()",
@@ -3473,7 +3473,7 @@
       "source_file": "scripts/overlord/build_org_governance_compendium.py",
       "source_location": "L242",
       "id": "build_org_governance_compendium_script_logic",
-      "community": 23
+      "community": 26
     },
     {
       "label": "markdown_logic()",
@@ -3481,7 +3481,7 @@
       "source_file": "scripts/overlord/build_org_governance_compendium.py",
       "source_location": "L253",
       "id": "build_org_governance_compendium_markdown_logic",
-      "community": 23
+      "community": 26
     },
     {
       "label": "describe_file()",
@@ -3489,7 +3489,7 @@
       "source_file": "scripts/overlord/build_org_governance_compendium.py",
       "source_location": "L261",
       "id": "build_org_governance_compendium_describe_file",
-      "community": 23
+      "community": 26
     },
     {
       "label": "schema_logic()",
@@ -3497,7 +3497,7 @@
       "source_file": "scripts/overlord/build_org_governance_compendium.py",
       "source_location": "L285",
       "id": "build_org_governance_compendium_schema_logic",
-      "community": 23
+      "community": 26
     },
     {
       "label": "one_line()",
@@ -3505,7 +3505,7 @@
       "source_file": "scripts/overlord/build_org_governance_compendium.py",
       "source_location": "L298",
       "id": "build_org_governance_compendium_one_line",
-      "community": 23
+      "community": 26
     },
     {
       "label": "esc()",
@@ -3513,7 +3513,7 @@
       "source_file": "scripts/overlord/build_org_governance_compendium.py",
       "source_location": "L304",
       "id": "build_org_governance_compendium_esc",
-      "community": 23
+      "community": 26
     },
     {
       "label": "graph_summary()",
@@ -3521,7 +3521,7 @@
       "source_file": "scripts/overlord/build_org_governance_compendium.py",
       "source_location": "L308",
       "id": "build_org_governance_compendium_graph_summary",
-      "community": 23
+      "community": 26
     },
     {
       "label": "build()",
@@ -3529,7 +3529,7 @@
       "source_file": "scripts/overlord/build_org_governance_compendium.py",
       "source_location": "L350",
       "id": "build_org_governance_compendium_build",
-      "community": 23
+      "community": 26
     },
     {
       "label": "main()",
@@ -3537,7 +3537,7 @@
       "source_file": "scripts/overlord/build_org_governance_compendium.py",
       "source_location": "L434",
       "id": "build_org_governance_compendium_main",
-      "community": 23
+      "community": 26
     },
     {
       "label": "check_execution_environment.py",
@@ -3545,7 +3545,7 @@
       "source_file": "scripts/overlord/check_execution_environment.py",
       "source_location": "L1",
       "id": "check_execution_environment",
-      "community": 9
+      "community": 12
     },
     {
       "label": "main()",
@@ -3553,7 +3553,7 @@
       "source_file": "scripts/overlord/check_execution_environment.py",
       "source_location": "L12",
       "id": "check_execution_environment_main",
-      "community": 9
+      "community": 12
     },
     {
       "label": "check_local_ci_gate_workflow_contract.py",
@@ -3561,7 +3561,7 @@
       "source_file": "scripts/overlord/check_local_ci_gate_workflow_contract.py",
       "source_location": "L1",
       "id": "check_local_ci_gate_workflow_contract",
-      "community": 19
+      "community": 22
     },
     {
       "label": "_load_workflow()",
@@ -3569,7 +3569,7 @@
       "source_file": "scripts/overlord/check_local_ci_gate_workflow_contract.py",
       "source_location": "L16",
       "id": "check_local_ci_gate_workflow_contract_load_workflow",
-      "community": 19
+      "community": 22
     },
     {
       "label": "_contains_main_branch()",
@@ -3577,7 +3577,7 @@
       "source_file": "scripts/overlord/check_local_ci_gate_workflow_contract.py",
       "source_location": "L28",
       "id": "check_local_ci_gate_workflow_contract_contains_main_branch",
-      "community": 19
+      "community": 22
     },
     {
       "label": "_steps()",
@@ -3585,7 +3585,7 @@
       "source_file": "scripts/overlord/check_local_ci_gate_workflow_contract.py",
       "source_location": "L39",
       "id": "check_local_ci_gate_workflow_contract_steps",
-      "community": 19
+      "community": 22
     },
     {
       "label": "_step_named()",
@@ -3593,7 +3593,7 @@
       "source_file": "scripts/overlord/check_local_ci_gate_workflow_contract.py",
       "source_location": "L61",
       "id": "check_local_ci_gate_workflow_contract_step_named",
-      "community": 19
+      "community": 22
     },
     {
       "label": "_executable_lines()",
@@ -3601,7 +3601,7 @@
       "source_file": "scripts/overlord/check_local_ci_gate_workflow_contract.py",
       "source_location": "L68",
       "id": "check_local_ci_gate_workflow_contract_executable_lines",
-      "community": 19
+      "community": 22
     },
     {
       "label": "_step_executable_lines()",
@@ -3609,7 +3609,7 @@
       "source_file": "scripts/overlord/check_local_ci_gate_workflow_contract.py",
       "source_location": "L78",
       "id": "check_local_ci_gate_workflow_contract_step_executable_lines",
-      "community": 19
+      "community": 22
     },
     {
       "label": "_normalized_run()",
@@ -3617,7 +3617,7 @@
       "source_file": "scripts/overlord/check_local_ci_gate_workflow_contract.py",
       "source_location": "L85",
       "id": "check_local_ci_gate_workflow_contract_normalized_run",
-      "community": 19
+      "community": 22
     },
     {
       "label": "_all_run_commands()",
@@ -3625,7 +3625,7 @@
       "source_file": "scripts/overlord/check_local_ci_gate_workflow_contract.py",
       "source_location": "L90",
       "id": "check_local_ci_gate_workflow_contract_all_run_commands",
-      "community": 19
+      "community": 22
     },
     {
       "label": "_all_executable_lines()",
@@ -3633,7 +3633,7 @@
       "source_file": "scripts/overlord/check_local_ci_gate_workflow_contract.py",
       "source_location": "L94",
       "id": "check_local_ci_gate_workflow_contract_all_executable_lines",
-      "community": 19
+      "community": 22
     },
     {
       "label": "_has_executable_line_starting_with()",
@@ -3641,7 +3641,7 @@
       "source_file": "scripts/overlord/check_local_ci_gate_workflow_contract.py",
       "source_location": "L101",
       "id": "check_local_ci_gate_workflow_contract_has_executable_line_starting_with",
-      "community": 19
+      "community": 22
     },
     {
       "label": "_failures_for_text()",
@@ -3649,7 +3649,7 @@
       "source_file": "scripts/overlord/check_local_ci_gate_workflow_contract.py",
       "source_location": "L105",
       "id": "check_local_ci_gate_workflow_contract_failures_for_text",
-      "community": 19
+      "community": 22
     },
     {
       "label": "check_contract()",
@@ -3657,7 +3657,7 @@
       "source_file": "scripts/overlord/check_local_ci_gate_workflow_contract.py",
       "source_location": "L170",
       "id": "check_local_ci_gate_workflow_contract_check_contract",
-      "community": 19
+      "community": 22
     },
     {
       "label": "main()",
@@ -3665,7 +3665,7 @@
       "source_file": "scripts/overlord/check_local_ci_gate_workflow_contract.py",
       "source_location": "L191",
       "id": "check_local_ci_gate_workflow_contract_main",
-      "community": 19
+      "community": 22
     },
     {
       "label": "check_org_repo_inventory.py",
@@ -3673,7 +3673,7 @@
       "source_file": "scripts/overlord/check_org_repo_inventory.py",
       "source_location": "L1",
       "id": "check_org_repo_inventory",
-      "community": 34
+      "community": 33
     },
     {
       "label": "OrgRepo",
@@ -3681,7 +3681,7 @@
       "source_file": "scripts/overlord/check_org_repo_inventory.py",
       "source_location": "L27",
       "id": "check_org_repo_inventory_orgrepo",
-      "community": 34
+      "community": 33
     },
     {
       "label": "InventoryDrift",
@@ -3689,7 +3689,7 @@
       "source_file": "scripts/overlord/check_org_repo_inventory.py",
       "source_location": "L38",
       "id": "check_org_repo_inventory_inventorydrift",
-      "community": 34
+      "community": 33
     },
     {
       "label": ".has_blocking_drift()",
@@ -3697,7 +3697,7 @@
       "source_file": "scripts/overlord/check_org_repo_inventory.py",
       "source_location": "L44",
       "id": "check_org_repo_inventory_inventorydrift_has_blocking_drift",
-      "community": 34
+      "community": 33
     },
     {
       "label": "_load_json()",
@@ -3705,7 +3705,7 @@
       "source_file": "scripts/overlord/check_org_repo_inventory.py",
       "source_location": "L48",
       "id": "check_org_repo_inventory_load_json",
-      "community": 34
+      "community": 33
     },
     {
       "label": "_inventory_rows_from_payload()",
@@ -3713,7 +3713,7 @@
       "source_file": "scripts/overlord/check_org_repo_inventory.py",
       "source_location": "L52",
       "id": "check_org_repo_inventory_inventory_rows_from_payload",
-      "community": 34
+      "community": 33
     },
     {
       "label": "_default_branch_name()",
@@ -3721,7 +3721,7 @@
       "source_file": "scripts/overlord/check_org_repo_inventory.py",
       "source_location": "L64",
       "id": "check_org_repo_inventory_default_branch_name",
-      "community": 34
+      "community": 33
     },
     {
       "label": "parse_inventory()",
@@ -3729,7 +3729,7 @@
       "source_file": "scripts/overlord/check_org_repo_inventory.py",
       "source_location": "L74",
       "id": "check_org_repo_inventory_parse_inventory",
-      "community": 34
+      "community": 33
     },
     {
       "label": "load_inventory_file()",
@@ -3737,7 +3737,7 @@
       "source_file": "scripts/overlord/check_org_repo_inventory.py",
       "source_location": "L95",
       "id": "check_org_repo_inventory_load_inventory_file",
-      "community": 34
+      "community": 33
     },
     {
       "label": "load_live_inventory()",
@@ -3745,7 +3745,7 @@
       "source_file": "scripts/overlord/check_org_repo_inventory.py",
       "source_location": "L99",
       "id": "check_org_repo_inventory_load_live_inventory",
-      "community": 34
+      "community": 33
     },
     {
       "label": "compare_inventory()",
@@ -3753,7 +3753,7 @@
       "source_file": "scripts/overlord/check_org_repo_inventory.py",
       "source_location": "L114",
       "id": "check_org_repo_inventory_compare_inventory",
-      "community": 34
+      "community": 33
     },
     {
       "label": "render_text()",
@@ -3761,7 +3761,7 @@
       "source_file": "scripts/overlord/check_org_repo_inventory.py",
       "source_location": "L154",
       "id": "check_org_repo_inventory_render_text",
-      "community": 34
+      "community": 33
     },
     {
       "label": "render_markdown()",
@@ -3769,7 +3769,7 @@
       "source_file": "scripts/overlord/check_org_repo_inventory.py",
       "source_location": "L181",
       "id": "check_org_repo_inventory_render_markdown",
-      "community": 34
+      "community": 33
     },
     {
       "label": "_repo_list()",
@@ -3777,7 +3777,7 @@
       "source_file": "scripts/overlord/check_org_repo_inventory.py",
       "source_location": "L211",
       "id": "check_org_repo_inventory_repo_list",
-      "community": 34
+      "community": 33
     },
     {
       "label": "render_json()",
@@ -3785,7 +3785,7 @@
       "source_file": "scripts/overlord/check_org_repo_inventory.py",
       "source_location": "L218",
       "id": "check_org_repo_inventory_render_json",
-      "community": 34
+      "community": 33
     },
     {
       "label": "main()",
@@ -3793,7 +3793,7 @@
       "source_file": "scripts/overlord/check_org_repo_inventory.py",
       "source_location": "L232",
       "id": "check_org_repo_inventory_main",
-      "community": 34
+      "community": 33
     },
     {
       "label": "check_overlord_backlog_github_alignment.py",
@@ -3801,7 +3801,7 @@
       "source_file": "scripts/overlord/check_overlord_backlog_github_alignment.py",
       "source_location": "L1",
       "id": "check_overlord_backlog_github_alignment",
-      "community": 28
+      "community": 29
     },
     {
       "label": "fail()",
@@ -3809,7 +3809,7 @@
       "source_file": "scripts/overlord/check_overlord_backlog_github_alignment.py",
       "source_location": "L21",
       "id": "check_overlord_backlog_github_alignment_fail",
-      "community": 28
+      "community": 29
     },
     {
       "label": "parse_markdown_row()",
@@ -3817,7 +3817,7 @@
       "source_file": "scripts/overlord/check_overlord_backlog_github_alignment.py",
       "source_location": "L26",
       "id": "check_overlord_backlog_github_alignment_parse_markdown_row",
-      "community": 28
+      "community": 29
     },
     {
       "label": "collect_section_lines()",
@@ -3825,7 +3825,7 @@
       "source_file": "scripts/overlord/check_overlord_backlog_github_alignment.py",
       "source_location": "L37",
       "id": "check_overlord_backlog_github_alignment_collect_section_lines",
-      "community": 28
+      "community": 29
     },
     {
       "label": "has_issue_ref()",
@@ -3833,7 +3833,7 @@
       "source_file": "scripts/overlord/check_overlord_backlog_github_alignment.py",
       "source_location": "L50",
       "id": "check_overlord_backlog_github_alignment_has_issue_ref",
-      "community": 28
+      "community": 29
     },
     {
       "label": "issue_numbers()",
@@ -3841,7 +3841,7 @@
       "source_file": "scripts/overlord/check_overlord_backlog_github_alignment.py",
       "source_location": "L54",
       "id": "check_overlord_backlog_github_alignment_issue_numbers",
-      "community": 28
+      "community": 29
     },
     {
       "label": "issue_column_index()",
@@ -3849,7 +3849,7 @@
       "source_file": "scripts/overlord/check_overlord_backlog_github_alignment.py",
       "source_location": "L58",
       "id": "check_overlord_backlog_github_alignment_issue_column_index",
-      "community": 28
+      "community": 29
     },
     {
       "label": "check_github_issue_open()",
@@ -3857,7 +3857,7 @@
       "source_file": "scripts/overlord/check_overlord_backlog_github_alignment.py",
       "source_location": "L65",
       "id": "check_overlord_backlog_github_alignment_check_github_issue_open",
-      "community": 28
+      "community": 29
     },
     {
       "label": "validate_section()",
@@ -3865,7 +3865,7 @@
       "source_file": "scripts/overlord/check_overlord_backlog_github_alignment.py",
       "source_location": "L98",
       "id": "check_overlord_backlog_github_alignment_validate_section",
-      "community": 28
+      "community": 29
     },
     {
       "label": "main()",
@@ -3873,12 +3873,12 @@
       "source_file": "scripts/overlord/check_overlord_backlog_github_alignment.py",
       "source_location": "L135",
       "id": "check_overlord_backlog_github_alignment_main",
-      "community": 28
+      "community": 29
     },
     {
       "label": "check_plan_preflight.py",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/hldpro-governance/var/worktrees/issue-463-stage6-closeout-439/scripts/overlord/check_plan_preflight.py",
+      "source_file": "scripts/overlord/check_plan_preflight.py",
       "source_location": "L1",
       "id": "check_plan_preflight",
       "community": 63
@@ -3886,7 +3886,7 @@
     {
       "label": "is_governed_path()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/hldpro-governance/var/worktrees/issue-463-stage6-closeout-439/scripts/overlord/check_plan_preflight.py",
+      "source_file": "scripts/overlord/check_plan_preflight.py",
       "source_location": "L32",
       "id": "check_plan_preflight_is_governed_path",
       "community": 63
@@ -3894,7 +3894,7 @@
     {
       "label": "recent_plan()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/hldpro-governance/var/worktrees/issue-463-stage6-closeout-439/scripts/overlord/check_plan_preflight.py",
+      "source_file": "scripts/overlord/check_plan_preflight.py",
       "source_location": "L37",
       "id": "check_plan_preflight_recent_plan",
       "community": 63
@@ -3902,7 +3902,7 @@
     {
       "label": "detect_bash_write_target()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/hldpro-governance/var/worktrees/issue-463-stage6-closeout-439/scripts/overlord/check_plan_preflight.py",
+      "source_file": "scripts/overlord/check_plan_preflight.py",
       "source_location": "L47",
       "id": "check_plan_preflight_detect_bash_write_target",
       "community": 63
@@ -3910,7 +3910,7 @@
     {
       "label": "block_reason()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/hldpro-governance/var/worktrees/issue-463-stage6-closeout-439/scripts/overlord/check_plan_preflight.py",
+      "source_file": "scripts/overlord/check_plan_preflight.py",
       "source_location": "L64",
       "id": "check_plan_preflight_block_reason",
       "community": 63
@@ -3918,7 +3918,7 @@
     {
       "label": "evaluate()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/hldpro-governance/var/worktrees/issue-463-stage6-closeout-439/scripts/overlord/check_plan_preflight.py",
+      "source_file": "scripts/overlord/check_plan_preflight.py",
       "source_location": "L78",
       "id": "check_plan_preflight_evaluate",
       "community": 63
@@ -3926,7 +3926,7 @@
     {
       "label": "parse_args()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/hldpro-governance/var/worktrees/issue-463-stage6-closeout-439/scripts/overlord/check_plan_preflight.py",
+      "source_file": "scripts/overlord/check_plan_preflight.py",
       "source_location": "L131",
       "id": "check_plan_preflight_parse_args",
       "community": 63
@@ -3934,7 +3934,7 @@
     {
       "label": "main()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/hldpro-governance/var/worktrees/issue-463-stage6-closeout-439/scripts/overlord/check_plan_preflight.py",
+      "source_file": "scripts/overlord/check_plan_preflight.py",
       "source_location": "L145",
       "id": "check_plan_preflight_main",
       "community": 63
@@ -3945,7 +3945,7 @@
       "source_file": "scripts/overlord/check_progress_github_issue_staleness.py",
       "source_location": "L1",
       "id": "check_progress_github_issue_staleness",
-      "community": 37
+      "community": 34
     },
     {
       "label": "IssueRef",
@@ -3953,7 +3953,7 @@
       "source_file": "scripts/overlord/check_progress_github_issue_staleness.py",
       "source_location": "L40",
       "id": "check_progress_github_issue_staleness_issueref",
-      "community": 37
+      "community": 34
     },
     {
       "label": "fail()",
@@ -3961,7 +3961,7 @@
       "source_file": "scripts/overlord/check_progress_github_issue_staleness.py",
       "source_location": "L47",
       "id": "check_progress_github_issue_staleness_fail",
-      "community": 37
+      "community": 34
     },
     {
       "label": "parse_args()",
@@ -3969,7 +3969,7 @@
       "source_file": "scripts/overlord/check_progress_github_issue_staleness.py",
       "source_location": "L52",
       "id": "check_progress_github_issue_staleness_parse_args",
-      "community": 37
+      "community": 34
     },
     {
       "label": "current_repo_slug()",
@@ -3977,7 +3977,7 @@
       "source_file": "scripts/overlord/check_progress_github_issue_staleness.py",
       "source_location": "L60",
       "id": "check_progress_github_issue_staleness_current_repo_slug",
-      "community": 37
+      "community": 34
     },
     {
       "label": "gh_json()",
@@ -3985,7 +3985,7 @@
       "source_file": "scripts/overlord/check_progress_github_issue_staleness.py",
       "source_location": "L69",
       "id": "check_progress_github_issue_staleness_gh_json",
-      "community": 37
+      "community": 34
     },
     {
       "label": "backlog_issues()",
@@ -3993,7 +3993,7 @@
       "source_file": "scripts/overlord/check_progress_github_issue_staleness.py",
       "source_location": "L80",
       "id": "check_progress_github_issue_staleness_backlog_issues",
-      "community": 37
+      "community": 34
     },
     {
       "label": "normalize_heading()",
@@ -4001,7 +4001,7 @@
       "source_file": "scripts/overlord/check_progress_github_issue_staleness.py",
       "source_location": "L107",
       "id": "check_progress_github_issue_staleness_normalize_heading",
-      "community": 37
+      "community": 34
     },
     {
       "label": "section_state()",
@@ -4009,7 +4009,7 @@
       "source_file": "scripts/overlord/check_progress_github_issue_staleness.py",
       "source_location": "L111",
       "id": "check_progress_github_issue_staleness_section_state",
-      "community": 37
+      "community": 34
     },
     {
       "label": "collect_active_issue_refs()",
@@ -4017,7 +4017,7 @@
       "source_file": "scripts/overlord/check_progress_github_issue_staleness.py",
       "source_location": "L119",
       "id": "check_progress_github_issue_staleness_collect_active_issue_refs",
-      "community": 37
+      "community": 34
     },
     {
       "label": "build_summary()",
@@ -4025,7 +4025,7 @@
       "source_file": "scripts/overlord/check_progress_github_issue_staleness.py",
       "source_location": "L138",
       "id": "check_progress_github_issue_staleness_build_summary",
-      "community": 37
+      "community": 34
     },
     {
       "label": "main()",
@@ -4033,7 +4033,7 @@
       "source_file": "scripts/overlord/check_progress_github_issue_staleness.py",
       "source_location": "L167",
       "id": "check_progress_github_issue_staleness_main",
-      "community": 37
+      "community": 34
     },
     {
       "label": "check_worker_handoff_route.py",
@@ -4041,7 +4041,7 @@
       "source_file": "scripts/overlord/check_worker_handoff_route.py",
       "source_location": "L1",
       "id": "check_worker_handoff_route",
-      "community": 9
+      "community": 12
     },
     {
       "label": "_normalize_repo_path()",
@@ -4049,7 +4049,7 @@
       "source_file": "scripts/overlord/check_worker_handoff_route.py",
       "source_location": "L29",
       "id": "check_worker_handoff_route_normalize_repo_path",
-      "community": 9
+      "community": 12
     },
     {
       "label": "_actionable_next_step()",
@@ -4057,7 +4057,7 @@
       "source_file": "scripts/overlord/check_worker_handoff_route.py",
       "source_location": "L33",
       "id": "check_worker_handoff_route_actionable_next_step",
-      "community": 9
+      "community": 12
     },
     {
       "label": "_result()",
@@ -4065,7 +4065,7 @@
       "source_file": "scripts/overlord/check_worker_handoff_route.py",
       "source_location": "L44",
       "id": "check_worker_handoff_route_result",
-      "community": 9
+      "community": 12
     },
     {
       "label": "_find_scope()",
@@ -4073,7 +4073,7 @@
       "source_file": "scripts/overlord/check_worker_handoff_route.py",
       "source_location": "L52",
       "id": "check_worker_handoff_route_find_scope",
-      "community": 9
+      "community": 12
     },
     {
       "label": "check_route()",
@@ -4081,7 +4081,7 @@
       "source_file": "scripts/overlord/check_worker_handoff_route.py",
       "source_location": "L64",
       "id": "check_worker_handoff_route_check_route",
-      "community": 9
+      "community": 12
     },
     {
       "label": "parse_args()",
@@ -4089,7 +4089,7 @@
       "source_file": "scripts/overlord/check_worker_handoff_route.py",
       "source_location": "L142",
       "id": "check_worker_handoff_route_parse_args",
-      "community": 9
+      "community": 12
     },
     {
       "label": "main()",
@@ -4097,7 +4097,7 @@
       "source_file": "scripts/overlord/check_worker_handoff_route.py",
       "source_location": "L152",
       "id": "check_worker_handoff_route_main",
-      "community": 9
+      "community": 12
     },
     {
       "label": "check_workflow_local_coverage.py",
@@ -4105,7 +4105,7 @@
       "source_file": "scripts/overlord/check_workflow_local_coverage.py",
       "source_location": "L1",
       "id": "check_workflow_local_coverage",
-      "community": 25
+      "community": 27
     },
     {
       "label": "_normalize_path()",
@@ -4113,7 +4113,7 @@
       "source_file": "scripts/overlord/check_workflow_local_coverage.py",
       "source_location": "L17",
       "id": "check_workflow_local_coverage_normalize_path",
-      "community": 25
+      "community": 27
     },
     {
       "label": "_load_inventory()",
@@ -4121,7 +4121,7 @@
       "source_file": "scripts/overlord/check_workflow_local_coverage.py",
       "source_location": "L23",
       "id": "check_workflow_local_coverage_load_inventory",
-      "community": 25
+      "community": 27
     },
     {
       "label": "_actual_workflows()",
@@ -4129,7 +4129,7 @@
       "source_file": "scripts/overlord/check_workflow_local_coverage.py",
       "source_location": "L27",
       "id": "check_workflow_local_coverage_actual_workflows",
-      "community": 25
+      "community": 27
     },
     {
       "label": "_command_file_candidates()",
@@ -4137,7 +4137,7 @@
       "source_file": "scripts/overlord/check_workflow_local_coverage.py",
       "source_location": "L36",
       "id": "check_workflow_local_coverage_command_file_candidates",
-      "community": 25
+      "community": 27
     },
     {
       "label": "_validate_coverage()",
@@ -4145,7 +4145,7 @@
       "source_file": "scripts/overlord/check_workflow_local_coverage.py",
       "source_location": "L49",
       "id": "check_workflow_local_coverage_validate_coverage",
-      "community": 25
+      "community": 27
     },
     {
       "label": "_validate_required_snippets()",
@@ -4153,7 +4153,7 @@
       "source_file": "scripts/overlord/check_workflow_local_coverage.py",
       "source_location": "L95",
       "id": "check_workflow_local_coverage_validate_required_snippets",
-      "community": 25
+      "community": 27
     },
     {
       "label": "check_inventory()",
@@ -4161,7 +4161,7 @@
       "source_file": "scripts/overlord/check_workflow_local_coverage.py",
       "source_location": "L110",
       "id": "check_workflow_local_coverage_check_inventory",
-      "community": 25
+      "community": 27
     },
     {
       "label": "main()",
@@ -4169,7 +4169,7 @@
       "source_file": "scripts/overlord/check_workflow_local_coverage.py",
       "source_location": "L160",
       "id": "check_workflow_local_coverage_main",
-      "community": 25
+      "community": 27
     },
     {
       "label": "codex_ingestion.py",
@@ -4177,7 +4177,7 @@
       "source_file": "scripts/overlord/codex_ingestion.py",
       "source_location": "L1",
       "id": "codex_ingestion",
-      "community": 6
+      "community": 7
     },
     {
       "label": "Finding",
@@ -4185,7 +4185,7 @@
       "source_file": "scripts/overlord/codex_ingestion.py",
       "source_location": "L61",
       "id": "codex_ingestion_finding",
-      "community": 6
+      "community": 7
     },
     {
       "label": "priority()",
@@ -4193,7 +4193,7 @@
       "source_file": "scripts/overlord/codex_ingestion.py",
       "source_location": "L72",
       "id": "codex_ingestion_priority",
-      "community": 6
+      "community": 7
     },
     {
       "label": "fail_fast_severity()",
@@ -4201,7 +4201,7 @@
       "source_file": "scripts/overlord/codex_ingestion.py",
       "source_location": "L80",
       "id": "codex_ingestion_fail_fast_severity",
-      "community": 6
+      "community": 7
     },
     {
       "label": "est_hours()",
@@ -4209,7 +4209,7 @@
       "source_file": "scripts/overlord/codex_ingestion.py",
       "source_location": "L90",
       "id": "codex_ingestion_est_hours",
-      "community": 6
+      "community": 7
     },
     {
       "label": "today_string()",
@@ -4217,7 +4217,7 @@
       "source_file": "scripts/overlord/codex_ingestion.py",
       "source_location": "L102",
       "id": "codex_ingestion_today_string",
-      "community": 6
+      "community": 7
     },
     {
       "label": "run()",
@@ -4225,7 +4225,7 @@
       "source_file": "scripts/overlord/codex_ingestion.py",
       "source_location": "L111",
       "id": "codex_ingestion_run",
-      "community": 6
+      "community": 7
     },
     {
       "label": "load_json()",
@@ -4233,7 +4233,7 @@
       "source_file": "scripts/overlord/codex_ingestion.py",
       "source_location": "L115",
       "id": "codex_ingestion_load_json",
-      "community": 6
+      "community": 7
     },
     {
       "label": "write_json()",
@@ -4241,7 +4241,7 @@
       "source_file": "scripts/overlord/codex_ingestion.py",
       "source_location": "L120",
       "id": "codex_ingestion_write_json",
-      "community": 6
+      "community": 7
     },
     {
       "label": "extract_json_from_stdout()",
@@ -4249,7 +4249,7 @@
       "source_file": "scripts/overlord/codex_ingestion.py",
       "source_location": "L125",
       "id": "codex_ingestion_extract_json_from_stdout",
-      "community": 6
+      "community": 7
     },
     {
       "label": "summarize_failure_output()",
@@ -4257,7 +4257,7 @@
       "source_file": "scripts/overlord/codex_ingestion.py",
       "source_location": "L139",
       "id": "codex_ingestion_summarize_failure_output",
-      "community": 6
+      "community": 7
     },
     {
       "label": "skip_payload()",
@@ -4265,7 +4265,7 @@
       "source_file": "scripts/overlord/codex_ingestion.py",
       "source_location": "L170",
       "id": "codex_ingestion_skip_payload",
-      "community": 6
+      "community": 7
     },
     {
       "label": "list_backlog_files()",
@@ -4273,7 +4273,7 @@
       "source_file": "scripts/overlord/codex_ingestion.py",
       "source_location": "L174",
       "id": "codex_ingestion_list_backlog_files",
-      "community": 6
+      "community": 7
     },
     {
       "label": "git_lines()",
@@ -4281,7 +4281,7 @@
       "source_file": "scripts/overlord/codex_ingestion.py",
       "source_location": "L181",
       "id": "codex_ingestion_git_lines",
-      "community": 6
+      "community": 7
     },
     {
       "label": "bounded_text()",
@@ -4289,7 +4289,7 @@
       "source_file": "scripts/overlord/codex_ingestion.py",
       "source_location": "L186",
       "id": "codex_ingestion_bounded_text",
-      "community": 6
+      "community": 7
     },
     {
       "label": "build_review_context()",
@@ -4297,7 +4297,7 @@
       "source_file": "scripts/overlord/codex_ingestion.py",
       "source_location": "L193",
       "id": "codex_ingestion_build_review_context",
-      "community": 6
+      "community": 7
     },
     {
       "label": "build_schema_file()",
@@ -4305,7 +4305,7 @@
       "source_file": "scripts/overlord/codex_ingestion.py",
       "source_location": "L221",
       "id": "codex_ingestion_build_schema_file",
-      "community": 6
+      "community": 7
     },
     {
       "label": "normalize_review()",
@@ -4313,7 +4313,7 @@
       "source_file": "scripts/overlord/codex_ingestion.py",
       "source_location": "L286",
       "id": "codex_ingestion_normalize_review",
-      "community": 6
+      "community": 7
     },
     {
       "label": "classify_finding()",
@@ -4321,7 +4321,7 @@
       "source_file": "scripts/overlord/codex_ingestion.py",
       "source_location": "L319",
       "id": "codex_ingestion_classify_finding",
-      "community": 6
+      "community": 7
     },
     {
       "label": "detect_duplicate()",
@@ -4329,7 +4329,7 @@
       "source_file": "scripts/overlord/codex_ingestion.py",
       "source_location": "L327",
       "id": "codex_ingestion_detect_duplicate",
-      "community": 6
+      "community": 7
     },
     {
       "label": "validate_location()",
@@ -4337,7 +4337,7 @@
       "source_file": "scripts/overlord/codex_ingestion.py",
       "source_location": "L343",
       "id": "codex_ingestion_validate_location",
-      "community": 6
+      "community": 7
     },
     {
       "label": "extract_claim_anchors()",
@@ -4345,7 +4345,7 @@
       "source_file": "scripts/overlord/codex_ingestion.py",
       "source_location": "L364",
       "id": "codex_ingestion_extract_claim_anchors",
-      "community": 6
+      "community": 7
     },
     {
       "label": "looks_like_camel_identifier()",
@@ -4353,7 +4353,7 @@
       "source_file": "scripts/overlord/codex_ingestion.py",
       "source_location": "L384",
       "id": "codex_ingestion_looks_like_camel_identifier",
-      "community": 6
+      "community": 7
     },
     {
       "label": "read_context_window()",
@@ -4361,7 +4361,7 @@
       "source_file": "scripts/overlord/codex_ingestion.py",
       "source_location": "L392",
       "id": "codex_ingestion_read_context_window",
-      "community": 6
+      "community": 7
     },
     {
       "label": "context_matches_anchors()",
@@ -4369,7 +4369,7 @@
       "source_file": "scripts/overlord/codex_ingestion.py",
       "source_location": "L398",
       "id": "codex_ingestion_context_matches_anchors",
-      "community": 6
+      "community": 7
     },
     {
       "label": "markdown_escape()",
@@ -4377,7 +4377,7 @@
       "source_file": "scripts/overlord/codex_ingestion.py",
       "source_location": "L405",
       "id": "codex_ingestion_markdown_escape",
-      "community": 6
+      "community": 7
     },
     {
       "label": "find_section_span()",
@@ -4385,7 +4385,7 @@
       "source_file": "scripts/overlord/codex_ingestion.py",
       "source_location": "L409",
       "id": "codex_ingestion_find_section_span",
-      "community": 6
+      "community": 7
     },
     {
       "label": "append_progress_candidate()",
@@ -4393,7 +4393,7 @@
       "source_file": "scripts/overlord/codex_ingestion.py",
       "source_location": "L420",
       "id": "codex_ingestion_append_progress_candidate",
-      "community": 6
+      "community": 7
     },
     {
       "label": "append_fail_fast_candidate()",
@@ -4401,7 +4401,7 @@
       "source_file": "scripts/overlord/codex_ingestion.py",
       "source_location": "L448",
       "id": "codex_ingestion_append_fail_fast_candidate",
-      "community": 6
+      "community": 7
     },
     {
       "label": "append_fail_fast_table_entry()",
@@ -4409,7 +4409,7 @@
       "source_file": "scripts/overlord/codex_ingestion.py",
       "source_location": "L455",
       "id": "codex_ingestion_append_fail_fast_table_entry",
-      "community": 6
+      "community": 7
     },
     {
       "label": "append_fail_fast_block_entry()",
@@ -4417,7 +4417,7 @@
       "source_file": "scripts/overlord/codex_ingestion.py",
       "source_location": "L478",
       "id": "codex_ingestion_append_fail_fast_block_entry",
-      "community": 6
+      "community": 7
     },
     {
       "label": "build_parser()",
@@ -4425,7 +4425,7 @@
       "source_file": "scripts/overlord/codex_ingestion.py",
       "source_location": "L500",
       "id": "codex_ingestion_build_parser",
-      "community": 6
+      "community": 7
     },
     {
       "label": "cmd_status()",
@@ -4433,7 +4433,7 @@
       "source_file": "scripts/overlord/codex_ingestion.py",
       "source_location": "L527",
       "id": "codex_ingestion_cmd_status",
-      "community": 6
+      "community": 7
     },
     {
       "label": "cmd_generate()",
@@ -4441,7 +4441,7 @@
       "source_file": "scripts/overlord/codex_ingestion.py",
       "source_location": "L541",
       "id": "codex_ingestion_cmd_generate",
-      "community": 6
+      "community": 7
     },
     {
       "label": "cmd_qualify()",
@@ -4449,7 +4449,7 @@
       "source_file": "scripts/overlord/codex_ingestion.py",
       "source_location": "L657",
       "id": "codex_ingestion_cmd_qualify",
-      "community": 6
+      "community": 7
     },
     {
       "label": "cmd_promote()",
@@ -4457,7 +4457,7 @@
       "source_file": "scripts/overlord/codex_ingestion.py",
       "source_location": "L831",
       "id": "codex_ingestion_cmd_promote",
-      "community": 6
+      "community": 7
     },
     {
       "label": "main()",
@@ -4465,7 +4465,7 @@
       "source_file": "scripts/overlord/codex_ingestion.py",
       "source_location": "L888",
       "id": "codex_ingestion_main",
-      "community": 6
+      "community": 7
     },
     {
       "label": "deploy_governance_tooling.py",
@@ -4473,7 +4473,7 @@
       "source_file": "scripts/overlord/deploy_governance_tooling.py",
       "source_location": "L1",
       "id": "deploy_governance_tooling",
-      "community": 18
+      "community": 4
     },
     {
       "label": "GovernanceDeployError",
@@ -4481,7 +4481,7 @@
       "source_file": "scripts/overlord/deploy_governance_tooling.py",
       "source_location": "L22",
       "id": "deploy_governance_tooling_governancedeployerror",
-      "community": 18
+      "community": 4
     },
     {
       "label": "ToolingPlan",
@@ -4489,7 +4489,7 @@
       "source_file": "scripts/overlord/deploy_governance_tooling.py",
       "source_location": "L27",
       "id": "deploy_governance_tooling_toolingplan",
-      "community": 18
+      "community": 4
     },
     {
       "label": ".managed_files()",
@@ -4497,7 +4497,7 @@
       "source_file": "scripts/overlord/deploy_governance_tooling.py",
       "source_location": "L40",
       "id": "deploy_governance_tooling_toolingplan_managed_files",
-      "community": 18
+      "community": 4
     },
     {
       "label": ".planned_write_set()",
@@ -4505,7 +4505,7 @@
       "source_file": "scripts/overlord/deploy_governance_tooling.py",
       "source_location": "L54",
       "id": "deploy_governance_tooling_toolingplan_planned_write_set",
-      "community": 18
+      "community": 4
     },
     {
       "label": ".planned_rollback_set()",
@@ -4513,7 +4513,7 @@
       "source_file": "scripts/overlord/deploy_governance_tooling.py",
       "source_location": "L57",
       "id": "deploy_governance_tooling_toolingplan_planned_rollback_set",
-      "community": 18
+      "community": 4
     },
     {
       "label": ".to_json()",
@@ -4521,7 +4521,7 @@
       "source_file": "scripts/overlord/deploy_governance_tooling.py",
       "source_location": "L60",
       "id": "deploy_governance_tooling_toolingplan_to_json",
-      "community": 18
+      "community": 4
     },
     {
       "label": "_fail()",
@@ -4529,7 +4529,7 @@
       "source_file": "scripts/overlord/deploy_governance_tooling.py",
       "source_location": "L79",
       "id": "deploy_governance_tooling_fail",
-      "community": 18
+      "community": 4
     },
     {
       "label": "_run_git()",
@@ -4537,7 +4537,7 @@
       "source_file": "scripts/overlord/deploy_governance_tooling.py",
       "source_location": "L83",
       "id": "deploy_governance_tooling_run_git",
-      "community": 18
+      "community": 4
     },
     {
       "label": "_git_root()",
@@ -4545,7 +4545,7 @@
       "source_file": "scripts/overlord/deploy_governance_tooling.py",
       "source_location": "L87",
       "id": "deploy_governance_tooling_git_root",
-      "community": 18
+      "community": 4
     },
     {
       "label": "_git_is_dirty()",
@@ -4553,7 +4553,7 @@
       "source_file": "scripts/overlord/deploy_governance_tooling.py",
       "source_location": "L94",
       "id": "deploy_governance_tooling_git_is_dirty",
-      "community": 18
+      "community": 4
     },
     {
       "label": "_git_head()",
@@ -4561,7 +4561,7 @@
       "source_file": "scripts/overlord/deploy_governance_tooling.py",
       "source_location": "L101",
       "id": "deploy_governance_tooling_git_head",
-      "community": 18
+      "community": 4
     },
     {
       "label": "_load_manifest()",
@@ -4569,7 +4569,7 @@
       "source_file": "scripts/overlord/deploy_governance_tooling.py",
       "source_location": "L108",
       "id": "deploy_governance_tooling_load_manifest",
-      "community": 18
+      "community": 4
     },
     {
       "label": "_consumer_record_relpath()",
@@ -4577,7 +4577,7 @@
       "source_file": "scripts/overlord/deploy_governance_tooling.py",
       "source_location": "L118",
       "id": "deploy_governance_tooling_consumer_record_relpath",
-      "community": 18
+      "community": 4
     },
     {
       "label": "_package_version()",
@@ -4585,7 +4585,7 @@
       "source_file": "scripts/overlord/deploy_governance_tooling.py",
       "source_location": "L127",
       "id": "deploy_governance_tooling_package_version",
-      "community": 18
+      "community": 4
     },
     {
       "label": "_record_state()",
@@ -4593,7 +4593,7 @@
       "source_file": "scripts/overlord/deploy_governance_tooling.py",
       "source_location": "L138",
       "id": "deploy_governance_tooling_record_state",
-      "community": 18
+      "community": 4
     },
     {
       "label": "_ensure_relative_to()",
@@ -4601,7 +4601,7 @@
       "source_file": "scripts/overlord/deploy_governance_tooling.py",
       "source_location": "L152",
       "id": "deploy_governance_tooling_ensure_relative_to",
-      "community": 18
+      "community": 4
     },
     {
       "label": "_build_local_ci_plan()",
@@ -4609,7 +4609,7 @@
       "source_file": "scripts/overlord/deploy_governance_tooling.py",
       "source_location": "L159",
       "id": "deploy_governance_tooling_build_local_ci_plan",
-      "community": 18
+      "community": 4
     },
     {
       "label": "build_plan()",
@@ -4617,7 +4617,7 @@
       "source_file": "scripts/overlord/deploy_governance_tooling.py",
       "source_location": "L170",
       "id": "deploy_governance_tooling_build_plan",
-      "community": 18
+      "community": 4
     },
     {
       "label": "_refuse_dirty()",
@@ -4625,7 +4625,7 @@
       "source_file": "scripts/overlord/deploy_governance_tooling.py",
       "source_location": "L201",
       "id": "deploy_governance_tooling_refuse_dirty",
-      "community": 18
+      "community": 4
     },
     {
       "label": "_refuse_unmanaged_record()",
@@ -4633,7 +4633,7 @@
       "source_file": "scripts/overlord/deploy_governance_tooling.py",
       "source_location": "L206",
       "id": "deploy_governance_tooling_refuse_unmanaged_record",
-      "community": 18
+      "community": 4
     },
     {
       "label": "_consumer_record()",
@@ -4641,7 +4641,7 @@
       "source_file": "scripts/overlord/deploy_governance_tooling.py",
       "source_location": "L211",
       "id": "deploy_governance_tooling_consumer_record",
-      "community": 18
+      "community": 4
     },
     {
       "label": "apply()",
@@ -4649,7 +4649,7 @@
       "source_file": "scripts/overlord/deploy_governance_tooling.py",
       "source_location": "L238",
       "id": "deploy_governance_tooling_apply",
-      "community": 18
+      "community": 4
     },
     {
       "label": "verify()",
@@ -4657,7 +4657,7 @@
       "source_file": "scripts/overlord/deploy_governance_tooling.py",
       "source_location": "L248",
       "id": "deploy_governance_tooling_verify",
-      "community": 18
+      "community": 4
     },
     {
       "label": "_required_record_fields()",
@@ -4665,7 +4665,7 @@
       "source_file": "scripts/overlord/deploy_governance_tooling.py",
       "source_location": "L277",
       "id": "deploy_governance_tooling_required_record_fields",
-      "community": 18
+      "community": 4
     },
     {
       "label": "rollback()",
@@ -4673,7 +4673,7 @@
       "source_file": "scripts/overlord/deploy_governance_tooling.py",
       "source_location": "L299",
       "id": "deploy_governance_tooling_rollback",
-      "community": 18
+      "community": 4
     },
     {
       "label": "print_json()",
@@ -4681,7 +4681,7 @@
       "source_file": "scripts/overlord/deploy_governance_tooling.py",
       "source_location": "L327",
       "id": "deploy_governance_tooling_print_json",
-      "community": 18
+      "community": 4
     },
     {
       "label": "add_common_args()",
@@ -4689,7 +4689,7 @@
       "source_file": "scripts/overlord/deploy_governance_tooling.py",
       "source_location": "L332",
       "id": "deploy_governance_tooling_add_common_args",
-      "community": 18
+      "community": 4
     },
     {
       "label": "main()",
@@ -4697,7 +4697,7 @@
       "source_file": "scripts/overlord/deploy_governance_tooling.py",
       "source_location": "L342",
       "id": "deploy_governance_tooling_main",
-      "community": 18
+      "community": 4
     },
     {
       "label": "deploy_local_ci_gate.py",
@@ -4705,7 +4705,7 @@
       "source_file": "scripts/overlord/deploy_local_ci_gate.py",
       "source_location": "L1",
       "id": "deploy_local_ci_gate",
-      "community": 31
+      "community": 4
     },
     {
       "label": "DeployError",
@@ -4713,7 +4713,7 @@
       "source_file": "scripts/overlord/deploy_local_ci_gate.py",
       "source_location": "L23",
       "id": "deploy_local_ci_gate_deployerror",
-      "community": 31
+      "community": 4
     },
     {
       "label": "DeployPlan",
@@ -4721,7 +4721,7 @@
       "source_file": "scripts/overlord/deploy_local_ci_gate.py",
       "source_location": "L28",
       "id": "deploy_local_ci_gate_deployplan",
-      "community": 31
+      "community": 4
     },
     {
       "label": ".planned_write_set()",
@@ -4729,7 +4729,7 @@
       "source_file": "scripts/overlord/deploy_local_ci_gate.py",
       "source_location": "L38",
       "id": "deploy_local_ci_gate_deployplan_planned_write_set",
-      "community": 31
+      "community": 4
     },
     {
       "label": ".to_json()",
@@ -4737,7 +4737,7 @@
       "source_file": "scripts/overlord/deploy_local_ci_gate.py",
       "source_location": "L45",
       "id": "deploy_local_ci_gate_deployplan_to_json",
-      "community": 31
+      "community": 4
     },
     {
       "label": "_fail()",
@@ -4745,7 +4745,7 @@
       "source_file": "scripts/overlord/deploy_local_ci_gate.py",
       "source_location": "L62",
       "id": "deploy_local_ci_gate_fail",
-      "community": 31
+      "community": 4
     },
     {
       "label": "_is_relative_to()",
@@ -4753,7 +4753,7 @@
       "source_file": "scripts/overlord/deploy_local_ci_gate.py",
       "source_location": "L66",
       "id": "deploy_local_ci_gate_is_relative_to",
-      "community": 31
+      "community": 4
     },
     {
       "label": "_existing_shim_state()",
@@ -4761,7 +4761,7 @@
       "source_file": "scripts/overlord/deploy_local_ci_gate.py",
       "source_location": "L74",
       "id": "deploy_local_ci_gate_existing_shim_state",
-      "community": 31
+      "community": 4
     },
     {
       "label": "_resolve_shim_path()",
@@ -4769,7 +4769,7 @@
       "source_file": "scripts/overlord/deploy_local_ci_gate.py",
       "source_location": "L83",
       "id": "deploy_local_ci_gate_resolve_shim_path",
-      "community": 31
+      "community": 4
     },
     {
       "label": "build_plan()",
@@ -4777,7 +4777,7 @@
       "source_file": "scripts/overlord/deploy_local_ci_gate.py",
       "source_location": "L98",
       "id": "deploy_local_ci_gate_build_plan",
-      "community": 31
+      "community": 4
     },
     {
       "label": "managed_shim_body()",
@@ -4785,7 +4785,7 @@
       "source_file": "scripts/overlord/deploy_local_ci_gate.py",
       "source_location": "L121",
       "id": "deploy_local_ci_gate_managed_shim_body",
-      "community": 31
+      "community": 4
     },
     {
       "label": "_refuse_unmanaged_overwrite()",
@@ -4793,7 +4793,7 @@
       "source_file": "scripts/overlord/deploy_local_ci_gate.py",
       "source_location": "L150",
       "id": "deploy_local_ci_gate_refuse_unmanaged_overwrite",
-      "community": 31
+      "community": 4
     },
     {
       "label": "_write_managed_shim()",
@@ -4801,7 +4801,7 @@
       "source_file": "scripts/overlord/deploy_local_ci_gate.py",
       "source_location": "L160",
       "id": "deploy_local_ci_gate_write_managed_shim",
-      "community": 31
+      "community": 4
     },
     {
       "label": "print_json()",
@@ -4809,7 +4809,7 @@
       "source_file": "scripts/overlord/deploy_local_ci_gate.py",
       "source_location": "L171",
       "id": "deploy_local_ci_gate_print_json",
-      "community": 31
+      "community": 4
     },
     {
       "label": "add_common_args()",
@@ -4817,7 +4817,7 @@
       "source_file": "scripts/overlord/deploy_local_ci_gate.py",
       "source_location": "L176",
       "id": "deploy_local_ci_gate_add_common_args",
-      "community": 31
+      "community": 4
     },
     {
       "label": "_common_preview_payload()",
@@ -4825,7 +4825,7 @@
       "source_file": "scripts/overlord/deploy_local_ci_gate.py",
       "source_location": "L184",
       "id": "deploy_local_ci_gate_common_preview_payload",
-      "community": 31
+      "community": 4
     },
     {
       "label": "main()",
@@ -4833,7 +4833,7 @@
       "source_file": "scripts/overlord/deploy_local_ci_gate.py",
       "source_location": "L204",
       "id": "deploy_local_ci_gate_main",
-      "community": 31
+      "community": 4
     },
     {
       "label": "governed_repos.py",
@@ -4841,7 +4841,7 @@
       "source_file": "scripts/overlord/governed_repos.py",
       "source_location": "L1",
       "id": "governed_repos",
-      "community": 5
+      "community": 6
     },
     {
       "label": "GovernedRepo",
@@ -4849,7 +4849,7 @@
       "source_file": "scripts/overlord/governed_repos.py",
       "source_location": "L18",
       "id": "governed_repos_governedrepo",
-      "community": 5
+      "community": 6
     },
     {
       "label": ".enabled()",
@@ -4857,7 +4857,7 @@
       "source_file": "scripts/overlord/governed_repos.py",
       "source_location": "L36",
       "id": "governed_repos_governedrepo_enabled",
-      "community": 5
+      "community": 6
     },
     {
       "label": "_expand_home()",
@@ -4865,7 +4865,7 @@
       "source_file": "scripts/overlord/governed_repos.py",
       "source_location": "L40",
       "id": "governed_repos_expand_home",
-      "community": 5
+      "community": 6
     },
     {
       "label": "load_registry()",
@@ -4873,7 +4873,7 @@
       "source_file": "scripts/overlord/governed_repos.py",
       "source_location": "L46",
       "id": "governed_repos_load_registry",
-      "community": 5
+      "community": 6
     },
     {
       "label": "governed_repos()",
@@ -4881,7 +4881,7 @@
       "source_file": "scripts/overlord/governed_repos.py",
       "source_location": "L54",
       "id": "governed_repos_governed_repos",
-      "community": 5
+      "community": 6
     },
     {
       "label": "repos_enabled_for()",
@@ -4889,7 +4889,7 @@
       "source_file": "scripts/overlord/governed_repos.py",
       "source_location": "L90",
       "id": "governed_repos_repos_enabled_for",
-      "community": 5
+      "community": 6
     },
     {
       "label": "repo_names_enabled_for()",
@@ -4897,7 +4897,7 @@
       "source_file": "scripts/overlord/governed_repos.py",
       "source_location": "L94",
       "id": "governed_repos_repo_names_enabled_for",
-      "community": 5
+      "community": 6
     },
     {
       "label": "repos_root()",
@@ -4905,7 +4905,95 @@
       "source_file": "scripts/overlord/governed_repos.py",
       "source_location": "L98",
       "id": "governed_repos_repos_root",
-      "community": 5
+      "community": 6
+    },
+    {
+      "label": "lane_bootstrap.py",
+      "file_type": "code",
+      "source_file": "scripts/overlord/lane_bootstrap.py",
+      "source_location": "L1",
+      "id": "lane_bootstrap",
+      "community": 50
+    },
+    {
+      "label": "LanePolicy",
+      "file_type": "code",
+      "source_file": "scripts/overlord/lane_bootstrap.py",
+      "source_location": "L20",
+      "id": "lane_bootstrap_lanepolicy",
+      "community": 50
+    },
+    {
+      "label": "load_policy()",
+      "file_type": "code",
+      "source_file": "scripts/overlord/lane_bootstrap.py",
+      "source_location": "L29",
+      "id": "lane_bootstrap_load_policy",
+      "community": 50
+    },
+    {
+      "label": "normalize_slug()",
+      "file_type": "code",
+      "source_file": "scripts/overlord/lane_bootstrap.py",
+      "source_location": "L43",
+      "id": "lane_bootstrap_normalize_slug",
+      "community": 50
+    },
+    {
+      "label": "_match()",
+      "file_type": "code",
+      "source_file": "scripts/overlord/lane_bootstrap.py",
+      "source_location": "L50",
+      "id": "lane_bootstrap_match",
+      "community": 50
+    },
+    {
+      "label": "validate_lane()",
+      "file_type": "code",
+      "source_file": "scripts/overlord/lane_bootstrap.py",
+      "source_location": "L54",
+      "id": "lane_bootstrap_validate_lane",
+      "community": 50
+    },
+    {
+      "label": "plan_lane()",
+      "file_type": "code",
+      "source_file": "scripts/overlord/lane_bootstrap.py",
+      "source_location": "L94",
+      "id": "lane_bootstrap_plan_lane",
+      "community": 50
+    },
+    {
+      "label": "cleanup_advice()",
+      "file_type": "code",
+      "source_file": "scripts/overlord/lane_bootstrap.py",
+      "source_location": "L116",
+      "id": "lane_bootstrap_cleanup_advice",
+      "community": 50
+    },
+    {
+      "label": "infer_repo_slug()",
+      "file_type": "code",
+      "source_file": "scripts/overlord/lane_bootstrap.py",
+      "source_location": "L130",
+      "id": "lane_bootstrap_infer_repo_slug",
+      "community": 50
+    },
+    {
+      "label": "parse_args()",
+      "file_type": "code",
+      "source_file": "scripts/overlord/lane_bootstrap.py",
+      "source_location": "L145",
+      "id": "lane_bootstrap_parse_args",
+      "community": 50
+    },
+    {
+      "label": "main()",
+      "file_type": "code",
+      "source_file": "scripts/overlord/lane_bootstrap.py",
+      "source_location": "L168",
+      "id": "lane_bootstrap_main",
+      "community": 50
     },
     {
       "label": "memory_integrity.py",
@@ -4913,7 +5001,7 @@
       "source_file": "scripts/overlord/memory_integrity.py",
       "source_location": "L1",
       "id": "memory_integrity",
-      "community": 59
+      "community": 60
     },
     {
       "label": "fail()",
@@ -4921,7 +5009,7 @@
       "source_file": "scripts/overlord/memory_integrity.py",
       "source_location": "L21",
       "id": "memory_integrity_fail",
-      "community": 59
+      "community": 60
     },
     {
       "label": "memory_dir_for_repo()",
@@ -4929,7 +5017,7 @@
       "source_file": "scripts/overlord/memory_integrity.py",
       "source_location": "L26",
       "id": "memory_integrity_memory_dir_for_repo",
-      "community": 59
+      "community": 60
     },
     {
       "label": "load_memory_lines()",
@@ -4937,7 +5025,7 @@
       "source_file": "scripts/overlord/memory_integrity.py",
       "source_location": "L30",
       "id": "memory_integrity_load_memory_lines",
-      "community": 59
+      "community": 60
     },
     {
       "label": "check_memory_exists()",
@@ -4945,7 +5033,7 @@
       "source_file": "scripts/overlord/memory_integrity.py",
       "source_location": "L34",
       "id": "memory_integrity_check_memory_exists",
-      "community": 59
+      "community": 60
     },
     {
       "label": "parse_pointer_filenames()",
@@ -4953,7 +5041,7 @@
       "source_file": "scripts/overlord/memory_integrity.py",
       "source_location": "L42",
       "id": "memory_integrity_parse_pointer_filenames",
-      "community": 59
+      "community": 60
     },
     {
       "label": "validate_frontmatter()",
@@ -4961,7 +5049,7 @@
       "source_file": "scripts/overlord/memory_integrity.py",
       "source_location": "L57",
       "id": "memory_integrity_validate_frontmatter",
-      "community": 59
+      "community": 60
     },
     {
       "label": "inspect_repo()",
@@ -4969,7 +5057,7 @@
       "source_file": "scripts/overlord/memory_integrity.py",
       "source_location": "L88",
       "id": "memory_integrity_inspect_repo",
-      "community": 59
+      "community": 60
     },
     {
       "label": "main()",
@@ -4977,7 +5065,7 @@
       "source_file": "scripts/overlord/memory_integrity.py",
       "source_location": "L120",
       "id": "memory_integrity_main",
-      "community": 59
+      "community": 60
     },
     {
       "label": "pentagi_sweep.py",
@@ -4985,7 +5073,7 @@
       "source_file": "scripts/overlord/pentagi_sweep.py",
       "source_location": "L1",
       "id": "pentagi_sweep",
-      "community": 5
+      "community": 6
     },
     {
       "label": "PentagiStatus",
@@ -4993,7 +5081,7 @@
       "source_file": "scripts/overlord/pentagi_sweep.py",
       "source_location": "L25",
       "id": "pentagi_sweep_pentagistatus",
-      "community": 5
+      "community": 6
     },
     {
       "label": "_parse_date()",
@@ -5001,7 +5089,7 @@
       "source_file": "scripts/overlord/pentagi_sweep.py",
       "source_location": "L42",
       "id": "pentagi_sweep_parse_date",
-      "community": 5
+      "community": 6
     },
     {
       "label": "_report_date()",
@@ -5009,7 +5097,7 @@
       "source_file": "scripts/overlord/pentagi_sweep.py",
       "source_location": "L49",
       "id": "pentagi_sweep_report_date",
-      "community": 5
+      "community": 6
     },
     {
       "label": "_git_commit()",
@@ -5017,7 +5105,7 @@
       "source_file": "scripts/overlord/pentagi_sweep.py",
       "source_location": "L56",
       "id": "pentagi_sweep_git_commit",
-      "community": 5
+      "community": 6
     },
     {
       "label": "_git_tracked_paths()",
@@ -5025,7 +5113,7 @@
       "source_file": "scripts/overlord/pentagi_sweep.py",
       "source_location": "L67",
       "id": "pentagi_sweep_git_tracked_paths",
-      "community": 5
+      "community": 6
     },
     {
       "label": "_git_path_is_tracked()",
@@ -5033,7 +5121,7 @@
       "source_file": "scripts/overlord/pentagi_sweep.py",
       "source_location": "L88",
       "id": "pentagi_sweep_git_path_is_tracked",
-      "community": 5
+      "community": 6
     },
     {
       "label": "_candidate_paths()",
@@ -5041,7 +5129,7 @@
       "source_file": "scripts/overlord/pentagi_sweep.py",
       "source_location": "L95",
       "id": "pentagi_sweep_candidate_paths",
-      "community": 5
+      "community": 6
     },
     {
       "label": "resolve_repo_path()",
@@ -5049,7 +5137,7 @@
       "source_file": "scripts/overlord/pentagi_sweep.py",
       "source_location": "L103",
       "id": "pentagi_sweep_resolve_repo_path",
-      "community": 5
+      "community": 6
     },
     {
       "label": "latest_pentagi_report()",
@@ -5057,7 +5145,7 @@
       "source_file": "scripts/overlord/pentagi_sweep.py",
       "source_location": "L111",
       "id": "pentagi_sweep_latest_pentagi_report",
-      "community": 5
+      "community": 6
     },
     {
       "label": "pentagi_repos()",
@@ -5065,7 +5153,7 @@
       "source_file": "scripts/overlord/pentagi_sweep.py",
       "source_location": "L128",
       "id": "pentagi_sweep_pentagi_repos",
-      "community": 5
+      "community": 6
     },
     {
       "label": "evaluate_repo()",
@@ -5073,7 +5161,7 @@
       "source_file": "scripts/overlord/pentagi_sweep.py",
       "source_location": "L136",
       "id": "pentagi_sweep_evaluate_repo",
-      "community": 5
+      "community": 6
     },
     {
       "label": "build_payload()",
@@ -5081,7 +5169,7 @@
       "source_file": "scripts/overlord/pentagi_sweep.py",
       "source_location": "L210",
       "id": "pentagi_sweep_build_payload",
-      "community": 5
+      "community": 6
     },
     {
       "label": "render_markdown()",
@@ -5089,7 +5177,7 @@
       "source_file": "scripts/overlord/pentagi_sweep.py",
       "source_location": "L222",
       "id": "pentagi_sweep_render_markdown",
-      "community": 5
+      "community": 6
     },
     {
       "label": "write_optional()",
@@ -5097,7 +5185,7 @@
       "source_file": "scripts/overlord/pentagi_sweep.py",
       "source_location": "L244",
       "id": "pentagi_sweep_write_optional",
-      "community": 5
+      "community": 6
     },
     {
       "label": "main()",
@@ -5105,7 +5193,7 @@
       "source_file": "scripts/overlord/pentagi_sweep.py",
       "source_location": "L252",
       "id": "pentagi_sweep_main",
-      "community": 5
+      "community": 6
     },
     {
       "label": "render_github_issue_feed.py",
@@ -5137,7 +5225,7 @@
       "source_file": "scripts/overlord/test_assert_execution_scope.py",
       "source_location": "L1",
       "id": "test_assert_execution_scope",
-      "community": 7
+      "community": 9
     },
     {
       "label": "_git()",
@@ -5145,7 +5233,7 @@
       "source_file": "scripts/overlord/test_assert_execution_scope.py",
       "source_location": "L27",
       "id": "test_assert_execution_scope_git",
-      "community": 7
+      "community": 9
     },
     {
       "label": "RepoFixture",
@@ -5153,7 +5241,7 @@
       "source_file": "scripts/overlord/test_assert_execution_scope.py",
       "source_location": "L37",
       "id": "test_assert_execution_scope_repofixture",
-      "community": 7
+      "community": 9
     },
     {
       "label": ".__init__()",
@@ -5161,7 +5249,7 @@
       "source_file": "scripts/overlord/test_assert_execution_scope.py",
       "source_location": "L38",
       "id": "test_assert_execution_scope_repofixture_init",
-      "community": 7
+      "community": 9
     },
     {
       "label": ".write()",
@@ -5169,7 +5257,7 @@
       "source_file": "scripts/overlord/test_assert_execution_scope.py",
       "source_location": "L50",
       "id": "test_assert_execution_scope_repofixture_write",
-      "community": 7
+      "community": 9
     },
     {
       "label": "TestAssertExecutionScope",
@@ -5177,7 +5265,7 @@
       "source_file": "scripts/overlord/test_assert_execution_scope.py",
       "source_location": "L56",
       "id": "test_assert_execution_scope_testassertexecutionscope",
-      "community": 7
+      "community": 9
     },
     {
       "label": "._scope_file()",
@@ -5185,7 +5273,7 @@
       "source_file": "scripts/overlord/test_assert_execution_scope.py",
       "source_location": "L57",
       "id": "test_assert_execution_scope_testassertexecutionscope_scope_file",
-      "community": 7
+      "community": 9
     },
     {
       "label": "._run_main()",
@@ -5193,7 +5281,7 @@
       "source_file": "scripts/overlord/test_assert_execution_scope.py",
       "source_location": "L87",
       "id": "test_assert_execution_scope_testassertexecutionscope_run_main",
-      "community": 7
+      "community": 9
     },
     {
       "label": "._changed_files_file()",
@@ -5201,7 +5289,7 @@
       "source_file": "scripts/overlord/test_assert_execution_scope.py",
       "source_location": "L105",
       "id": "test_assert_execution_scope_testassertexecutionscope_changed_files_file",
-      "community": 7
+      "community": 9
     },
     {
       "label": "._write_exception_file()",
@@ -5209,7 +5297,7 @@
       "source_file": "scripts/overlord/test_assert_execution_scope.py",
       "source_location": "L110",
       "id": "test_assert_execution_scope_testassertexecutionscope_write_exception_file",
-      "community": 7
+      "community": 9
     },
     {
       "label": "._handoff()",
@@ -5217,7 +5305,7 @@
       "source_file": "scripts/overlord/test_assert_execution_scope.py",
       "source_location": "L113",
       "id": "test_assert_execution_scope_testassertexecutionscope_handoff",
-      "community": 7
+      "community": 9
     },
     {
       "label": "._lane_claim()",
@@ -5225,7 +5313,7 @@
       "source_file": "scripts/overlord/test_assert_execution_scope.py",
       "source_location": "L132",
       "id": "test_assert_execution_scope_testassertexecutionscope_lane_claim",
-      "community": 7
+      "community": 9
     },
     {
       "label": ".test_allows_changes_in_allowed_paths_dirty_tree_mode()",
@@ -5233,7 +5321,7 @@
       "source_file": "scripts/overlord/test_assert_execution_scope.py",
       "source_location": "L140",
       "id": "test_assert_execution_scope_testassertexecutionscope_test_allows_changes_in_allowed_paths_dirty_tree_mode",
-      "community": 7
+      "community": 9
     },
     {
       "label": ".test_planning_only_diff_inside_allowed_paths_passes()",
@@ -5241,7 +5329,7 @@
       "source_file": "scripts/overlord/test_assert_execution_scope.py",
       "source_location": "L153",
       "id": "test_assert_execution_scope_testassertexecutionscope_test_planning_only_diff_inside_allowed_paths_passes",
-      "community": 7
+      "community": 9
     },
     {
       "label": ".test_planning_only_diff_outside_allowed_paths_fails()",
@@ -5249,7 +5337,7 @@
       "source_file": "scripts/overlord/test_assert_execution_scope.py",
       "source_location": "L165",
       "id": "test_assert_execution_scope_testassertexecutionscope_test_planning_only_diff_outside_allowed_paths_fails",
-      "community": 7
+      "community": 9
     },
     {
       "label": ".test_non_planning_without_handoff_fails()",
@@ -5257,7 +5345,7 @@
       "source_file": "scripts/overlord/test_assert_execution_scope.py",
       "source_location": "L178",
       "id": "test_assert_execution_scope_testassertexecutionscope_test_non_planning_without_handoff_fails",
-      "community": 7
+      "community": 9
     },
     {
       "label": ".test_non_planning_with_accepted_handoff_passes()",
@@ -5265,7 +5353,7 @@
       "source_file": "scripts/overlord/test_assert_execution_scope.py",
       "source_location": "L190",
       "id": "test_assert_execution_scope_testassertexecutionscope_test_non_planning_with_accepted_handoff_passes",
-      "community": 7
+      "community": 9
     },
     {
       "label": ".test_same_model_or_family_without_active_exception_fails()",
@@ -5273,7 +5361,7 @@
       "source_file": "scripts/overlord/test_assert_execution_scope.py",
       "source_location": "L210",
       "id": "test_assert_execution_scope_testassertexecutionscope_test_same_model_or_family_without_active_exception_fails",
-      "community": 7
+      "community": 9
     },
     {
       "label": ".test_gpt_major_decimal_variants_without_active_exception_fail()",
@@ -5281,7 +5369,7 @@
       "source_file": "scripts/overlord/test_assert_execution_scope.py",
       "source_location": "L230",
       "id": "test_assert_execution_scope_testassertexecutionscope_test_gpt_major_decimal_variants_without_active_exception_fail",
-      "community": 7
+      "community": 9
     },
     {
       "label": ".test_gpt_major_decimal_variants_with_active_exception_pass()",
@@ -5289,7 +5377,7 @@
       "source_file": "scripts/overlord/test_assert_execution_scope.py",
       "source_location": "L250",
       "id": "test_assert_execution_scope_testassertexecutionscope_test_gpt_major_decimal_variants_with_active_exception_pass",
-      "community": 7
+      "community": 9
     },
     {
       "label": ".test_active_exception_with_expiry_passes()",
@@ -5297,7 +5385,7 @@
       "source_file": "scripts/overlord/test_assert_execution_scope.py",
       "source_location": "L273",
       "id": "test_assert_execution_scope_testassertexecutionscope_test_active_exception_with_expiry_passes",
-      "community": 7
+      "community": 9
     },
     {
       "label": ".test_active_exception_ref_nonexistent_file_fails()",
@@ -5305,7 +5393,7 @@
       "source_file": "scripts/overlord/test_assert_execution_scope.py",
       "source_location": "L296",
       "id": "test_assert_execution_scope_testassertexecutionscope_test_active_exception_ref_nonexistent_file_fails",
-      "community": 7
+      "community": 9
     },
     {
       "label": ".test_active_exception_ref_existing_file_with_anchor_passes()",
@@ -5313,7 +5401,7 @@
       "source_file": "scripts/overlord/test_assert_execution_scope.py",
       "source_location": "L319",
       "id": "test_assert_execution_scope_testassertexecutionscope_test_active_exception_ref_existing_file_with_anchor_passes",
-      "community": 7
+      "community": 9
     },
     {
       "label": ".test_diff_mode_and_dirty_tree_mode_share_path_normalization()",
@@ -5321,7 +5409,7 @@
       "source_file": "scripts/overlord/test_assert_execution_scope.py",
       "source_location": "L342",
       "id": "test_assert_execution_scope_testassertexecutionscope_test_diff_mode_and_dirty_tree_mode_share_path_normalization",
-      "community": 7
+      "community": 9
     },
     {
       "label": ".test_portable_expected_root_sentinel_passes_in_copied_checkout()",
@@ -5329,7 +5417,7 @@
       "source_file": "scripts/overlord/test_assert_execution_scope.py",
       "source_location": "L356",
       "id": "test_assert_execution_scope_testassertexecutionscope_test_portable_expected_root_sentinel_passes_in_copied_checkout",
-      "community": 7
+      "community": 9
     },
     {
       "label": ".test_refuses_wrong_root()",
@@ -5337,7 +5425,7 @@
       "source_file": "scripts/overlord/test_assert_execution_scope.py",
       "source_location": "L369",
       "id": "test_assert_execution_scope_testassertexecutionscope_test_refuses_wrong_root",
-      "community": 7
+      "community": 9
     },
     {
       "label": ".test_refuses_wrong_branch()",
@@ -5345,7 +5433,7 @@
       "source_file": "scripts/overlord/test_assert_execution_scope.py",
       "source_location": "L381",
       "id": "test_assert_execution_scope_testassertexecutionscope_test_refuses_wrong_branch",
-      "community": 7
+      "community": 9
     },
     {
       "label": ".test_require_lane_claim_passes_when_issue_matches_branch_and_scope()",
@@ -5353,7 +5441,7 @@
       "source_file": "scripts/overlord/test_assert_execution_scope.py",
       "source_location": "L392",
       "id": "test_assert_execution_scope_testassertexecutionscope_test_require_lane_claim_passes_when_issue_matches_branch_and_scope",
-      "community": 7
+      "community": 9
     },
     {
       "label": ".test_require_lane_claim_fails_when_missing()",
@@ -5361,7 +5449,7 @@
       "source_file": "scripts/overlord/test_assert_execution_scope.py",
       "source_location": "L409",
       "id": "test_assert_execution_scope_testassertexecutionscope_test_require_lane_claim_fails_when_missing",
-      "community": 7
+      "community": 9
     },
     {
       "label": ".test_require_lane_claim_fails_when_current_branch_issue_mismatches()",
@@ -5369,7 +5457,7 @@
       "source_file": "scripts/overlord/test_assert_execution_scope.py",
       "source_location": "L420",
       "id": "test_assert_execution_scope_testassertexecutionscope_test_require_lane_claim_fails_when_current_branch_issue_mismatches",
-      "community": 7
+      "community": 9
     },
     {
       "label": ".test_require_lane_claim_fails_when_expected_branch_issue_mismatches()",
@@ -5377,7 +5465,7 @@
       "source_file": "scripts/overlord/test_assert_execution_scope.py",
       "source_location": "L436",
       "id": "test_assert_execution_scope_testassertexecutionscope_test_require_lane_claim_fails_when_expected_branch_issue_mismatches",
-      "community": 7
+      "community": 9
     },
     {
       "label": ".test_detached_checkout_uses_github_head_ref()",
@@ -5385,7 +5473,7 @@
       "source_file": "scripts/overlord/test_assert_execution_scope.py",
       "source_location": "L452",
       "id": "test_assert_execution_scope_testassertexecutionscope_test_detached_checkout_uses_github_head_ref",
-      "community": 7
+      "community": 9
     },
     {
       "label": ".test_refuses_dirty_forbidden_root()",
@@ -5393,7 +5481,7 @@
       "source_file": "scripts/overlord/test_assert_execution_scope.py",
       "source_location": "L471",
       "id": "test_assert_execution_scope_testassertexecutionscope_test_refuses_dirty_forbidden_root",
-      "community": 7
+      "community": 9
     },
     {
       "label": ".test_declared_active_parallel_root_warns_instead_of_failing()",
@@ -5401,7 +5489,7 @@
       "source_file": "scripts/overlord/test_assert_execution_scope.py",
       "source_location": "L485",
       "id": "test_assert_execution_scope_testassertexecutionscope_test_declared_active_parallel_root_warns_instead_of_failing",
-      "community": 7
+      "community": 9
     },
     {
       "label": ".test_active_parallel_root_does_not_hide_inactive_dirty_root()",
@@ -5409,7 +5497,7 @@
       "source_file": "scripts/overlord/test_assert_execution_scope.py",
       "source_location": "L510",
       "id": "test_assert_execution_scope_testassertexecutionscope_test_active_parallel_root_does_not_hide_inactive_dirty_root",
-      "community": 7
+      "community": 9
     },
     {
       "label": ".test_clean_active_parallel_root_does_not_warn()",
@@ -5417,7 +5505,7 @@
       "source_file": "scripts/overlord/test_assert_execution_scope.py",
       "source_location": "L537",
       "id": "test_assert_execution_scope_testassertexecutionscope_test_clean_active_parallel_root_does_not_warn",
-      "community": 7
+      "community": 9
     },
     {
       "label": ".test_refuses_active_parallel_root_not_in_forbidden_roots()",
@@ -5425,7 +5513,7 @@
       "source_file": "scripts/overlord/test_assert_execution_scope.py",
       "source_location": "L559",
       "id": "test_assert_execution_scope_testassertexecutionscope_test_refuses_active_parallel_root_not_in_forbidden_roots",
-      "community": 7
+      "community": 9
     },
     {
       "label": ".test_refuses_active_parallel_root_without_reason()",
@@ -5433,7 +5521,7 @@
       "source_file": "scripts/overlord/test_assert_execution_scope.py",
       "source_location": "L581",
       "id": "test_assert_execution_scope_testassertexecutionscope_test_refuses_active_parallel_root_without_reason",
-      "community": 7
+      "community": 9
     },
     {
       "label": ".test_refuses_out_of_scope_changes()",
@@ -5441,7 +5529,7 @@
       "source_file": "scripts/overlord/test_assert_execution_scope.py",
       "source_location": "L603",
       "id": "test_assert_execution_scope_testassertexecutionscope_test_refuses_out_of_scope_changes",
-      "community": 7
+      "community": 9
     },
     {
       "label": "_working_directory()",
@@ -5449,7 +5537,7 @@
       "source_file": "scripts/overlord/test_assert_execution_scope.py",
       "source_location": "L618",
       "id": "test_assert_execution_scope_working_directory",
-      "community": 7
+      "community": 9
     },
     {
       "label": "test_automerge_policy_check.py",
@@ -5457,7 +5545,7 @@
       "source_file": "scripts/overlord/test_automerge_policy_check.py",
       "source_location": "L1",
       "id": "test_automerge_policy_check",
-      "community": 47
+      "community": 45
     },
     {
       "label": "eligible_payload()",
@@ -5465,7 +5553,7 @@
       "source_file": "scripts/overlord/test_automerge_policy_check.py",
       "source_location": "L14",
       "id": "test_automerge_policy_check_eligible_payload",
-      "community": 47
+      "community": 45
     },
     {
       "label": "TestAutomergePolicyCheck",
@@ -5473,7 +5561,7 @@
       "source_file": "scripts/overlord/test_automerge_policy_check.py",
       "source_location": "L43",
       "id": "test_automerge_policy_check_testautomergepolicycheck",
-      "community": 47
+      "community": 45
     },
     {
       "label": ".test_eligible_payload_passes()",
@@ -5481,7 +5569,7 @@
       "source_file": "scripts/overlord/test_automerge_policy_check.py",
       "source_location": "L44",
       "id": "test_automerge_policy_check_testautomergepolicycheck_test_eligible_payload_passes",
-      "community": 47
+      "community": 45
     },
     {
       "label": ".test_blocks_draft_red_unreviewed_conflicted_pr()",
@@ -5489,7 +5577,7 @@
       "source_file": "scripts/overlord/test_automerge_policy_check.py",
       "source_location": "L51",
       "id": "test_automerge_policy_check_testautomergepolicycheck_test_blocks_draft_red_unreviewed_conflicted_pr",
-      "community": 47
+      "community": 45
     },
     {
       "label": ".test_blocks_disabled_repo_missing_opt_in_and_blocking_label()",
@@ -5497,7 +5585,7 @@
       "source_file": "scripts/overlord/test_automerge_policy_check.py",
       "source_location": "L78",
       "id": "test_automerge_policy_check_testautomergepolicycheck_test_blocks_disabled_repo_missing_opt_in_and_blocking_label",
-      "community": 47
+      "community": 45
     },
     {
       "label": ".test_cli_returns_two_for_blocked_payload_and_writes_json()",
@@ -5505,7 +5593,7 @@
       "source_file": "scripts/overlord/test_automerge_policy_check.py",
       "source_location": "L93",
       "id": "test_automerge_policy_check_testautomergepolicycheck_test_cli_returns_two_for_blocked_payload_and_writes_json",
-      "community": 47
+      "community": 45
     },
     {
       "label": "test_branch_switch_guard.py",
@@ -5513,7 +5601,7 @@
       "source_file": "scripts/overlord/test_branch_switch_guard.py",
       "source_location": "L1",
       "id": "test_branch_switch_guard",
-      "community": 60
+      "community": 51
     },
     {
       "label": "run_hook()",
@@ -5521,7 +5609,7 @@
       "source_file": "scripts/overlord/test_branch_switch_guard.py",
       "source_location": "L15",
       "id": "test_branch_switch_guard_run_hook",
-      "community": 60
+      "community": 51
     },
     {
       "label": "TestBranchSwitchGuard",
@@ -5529,7 +5617,7 @@
       "source_file": "scripts/overlord/test_branch_switch_guard.py",
       "source_location": "L26",
       "id": "test_branch_switch_guard_testbranchswitchguard",
-      "community": 60
+      "community": 51
     },
     {
       "label": ".test_blocks_unclaimed_issue_worktree_add()",
@@ -5537,47 +5625,63 @@
       "source_file": "scripts/overlord/test_branch_switch_guard.py",
       "source_location": "L27",
       "id": "test_branch_switch_guard_testbranchswitchguard_test_blocks_unclaimed_issue_worktree_add",
-      "community": 60
+      "community": 51
     },
     {
       "label": ".test_allows_explicit_planning_bootstrap_issue_worktree_add()",
       "file_type": "code",
       "source_file": "scripts/overlord/test_branch_switch_guard.py",
-      "source_location": "L33",
+      "source_location": "L35",
       "id": "test_branch_switch_guard_testbranchswitchguard_test_allows_explicit_planning_bootstrap_issue_worktree_add",
-      "community": 60
+      "community": 51
     },
     {
       "label": ".test_allows_non_issue_worktree_add()",
       "file_type": "code",
       "source_file": "scripts/overlord/test_branch_switch_guard.py",
-      "source_location": "L40",
+      "source_location": "L42",
       "id": "test_branch_switch_guard_testbranchswitchguard_test_allows_non_issue_worktree_add",
-      "community": 60
+      "community": 51
     },
     {
       "label": ".test_allows_issue_worktree_add_with_matching_claimed_scope()",
       "file_type": "code",
       "source_file": "scripts/overlord/test_branch_switch_guard.py",
-      "source_location": "L45",
+      "source_location": "L47",
       "id": "test_branch_switch_guard_testbranchswitchguard_test_allows_issue_worktree_add_with_matching_claimed_scope",
-      "community": 60
+      "community": 51
     },
     {
       "label": ".test_blocks_issue_worktree_add_with_mismatched_claimed_scope()",
       "file_type": "code",
       "source_file": "scripts/overlord/test_branch_switch_guard.py",
-      "source_location": "L61",
+      "source_location": "L63",
       "id": "test_branch_switch_guard_testbranchswitchguard_test_blocks_issue_worktree_add_with_mismatched_claimed_scope",
-      "community": 60
+      "community": 51
+    },
+    {
+      "label": ".test_healthcareplatform_policy_rejects_non_sandbox_branch()",
+      "file_type": "code",
+      "source_file": "scripts/overlord/test_branch_switch_guard.py",
+      "source_location": "L80",
+      "id": "test_branch_switch_guard_testbranchswitchguard_test_healthcareplatform_policy_rejects_non_sandbox_branch",
+      "community": 51
+    },
+    {
+      "label": ".test_healthcareplatform_policy_accepts_sandbox_pr_pending_lane()",
+      "file_type": "code",
+      "source_file": "scripts/overlord/test_branch_switch_guard.py",
+      "source_location": "L89",
+      "id": "test_branch_switch_guard_testbranchswitchguard_test_healthcareplatform_policy_accepts_sandbox_pr_pending_lane",
+      "community": 51
     },
     {
       "label": ".test_still_blocks_branch_checkout()",
       "file_type": "code",
       "source_file": "scripts/overlord/test_branch_switch_guard.py",
-      "source_location": "L78",
+      "source_location": "L97",
       "id": "test_branch_switch_guard_testbranchswitchguard_test_still_blocks_branch_checkout",
-      "community": 60
+      "community": 51
     },
     {
       "label": "test_check_org_repo_inventory.py",
@@ -5585,7 +5689,7 @@
       "source_file": "scripts/overlord/test_check_org_repo_inventory.py",
       "source_location": "L1",
       "id": "test_check_org_repo_inventory",
-      "community": 44
+      "community": 41
     },
     {
       "label": "TestOrgRepoInventory",
@@ -5593,7 +5697,7 @@
       "source_file": "scripts/overlord/test_check_org_repo_inventory.py",
       "source_location": "L23",
       "id": "test_check_org_repo_inventory_testorgrepoinventory",
-      "community": 44
+      "community": 41
     },
     {
       "label": "._registry()",
@@ -5601,7 +5705,7 @@
       "source_file": "scripts/overlord/test_check_org_repo_inventory.py",
       "source_location": "L24",
       "id": "test_check_org_repo_inventory_testorgrepoinventory_registry",
-      "community": 44
+      "community": 41
     },
     {
       "label": "._inventory()",
@@ -5609,7 +5713,7 @@
       "source_file": "scripts/overlord/test_check_org_repo_inventory.py",
       "source_location": "L73",
       "id": "test_check_org_repo_inventory_testorgrepoinventory_inventory",
-      "community": 44
+      "community": 41
     },
     {
       "label": "._repo_row()",
@@ -5617,7 +5721,7 @@
       "source_file": "scripts/overlord/test_check_org_repo_inventory.py",
       "source_location": "L78",
       "id": "test_check_org_repo_inventory_testorgrepoinventory_repo_row",
-      "community": 44
+      "community": 41
     },
     {
       "label": "._run()",
@@ -5625,7 +5729,7 @@
       "source_file": "scripts/overlord/test_check_org_repo_inventory.py",
       "source_location": "L88",
       "id": "test_check_org_repo_inventory_testorgrepoinventory_run",
-      "community": 44
+      "community": 41
     },
     {
       "label": ".test_exact_active_inventory_passes()",
@@ -5633,7 +5737,7 @@
       "source_file": "scripts/overlord/test_check_org_repo_inventory.py",
       "source_location": "L95",
       "id": "test_check_org_repo_inventory_testorgrepoinventory_test_exact_active_inventory_passes",
-      "community": 44
+      "community": 41
     },
     {
       "label": ".test_missing_active_repo_fails()",
@@ -5641,7 +5745,7 @@
       "source_file": "scripts/overlord/test_check_org_repo_inventory.py",
       "source_location": "L109",
       "id": "test_check_org_repo_inventory_testorgrepoinventory_test_missing_active_repo_fails",
-      "community": 44
+      "community": 41
     },
     {
       "label": ".test_warn_only_reports_missing_active_repo_but_passes()",
@@ -5649,7 +5753,7 @@
       "source_file": "scripts/overlord/test_check_org_repo_inventory.py",
       "source_location": "L124",
       "id": "test_check_org_repo_inventory_testorgrepoinventory_test_warn_only_reports_missing_active_repo_but_passes",
-      "community": 44
+      "community": 41
     },
     {
       "label": ".test_stale_registry_repo_fails()",
@@ -5657,7 +5761,7 @@
       "source_file": "scripts/overlord/test_check_org_repo_inventory.py",
       "source_location": "L147",
       "id": "test_check_org_repo_inventory_testorgrepoinventory_test_stale_registry_repo_fails",
-      "community": 44
+      "community": 41
     },
     {
       "label": ".test_archived_unregistered_repo_is_notice_not_blocker()",
@@ -5665,7 +5769,7 @@
       "source_file": "scripts/overlord/test_check_org_repo_inventory.py",
       "source_location": "L159",
       "id": "test_check_org_repo_inventory_testorgrepoinventory_test_archived_unregistered_repo_is_notice_not_blocker",
-      "community": 44
+      "community": 41
     },
     {
       "label": ".test_archived_registry_repo_fails_without_archived_lifecycle_classification()",
@@ -5673,7 +5777,7 @@
       "source_file": "scripts/overlord/test_check_org_repo_inventory.py",
       "source_location": "L174",
       "id": "test_check_org_repo_inventory_testorgrepoinventory_test_archived_registry_repo_fails_without_archived_lifecycle_classification",
-      "community": 44
+      "community": 41
     },
     {
       "label": ".test_archived_registry_repo_passes_with_archived_lifecycle_classification()",
@@ -5681,7 +5785,7 @@
       "source_file": "scripts/overlord/test_check_org_repo_inventory.py",
       "source_location": "L189",
       "id": "test_check_org_repo_inventory_testorgrepoinventory_test_archived_registry_repo_passes_with_archived_lifecycle_classification",
-      "community": 44
+      "community": 41
     },
     {
       "label": "test_check_overlord_backlog_github_alignment.py",
@@ -5689,7 +5793,7 @@
       "source_file": "scripts/overlord/test_check_overlord_backlog_github_alignment.py",
       "source_location": "L1",
       "id": "test_check_overlord_backlog_github_alignment",
-      "community": 28
+      "community": 29
     },
     {
       "label": "TestOverlordBacklogGithubAlignment",
@@ -5697,7 +5801,7 @@
       "source_file": "scripts/overlord/test_check_overlord_backlog_github_alignment.py",
       "source_location": "L17",
       "id": "test_check_overlord_backlog_github_alignment_testoverlordbackloggithubalignment",
-      "community": 28
+      "community": 29
     },
     {
       "label": ".test_in_progress_closed_issue_fails()",
@@ -5705,7 +5809,7 @@
       "source_file": "scripts/overlord/test_check_overlord_backlog_github_alignment.py",
       "source_location": "L18",
       "id": "test_check_overlord_backlog_github_alignment_testoverlordbackloggithubalignment_test_in_progress_closed_issue_fails",
-      "community": 28
+      "community": 29
     },
     {
       "label": ".test_planned_open_issue_passes()",
@@ -5713,7 +5817,7 @@
       "source_file": "scripts/overlord/test_check_overlord_backlog_github_alignment.py",
       "source_location": "L36",
       "id": "test_check_overlord_backlog_github_alignment_testoverlordbackloggithubalignment_test_planned_open_issue_passes",
-      "community": 28
+      "community": 29
     },
     {
       "label": ".test_missing_issue_column_reference_fails()",
@@ -5721,95 +5825,95 @@
       "source_file": "scripts/overlord/test_check_overlord_backlog_github_alignment.py",
       "source_location": "L42",
       "id": "test_check_overlord_backlog_github_alignment_testoverlordbackloggithubalignment_test_missing_issue_column_reference_fails",
-      "community": 28
+      "community": 29
     },
     {
       "label": "test_check_plan_preflight.py",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/hldpro-governance/var/worktrees/issue-463-stage6-closeout-439/scripts/overlord/test_check_plan_preflight.py",
+      "source_file": "scripts/overlord/test_check_plan_preflight.py",
       "source_location": "L1",
       "id": "test_check_plan_preflight",
-      "community": 51
+      "community": 52
     },
     {
       "label": "_run()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/hldpro-governance/var/worktrees/issue-463-stage6-closeout-439/scripts/overlord/test_check_plan_preflight.py",
+      "source_file": "scripts/overlord/test_check_plan_preflight.py",
       "source_location": "L17",
       "id": "test_check_plan_preflight_run",
-      "community": 51
+      "community": 52
     },
     {
       "label": "TestPlanPreflight",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/hldpro-governance/var/worktrees/issue-463-stage6-closeout-439/scripts/overlord/test_check_plan_preflight.py",
+      "source_file": "scripts/overlord/test_check_plan_preflight.py",
       "source_location": "L27",
       "id": "test_check_plan_preflight_testplanpreflight",
-      "community": 51
+      "community": 52
     },
     {
       "label": ".test_code_file_without_recent_plan_blocks_with_route_tokens()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/hldpro-governance/var/worktrees/issue-463-stage6-closeout-439/scripts/overlord/test_check_plan_preflight.py",
+      "source_file": "scripts/overlord/test_check_plan_preflight.py",
       "source_location": "L28",
       "id": "test_check_plan_preflight_testplanpreflight_test_code_file_without_recent_plan_blocks_with_route_tokens",
-      "community": 51
+      "community": 52
     },
     {
       "label": ".test_read_only_intent_is_allowed()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/hldpro-governance/var/worktrees/issue-463-stage6-closeout-439/scripts/overlord/test_check_plan_preflight.py",
+      "source_file": "scripts/overlord/test_check_plan_preflight.py",
       "source_location": "L40",
       "id": "test_check_plan_preflight_testplanpreflight_test_read_only_intent_is_allowed",
-      "community": 51
+      "community": 52
     },
     {
       "label": ".test_trivial_single_line_bypass_is_explicitly_bounded()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/hldpro-governance/var/worktrees/issue-463-stage6-closeout-439/scripts/overlord/test_check_plan_preflight.py",
+      "source_file": "scripts/overlord/test_check_plan_preflight.py",
       "source_location": "L48",
       "id": "test_check_plan_preflight_testplanpreflight_test_trivial_single_line_bypass_is_explicitly_bounded",
-      "community": 51
+      "community": 52
     },
     {
       "label": ".test_general_bypass_without_trivial_marker_still_blocks()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/hldpro-governance/var/worktrees/issue-463-stage6-closeout-439/scripts/overlord/test_check_plan_preflight.py",
+      "source_file": "scripts/overlord/test_check_plan_preflight.py",
       "source_location": "L62",
       "id": "test_check_plan_preflight_testplanpreflight_test_general_bypass_without_trivial_marker_still_blocks",
-      "community": 51
+      "community": 52
     },
     {
       "label": ".test_recent_plan_allows_governed_write()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/hldpro-governance/var/worktrees/issue-463-stage6-closeout-439/scripts/overlord/test_check_plan_preflight.py",
+      "source_file": "scripts/overlord/test_check_plan_preflight.py",
       "source_location": "L69",
       "id": "test_check_plan_preflight_testplanpreflight_test_recent_plan_allows_governed_write",
-      "community": 51
+      "community": 52
     },
     {
       "label": ".test_stale_plan_does_not_clear_preflight()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/hldpro-governance/var/worktrees/issue-463-stage6-closeout-439/scripts/overlord/test_check_plan_preflight.py",
+      "source_file": "scripts/overlord/test_check_plan_preflight.py",
       "source_location": "L82",
       "id": "test_check_plan_preflight_testplanpreflight_test_stale_plan_does_not_clear_preflight",
-      "community": 51
+      "community": 52
     },
     {
       "label": ".test_bash_write_command_detects_target()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/hldpro-governance/var/worktrees/issue-463-stage6-closeout-439/scripts/overlord/test_check_plan_preflight.py",
+      "source_file": "scripts/overlord/test_check_plan_preflight.py",
       "source_location": "L97",
       "id": "test_check_plan_preflight_testplanpreflight_test_bash_write_command_detects_target",
-      "community": 51
+      "community": 52
     },
     {
       "label": ".test_python_write_command_is_refused_with_routing_signal()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/hldpro-governance/var/worktrees/issue-463-stage6-closeout-439/scripts/overlord/test_check_plan_preflight.py",
+      "source_file": "scripts/overlord/test_check_plan_preflight.py",
       "source_location": "L109",
       "id": "test_check_plan_preflight_testplanpreflight_test_python_write_command_is_refused_with_routing_signal",
-      "community": 51
+      "community": 52
     },
     {
       "label": "test_check_worker_handoff_route.py",
@@ -5945,7 +6049,7 @@
       "source_file": "scripts/overlord/test_deploy_governance_tooling.py",
       "source_location": "L1",
       "id": "test_deploy_governance_tooling",
-      "community": 27
+      "community": 28
     },
     {
       "label": "TestDeployGovernanceTooling",
@@ -5953,7 +6057,7 @@
       "source_file": "scripts/overlord/test_deploy_governance_tooling.py",
       "source_location": "L26",
       "id": "test_deploy_governance_tooling_testdeploygovernancetooling",
-      "community": 27
+      "community": 28
     },
     {
       "label": ".setUp()",
@@ -5961,7 +6065,7 @@
       "source_file": "scripts/overlord/test_deploy_governance_tooling.py",
       "source_location": "L27",
       "id": "test_deploy_governance_tooling_testdeploygovernancetooling_setup",
-      "community": 27
+      "community": 28
     },
     {
       "label": ".tearDown()",
@@ -5969,7 +6073,7 @@
       "source_file": "scripts/overlord/test_deploy_governance_tooling.py",
       "source_location": "L40",
       "id": "test_deploy_governance_tooling_testdeploygovernancetooling_teardown",
-      "community": 27
+      "community": 28
     },
     {
       "label": "._invoke()",
@@ -5977,7 +6081,7 @@
       "source_file": "scripts/overlord/test_deploy_governance_tooling.py",
       "source_location": "L43",
       "id": "test_deploy_governance_tooling_testdeploygovernancetooling_invoke",
-      "community": 27
+      "community": 28
     },
     {
       "label": "._base_args()",
@@ -5985,7 +6089,7 @@
       "source_file": "scripts/overlord/test_deploy_governance_tooling.py",
       "source_location": "L50",
       "id": "test_deploy_governance_tooling_testdeploygovernancetooling_base_args",
-      "community": 27
+      "community": 28
     },
     {
       "label": "._record()",
@@ -5993,7 +6097,7 @@
       "source_file": "scripts/overlord/test_deploy_governance_tooling.py",
       "source_location": "L62",
       "id": "test_deploy_governance_tooling_testdeploygovernancetooling_record",
-      "community": 27
+      "community": 28
     },
     {
       "label": "._shim()",
@@ -6001,7 +6105,7 @@
       "source_file": "scripts/overlord/test_deploy_governance_tooling.py",
       "source_location": "L65",
       "id": "test_deploy_governance_tooling_testdeploygovernancetooling_shim",
-      "community": 27
+      "community": 28
     },
     {
       "label": ".test_dry_run_plans_managed_files_without_writing()",
@@ -6009,7 +6113,7 @@
       "source_file": "scripts/overlord/test_deploy_governance_tooling.py",
       "source_location": "L68",
       "id": "test_deploy_governance_tooling_testdeploygovernancetooling_test_dry_run_plans_managed_files_without_writing",
-      "community": 27
+      "community": 28
     },
     {
       "label": ".test_apply_writes_managed_shim_and_consumer_record()",
@@ -6017,7 +6121,7 @@
       "source_file": "scripts/overlord/test_deploy_governance_tooling.py",
       "source_location": "L82",
       "id": "test_deploy_governance_tooling_testdeploygovernancetooling_test_apply_writes_managed_shim_and_consumer_record",
-      "community": 27
+      "community": 28
     },
     {
       "label": ".test_verify_passes_after_apply()",
@@ -6025,7 +6129,7 @@
       "source_file": "scripts/overlord/test_deploy_governance_tooling.py",
       "source_location": "L99",
       "id": "test_deploy_governance_tooling_testdeploygovernancetooling_test_verify_passes_after_apply",
-      "community": 27
+      "community": 28
     },
     {
       "label": ".test_rollback_removes_managed_files()",
@@ -6033,7 +6137,7 @@
       "source_file": "scripts/overlord/test_deploy_governance_tooling.py",
       "source_location": "L110",
       "id": "test_deploy_governance_tooling_testdeploygovernancetooling_test_rollback_removes_managed_files",
-      "community": 27
+      "community": 28
     },
     {
       "label": ".test_apply_is_idempotent_for_managed_files()",
@@ -6041,7 +6145,7 @@
       "source_file": "scripts/overlord/test_deploy_governance_tooling.py",
       "source_location": "L122",
       "id": "test_deploy_governance_tooling_testdeploygovernancetooling_test_apply_is_idempotent_for_managed_files",
-      "community": 27
+      "community": 28
     },
     {
       "label": ".test_apply_refuses_unmanaged_shim_by_default()",
@@ -6049,7 +6153,7 @@
       "source_file": "scripts/overlord/test_deploy_governance_tooling.py",
       "source_location": "L133",
       "id": "test_deploy_governance_tooling_testdeploygovernancetooling_test_apply_refuses_unmanaged_shim_by_default",
-      "community": 27
+      "community": 28
     },
     {
       "label": ".test_apply_refuses_unmanaged_consumer_record_by_default()",
@@ -6057,7 +6161,7 @@
       "source_file": "scripts/overlord/test_deploy_governance_tooling.py",
       "source_location": "L144",
       "id": "test_deploy_governance_tooling_testdeploygovernancetooling_test_apply_refuses_unmanaged_consumer_record_by_default",
-      "community": 27
+      "community": 28
     },
     {
       "label": ".test_apply_refuses_dirty_target_by_default()",
@@ -6065,7 +6169,7 @@
       "source_file": "scripts/overlord/test_deploy_governance_tooling.py",
       "source_location": "L154",
       "id": "test_deploy_governance_tooling_testdeploygovernancetooling_test_apply_refuses_dirty_target_by_default",
-      "community": 27
+      "community": 28
     },
     {
       "label": ".test_verify_fails_when_record_is_missing()",
@@ -6073,7 +6177,7 @@
       "source_file": "scripts/overlord/test_deploy_governance_tooling.py",
       "source_location": "L165",
       "id": "test_deploy_governance_tooling_testdeploygovernancetooling_test_verify_fails_when_record_is_missing",
-      "community": 27
+      "community": 28
     },
     {
       "label": ".test_verify_fails_when_managed_shim_body_is_tampered()",
@@ -6081,7 +6185,7 @@
       "source_file": "scripts/overlord/test_deploy_governance_tooling.py",
       "source_location": "L174",
       "id": "test_deploy_governance_tooling_testdeploygovernancetooling_test_verify_fails_when_managed_shim_body_is_tampered",
-      "community": 27
+      "community": 28
     },
     {
       "label": ".test_rollback_refuses_unmanaged_record_before_removing_shim()",
@@ -6089,7 +6193,7 @@
       "source_file": "scripts/overlord/test_deploy_governance_tooling.py",
       "source_location": "L190",
       "id": "test_deploy_governance_tooling_testdeploygovernancetooling_test_rollback_refuses_unmanaged_record_before_removing_shim",
-      "community": 27
+      "community": 28
     },
     {
       "label": ".test_real_e2e_apply_verify_rollback_against_temp_git_repo()",
@@ -6097,7 +6201,7 @@
       "source_file": "scripts/overlord/test_deploy_governance_tooling.py",
       "source_location": "L203",
       "id": "test_deploy_governance_tooling_testdeploygovernancetooling_test_real_e2e_apply_verify_rollback_against_temp_git_repo",
-      "community": 27
+      "community": 28
     },
     {
       "label": "test_deploy_local_ci_gate.py",
@@ -6105,7 +6209,7 @@
       "source_file": "scripts/overlord/test_deploy_local_ci_gate.py",
       "source_location": "L1",
       "id": "test_deploy_local_ci_gate",
-      "community": 32
+      "community": 31
     },
     {
       "label": "TestDeployLocalCIGate",
@@ -6113,7 +6217,7 @@
       "source_file": "scripts/overlord/test_deploy_local_ci_gate.py",
       "source_location": "L26",
       "id": "test_deploy_local_ci_gate_testdeploylocalcigate",
-      "community": 32
+      "community": 31
     },
     {
       "label": ".setUp()",
@@ -6121,7 +6225,7 @@
       "source_file": "scripts/overlord/test_deploy_local_ci_gate.py",
       "source_location": "L27",
       "id": "test_deploy_local_ci_gate_testdeploylocalcigate_setup",
-      "community": 32
+      "community": 31
     },
     {
       "label": ".tearDown()",
@@ -6129,7 +6233,7 @@
       "source_file": "scripts/overlord/test_deploy_local_ci_gate.py",
       "source_location": "L36",
       "id": "test_deploy_local_ci_gate_testdeploylocalcigate_teardown",
-      "community": 32
+      "community": 31
     },
     {
       "label": "._invoke()",
@@ -6137,7 +6241,7 @@
       "source_file": "scripts/overlord/test_deploy_local_ci_gate.py",
       "source_location": "L39",
       "id": "test_deploy_local_ci_gate_testdeploylocalcigate_invoke",
-      "community": 32
+      "community": 31
     },
     {
       "label": "._shim()",
@@ -6145,7 +6249,7 @@
       "source_file": "scripts/overlord/test_deploy_local_ci_gate.py",
       "source_location": "L46",
       "id": "test_deploy_local_ci_gate_testdeploylocalcigate_shim",
-      "community": 32
+      "community": 31
     },
     {
       "label": "._write_fake_runner()",
@@ -6153,7 +6257,7 @@
       "source_file": "scripts/overlord/test_deploy_local_ci_gate.py",
       "source_location": "L49",
       "id": "test_deploy_local_ci_gate_testdeploylocalcigate_write_fake_runner",
-      "community": 32
+      "community": 31
     },
     {
       "label": ".test_resolve_reports_repo_local_target_and_write_set()",
@@ -6161,7 +6265,7 @@
       "source_file": "scripts/overlord/test_deploy_local_ci_gate.py",
       "source_location": "L57",
       "id": "test_deploy_local_ci_gate_testdeploylocalcigate_test_resolve_reports_repo_local_target_and_write_set",
-      "community": 32
+      "community": 31
     },
     {
       "label": ".test_dry_run_includes_managed_body_and_command_preview()",
@@ -6169,7 +6273,7 @@
       "source_file": "scripts/overlord/test_deploy_local_ci_gate.py",
       "source_location": "L81",
       "id": "test_deploy_local_ci_gate_testdeploylocalcigate_test_dry_run_includes_managed_body_and_command_preview",
-      "community": 32
+      "community": 31
     },
     {
       "label": ".test_install_refuses_unmanaged_existing_shim_without_override()",
@@ -6177,7 +6281,7 @@
       "source_file": "scripts/overlord/test_deploy_local_ci_gate.py",
       "source_location": "L109",
       "id": "test_deploy_local_ci_gate_testdeploylocalcigate_test_install_refuses_unmanaged_existing_shim_without_override",
-      "community": 32
+      "community": 31
     },
     {
       "label": ".test_install_with_backup_existing_renames_unmanaged_shim()",
@@ -6185,7 +6289,7 @@
       "source_file": "scripts/overlord/test_deploy_local_ci_gate.py",
       "source_location": "L127",
       "id": "test_deploy_local_ci_gate_testdeploylocalcigate_test_install_with_backup_existing_renames_unmanaged_shim",
-      "community": 32
+      "community": 31
     },
     {
       "label": ".test_installed_shim_uses_embedded_root_then_env_override()",
@@ -6193,7 +6297,7 @@
       "source_file": "scripts/overlord/test_deploy_local_ci_gate.py",
       "source_location": "L154",
       "id": "test_deploy_local_ci_gate_testdeploylocalcigate_test_installed_shim_uses_embedded_root_then_env_override",
-      "community": 32
+      "community": 31
     },
     {
       "label": ".test_installed_shim_remains_portable_when_copied_to_another_repo()",
@@ -6201,7 +6305,7 @@
       "source_file": "scripts/overlord/test_deploy_local_ci_gate.py",
       "source_location": "L186",
       "id": "test_deploy_local_ci_gate_testdeploylocalcigate_test_installed_shim_remains_portable_when_copied_to_another_repo",
-      "community": 32
+      "community": 31
     },
     {
       "label": ".test_installed_shim_propagates_runner_failure()",
@@ -6209,7 +6313,7 @@
       "source_file": "scripts/overlord/test_deploy_local_ci_gate.py",
       "source_location": "L215",
       "id": "test_deploy_local_ci_gate_testdeploylocalcigate_test_installed_shim_propagates_runner_failure",
-      "community": 32
+      "community": 31
     },
     {
       "label": ".test_installed_shim_propagates_real_runner_blocker_failure()",
@@ -6217,7 +6321,7 @@
       "source_file": "scripts/overlord/test_deploy_local_ci_gate.py",
       "source_location": "L231",
       "id": "test_deploy_local_ci_gate_testdeploylocalcigate_test_installed_shim_propagates_real_runner_blocker_failure",
-      "community": 32
+      "community": 31
     },
     {
       "label": ".test_refresh_updates_managed_shim_content()",
@@ -6225,7 +6329,7 @@
       "source_file": "scripts/overlord/test_deploy_local_ci_gate.py",
       "source_location": "L271",
       "id": "test_deploy_local_ci_gate_testdeploylocalcigate_test_refresh_updates_managed_shim_content",
-      "community": 32
+      "community": 31
     },
     {
       "label": ".test_rejects_shim_paths_outside_the_repo_local_allowlist()",
@@ -6233,7 +6337,103 @@
       "source_file": "scripts/overlord/test_deploy_local_ci_gate.py",
       "source_location": "L303",
       "id": "test_deploy_local_ci_gate_testdeploylocalcigate_test_rejects_shim_paths_outside_the_repo_local_allowlist",
-      "community": 32
+      "community": 31
+    },
+    {
+      "label": "test_lane_bootstrap.py",
+      "file_type": "code",
+      "source_file": "scripts/overlord/test_lane_bootstrap.py",
+      "source_location": "L1",
+      "id": "test_lane_bootstrap",
+      "community": 46
+    },
+    {
+      "label": "run_helper()",
+      "file_type": "code",
+      "source_file": "scripts/overlord/test_lane_bootstrap.py",
+      "source_location": "L14",
+      "id": "test_lane_bootstrap_run_helper",
+      "community": 46
+    },
+    {
+      "label": "TestLaneBootstrap",
+      "file_type": "code",
+      "source_file": "scripts/overlord/test_lane_bootstrap.py",
+      "source_location": "L24",
+      "id": "test_lane_bootstrap_testlanebootstrap",
+      "community": 46
+    },
+    {
+      "label": ".test_valid_healthcareplatform_lane_accepted()",
+      "file_type": "code",
+      "source_file": "scripts/overlord/test_lane_bootstrap.py",
+      "source_location": "L25",
+      "id": "test_lane_bootstrap_testlanebootstrap_test_valid_healthcareplatform_lane_accepted",
+      "community": 46
+    },
+    {
+      "label": ".test_invalid_healthcareplatform_branch_pattern_rejected()",
+      "file_type": "code",
+      "source_file": "scripts/overlord/test_lane_bootstrap.py",
+      "source_location": "L41",
+      "id": "test_lane_bootstrap_testlanebootstrap_test_invalid_healthcareplatform_branch_pattern_rejected",
+      "community": 46
+    },
+    {
+      "label": ".test_invalid_healthcareplatform_worktree_path_rejected()",
+      "file_type": "code",
+      "source_file": "scripts/overlord/test_lane_bootstrap.py",
+      "source_location": "L57",
+      "id": "test_lane_bootstrap_testlanebootstrap_test_invalid_healthcareplatform_worktree_path_rejected",
+      "community": 46
+    },
+    {
+      "label": ".test_branch_worktree_issue_mismatch_rejected()",
+      "file_type": "code",
+      "source_file": "scripts/overlord/test_lane_bootstrap.py",
+      "source_location": "L73",
+      "id": "test_lane_bootstrap_testlanebootstrap_test_branch_worktree_issue_mismatch_rejected",
+      "community": 46
+    },
+    {
+      "label": ".test_branch_worktree_scope_mismatch_rejected()",
+      "file_type": "code",
+      "source_file": "scripts/overlord/test_lane_bootstrap.py",
+      "source_location": "L89",
+      "id": "test_lane_bootstrap_testlanebootstrap_test_branch_worktree_scope_mismatch_rejected",
+      "community": 46
+    },
+    {
+      "label": ".test_standard_repo_lane_policy_accepted()",
+      "file_type": "code",
+      "source_file": "scripts/overlord/test_lane_bootstrap.py",
+      "source_location": "L105",
+      "id": "test_lane_bootstrap_testlanebootstrap_test_standard_repo_lane_policy_accepted",
+      "community": 46
+    },
+    {
+      "label": ".test_plan_generates_healthcareplatform_names()",
+      "file_type": "code",
+      "source_file": "scripts/overlord/test_lane_bootstrap.py",
+      "source_location": "L121",
+      "id": "test_lane_bootstrap_testlanebootstrap_test_plan_generates_healthcareplatform_names",
+      "community": 46
+    },
+    {
+      "label": ".test_dirty_invalid_lane_cleanup_refused()",
+      "file_type": "code",
+      "source_file": "scripts/overlord/test_lane_bootstrap.py",
+      "source_location": "L139",
+      "id": "test_lane_bootstrap_testlanebootstrap_test_dirty_invalid_lane_cleanup_refused",
+      "community": 46
+    },
+    {
+      "label": ".test_clean_invalid_lane_cleanup_documented()",
+      "file_type": "code",
+      "source_file": "scripts/overlord/test_lane_bootstrap.py",
+      "source_location": "L145",
+      "id": "test_lane_bootstrap_testlanebootstrap_test_clean_invalid_lane_cleanup_documented",
+      "community": 46
     },
     {
       "label": "test_local_ci_gate_workflow_contract.py",
@@ -6241,7 +6441,7 @@
       "source_file": "scripts/overlord/test_local_ci_gate_workflow_contract.py",
       "source_location": "L1",
       "id": "test_local_ci_gate_workflow_contract",
-      "community": 19
+      "community": 22
     },
     {
       "label": "TestLocalCiGateWorkflowContract",
@@ -6249,7 +6449,7 @@
       "source_file": "scripts/overlord/test_local_ci_gate_workflow_contract.py",
       "source_location": "L53",
       "id": "test_local_ci_gate_workflow_contract_testlocalcigateworkflowcontract",
-      "community": 19
+      "community": 22
     },
     {
       "label": ".test_repository_workflow_contract_passes()",
@@ -6257,7 +6457,7 @@
       "source_file": "scripts/overlord/test_local_ci_gate_workflow_contract.py",
       "source_location": "L54",
       "id": "test_local_ci_gate_workflow_contract_testlocalcigateworkflowcontract_test_repository_workflow_contract_passes",
-      "community": 19
+      "community": 22
     },
     {
       "label": ".test_rejects_dry_run_workflow()",
@@ -6265,7 +6465,7 @@
       "source_file": "scripts/overlord/test_local_ci_gate_workflow_contract.py",
       "source_location": "L59",
       "id": "test_local_ci_gate_workflow_contract_testlocalcigateworkflowcontract_test_rejects_dry_run_workflow",
-      "community": 19
+      "community": 22
     },
     {
       "label": ".test_rejects_shallow_checkout_without_full_history()",
@@ -6273,7 +6473,7 @@
       "source_file": "scripts/overlord/test_local_ci_gate_workflow_contract.py",
       "source_location": "L67",
       "id": "test_local_ci_gate_workflow_contract_testlocalcigateworkflowcontract_test_rejects_shallow_checkout_without_full_history",
-      "community": 19
+      "community": 22
     },
     {
       "label": ".test_rejects_later_shallow_checkout()",
@@ -6281,7 +6481,7 @@
       "source_file": "scripts/overlord/test_local_ci_gate_workflow_contract.py",
       "source_location": "L75",
       "id": "test_local_ci_gate_workflow_contract_testlocalcigateworkflowcontract_test_rejects_later_shallow_checkout",
-      "community": 19
+      "community": 22
     },
     {
       "label": ".test_requires_independent_contract_workflow()",
@@ -6289,7 +6489,7 @@
       "source_file": "scripts/overlord/test_local_ci_gate_workflow_contract.py",
       "source_location": "L85",
       "id": "test_local_ci_gate_workflow_contract_testlocalcigateworkflowcontract_test_requires_independent_contract_workflow",
-      "community": 19
+      "community": 22
     },
     {
       "label": ".test_ignores_dead_text_outside_workflow_steps()",
@@ -6297,7 +6497,7 @@
       "source_file": "scripts/overlord/test_local_ci_gate_workflow_contract.py",
       "source_location": "L93",
       "id": "test_local_ci_gate_workflow_contract_testlocalcigateworkflowcontract_test_ignores_dead_text_outside_workflow_steps",
-      "community": 19
+      "community": 22
     },
     {
       "label": ".test_rejects_missing_bytecode_suppression()",
@@ -6305,7 +6505,7 @@
       "source_file": "scripts/overlord/test_local_ci_gate_workflow_contract.py",
       "source_location": "L121",
       "id": "test_local_ci_gate_workflow_contract_testlocalcigateworkflowcontract_test_rejects_missing_bytecode_suppression",
-      "community": 19
+      "community": 22
     },
     {
       "label": ".test_requires_pr_branch_normalization()",
@@ -6313,7 +6513,7 @@
       "source_file": "scripts/overlord/test_local_ci_gate_workflow_contract.py",
       "source_location": "L129",
       "id": "test_local_ci_gate_workflow_contract_testlocalcigateworkflowcontract_test_requires_pr_branch_normalization",
-      "community": 19
+      "community": 22
     },
     {
       "label": ".test_requires_profile_on_actual_runner_command()",
@@ -6321,7 +6521,7 @@
       "source_file": "scripts/overlord/test_local_ci_gate_workflow_contract.py",
       "source_location": "L140",
       "id": "test_local_ci_gate_workflow_contract_testlocalcigateworkflowcontract_test_requires_profile_on_actual_runner_command",
-      "community": 19
+      "community": 22
     },
     {
       "label": ".test_rejects_echoed_runner_command()",
@@ -6329,7 +6529,7 @@
       "source_file": "scripts/overlord/test_local_ci_gate_workflow_contract.py",
       "source_location": "L150",
       "id": "test_local_ci_gate_workflow_contract_testlocalcigateworkflowcontract_test_rejects_echoed_runner_command",
-      "community": 19
+      "community": 22
     },
     {
       "label": ".test_rejects_echoed_fetch_command()",
@@ -6337,7 +6537,7 @@
       "source_file": "scripts/overlord/test_local_ci_gate_workflow_contract.py",
       "source_location": "L160",
       "id": "test_local_ci_gate_workflow_contract_testlocalcigateworkflowcontract_test_rejects_echoed_fetch_command",
-      "community": 19
+      "community": 22
     },
     {
       "label": ".test_main_returns_nonzero_for_missing_workflow()",
@@ -6345,7 +6545,7 @@
       "source_file": "scripts/overlord/test_local_ci_gate_workflow_contract.py",
       "source_location": "L170",
       "id": "test_local_ci_gate_workflow_contract_testlocalcigateworkflowcontract_test_main_returns_nonzero_for_missing_workflow",
-      "community": 19
+      "community": 22
     },
     {
       "label": "test_pentagi_sweep.py",
@@ -6353,7 +6553,7 @@
       "source_file": "scripts/overlord/test_pentagi_sweep.py",
       "source_location": "L1",
       "id": "test_pentagi_sweep",
-      "community": 43
+      "community": 42
     },
     {
       "label": "_registry()",
@@ -6361,7 +6561,7 @@
       "source_file": "scripts/overlord/test_pentagi_sweep.py",
       "source_location": "L10",
       "id": "test_pentagi_sweep_registry",
-      "community": 43
+      "community": 42
     },
     {
       "label": "_repo()",
@@ -6369,7 +6569,7 @@
       "source_file": "scripts/overlord/test_pentagi_sweep.py",
       "source_location": "L75",
       "id": "test_pentagi_sweep_repo",
-      "community": 43
+      "community": 42
     },
     {
       "label": "_track()",
@@ -6377,7 +6577,7 @@
       "source_file": "scripts/overlord/test_pentagi_sweep.py",
       "source_location": "L84",
       "id": "test_pentagi_sweep_track",
-      "community": 43
+      "community": 42
     },
     {
       "label": "_run()",
@@ -6385,7 +6585,7 @@
       "source_file": "scripts/overlord/test_pentagi_sweep.py",
       "source_location": "L88",
       "id": "test_pentagi_sweep_run",
-      "community": 43
+      "community": 42
     },
     {
       "label": "test_missing_report_skips_with_missing_token()",
@@ -6393,7 +6593,7 @@
       "source_file": "scripts/overlord/test_pentagi_sweep.py",
       "source_location": "L107",
       "id": "test_pentagi_sweep_test_missing_report_skips_with_missing_token",
-      "community": 43
+      "community": 42
     },
     {
       "label": "test_stale_report_skips_with_missing_token()",
@@ -6401,7 +6601,7 @@
       "source_file": "scripts/overlord/test_pentagi_sweep.py",
       "source_location": "L121",
       "id": "test_pentagi_sweep_test_stale_report_skips_with_missing_token",
-      "community": 43
+      "community": 42
     },
     {
       "label": "test_missing_runner_is_explicit_when_token_exists()",
@@ -6409,7 +6609,7 @@
       "source_file": "scripts/overlord/test_pentagi_sweep.py",
       "source_location": "L136",
       "id": "test_pentagi_sweep_test_missing_runner_is_explicit_when_token_exists",
-      "community": 43
+      "community": 42
     },
     {
       "label": "test_fresh_report_does_not_trigger()",
@@ -6417,7 +6617,7 @@
       "source_file": "scripts/overlord/test_pentagi_sweep.py",
       "source_location": "L147",
       "id": "test_pentagi_sweep_test_fresh_report_does_not_trigger",
-      "community": 43
+      "community": 42
     },
     {
       "label": "test_runner_would_run_without_execute()",
@@ -6425,7 +6625,7 @@
       "source_file": "scripts/overlord/test_pentagi_sweep.py",
       "source_location": "L161",
       "id": "test_pentagi_sweep_test_runner_would_run_without_execute",
-      "community": 43
+      "community": 42
     },
     {
       "label": "test_untracked_fresh_report_does_not_count_for_audited_ref()",
@@ -6433,7 +6633,7 @@
       "source_file": "scripts/overlord/test_pentagi_sweep.py",
       "source_location": "L175",
       "id": "test_pentagi_sweep_test_untracked_fresh_report_does_not_count_for_audited_ref",
-      "community": 43
+      "community": 42
     },
     {
       "label": "test_execute_runs_tracked_runner()",
@@ -6441,7 +6641,7 @@
       "source_file": "scripts/overlord/test_pentagi_sweep.py",
       "source_location": "L188",
       "id": "test_pentagi_sweep_test_execute_runs_tracked_runner",
-      "community": 43
+      "community": 42
     },
     {
       "label": "test_markdown_records_same_source_root_for_dashboard_consumers()",
@@ -6449,95 +6649,95 @@
       "source_file": "scripts/overlord/test_pentagi_sweep.py",
       "source_location": "L202",
       "id": "test_pentagi_sweep_test_markdown_records_same_source_root_for_dashboard_consumers",
-      "community": 43
+      "community": 42
     },
     {
       "label": "test_schema_guard_hook.py",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/hldpro-governance/var/worktrees/issue-463-stage6-closeout-439/scripts/overlord/test_schema_guard_hook.py",
+      "source_file": "scripts/overlord/test_schema_guard_hook.py",
       "source_location": "L1",
       "id": "test_schema_guard_hook",
-      "community": 52
+      "community": 53
     },
     {
       "label": "_payload()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/hldpro-governance/var/worktrees/issue-463-stage6-closeout-439/scripts/overlord/test_schema_guard_hook.py",
+      "source_file": "scripts/overlord/test_schema_guard_hook.py",
       "source_location": "L16",
       "id": "test_schema_guard_hook_payload",
-      "community": 52
+      "community": 53
     },
     {
       "label": "_run_hook()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/hldpro-governance/var/worktrees/issue-463-stage6-closeout-439/scripts/overlord/test_schema_guard_hook.py",
+      "source_file": "scripts/overlord/test_schema_guard_hook.py",
       "source_location": "L20",
       "id": "test_schema_guard_hook_run_hook",
-      "community": 52
+      "community": 53
     },
     {
       "label": "TestSchemaGuardHook",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/hldpro-governance/var/worktrees/issue-463-stage6-closeout-439/scripts/overlord/test_schema_guard_hook.py",
+      "source_file": "scripts/overlord/test_schema_guard_hook.py",
       "source_location": "L35",
       "id": "test_schema_guard_hook_testschemaguardhook",
-      "community": 52
+      "community": 53
     },
     {
       "label": ".test_blocked_bash_file_write_has_stderr()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/hldpro-governance/var/worktrees/issue-463-stage6-closeout-439/scripts/overlord/test_schema_guard_hook.py",
+      "source_file": "scripts/overlord/test_schema_guard_hook.py",
       "source_location": "L36",
       "id": "test_schema_guard_hook_testschemaguardhook_test_blocked_bash_file_write_has_stderr",
-      "community": 52
+      "community": 53
     },
     {
       "label": ".test_trivial_plan_bypass_still_reaches_som_write_block()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/hldpro-governance/var/worktrees/issue-463-stage6-closeout-439/scripts/overlord/test_schema_guard_hook.py",
+      "source_file": "scripts/overlord/test_schema_guard_hook.py",
       "source_location": "L46",
       "id": "test_schema_guard_hook_testschemaguardhook_test_trivial_plan_bypass_still_reaches_som_write_block",
-      "community": 52
+      "community": 53
     },
     {
       "label": ".test_missing_schema_has_explicit_stderr()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/hldpro-governance/var/worktrees/issue-463-stage6-closeout-439/scripts/overlord/test_schema_guard_hook.py",
+      "source_file": "scripts/overlord/test_schema_guard_hook.py",
       "source_location": "L57",
       "id": "test_schema_guard_hook_testschemaguardhook_test_missing_schema_has_explicit_stderr",
-      "community": 52
+      "community": 53
     },
     {
       "label": ".test_malformed_input_payload_has_stderr()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/hldpro-governance/var/worktrees/issue-463-stage6-closeout-439/scripts/overlord/test_schema_guard_hook.py",
+      "source_file": "scripts/overlord/test_schema_guard_hook.py",
       "source_location": "L66",
       "id": "test_schema_guard_hook_testschemaguardhook_test_malformed_input_payload_has_stderr",
-      "community": 52
+      "community": 53
     },
     {
       "label": ".test_validator_nonzero_is_summarized()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/hldpro-governance/var/worktrees/issue-463-stage6-closeout-439/scripts/overlord/test_schema_guard_hook.py",
+      "source_file": "scripts/overlord/test_schema_guard_hook.py",
       "source_location": "L72",
       "id": "test_schema_guard_hook_testschemaguardhook_test_validator_nonzero_is_summarized",
-      "community": 52
+      "community": 53
     },
     {
       "label": ".test_allowed_read_only_command_remains_allowed()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/hldpro-governance/var/worktrees/issue-463-stage6-closeout-439/scripts/overlord/test_schema_guard_hook.py",
+      "source_file": "scripts/overlord/test_schema_guard_hook.py",
       "source_location": "L88",
       "id": "test_schema_guard_hook_testschemaguardhook_test_allowed_read_only_command_remains_allowed",
-      "community": 52
+      "community": 53
     },
     {
       "label": ".test_python_file_write_policy_block_has_stderr()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/hldpro-governance/var/worktrees/issue-463-stage6-closeout-439/scripts/overlord/test_schema_guard_hook.py",
+      "source_file": "scripts/overlord/test_schema_guard_hook.py",
       "source_location": "L95",
       "id": "test_schema_guard_hook_testschemaguardhook_test_python_file_write_policy_block_has_stderr",
-      "community": 52
+      "community": 53
     },
     {
       "label": "test_validate_backlog_gh_sync.py",
@@ -6545,7 +6745,7 @@
       "source_file": "scripts/overlord/test_validate_backlog_gh_sync.py",
       "source_location": "L1",
       "id": "test_validate_backlog_gh_sync",
-      "community": 28
+      "community": 29
     },
     {
       "label": "TestValidateBacklogGhSync",
@@ -6553,7 +6753,7 @@
       "source_file": "scripts/overlord/test_validate_backlog_gh_sync.py",
       "source_location": "L10",
       "id": "test_validate_backlog_gh_sync_testvalidatebacklogghsync",
-      "community": 28
+      "community": 29
     },
     {
       "label": ".test_delegates_to_hardened_overlord_alignment_checker()",
@@ -6561,7 +6761,7 @@
       "source_file": "scripts/overlord/test_validate_backlog_gh_sync.py",
       "source_location": "L11",
       "id": "test_validate_backlog_gh_sync_testvalidatebacklogghsync_test_delegates_to_hardened_overlord_alignment_checker",
-      "community": 28
+      "community": 29
     },
     {
       "label": "test_validate_closeout.py",
@@ -6569,7 +6769,7 @@
       "source_file": "scripts/overlord/test_validate_closeout.py",
       "source_location": "L1",
       "id": "test_validate_closeout",
-      "community": 10
+      "community": 14
     },
     {
       "label": "_write()",
@@ -6577,7 +6777,7 @@
       "source_file": "scripts/overlord/test_validate_closeout.py",
       "source_location": "L11",
       "id": "test_validate_closeout_write",
-      "community": 10
+      "community": 14
     },
     {
       "label": "_json()",
@@ -6585,7 +6785,7 @@
       "source_file": "scripts/overlord/test_validate_closeout.py",
       "source_location": "L16",
       "id": "test_validate_closeout_json",
-      "community": 10
+      "community": 14
     },
     {
       "label": "TestValidateCloseout",
@@ -6593,7 +6793,7 @@
       "source_file": "scripts/overlord/test_validate_closeout.py",
       "source_location": "L20",
       "id": "test_validate_closeout_testvalidatecloseout",
-      "community": 10
+      "community": 14
     },
     {
       "label": "._repo()",
@@ -6601,7 +6801,7 @@
       "source_file": "scripts/overlord/test_validate_closeout.py",
       "source_location": "L21",
       "id": "test_validate_closeout_testvalidatecloseout_repo",
-      "community": 10
+      "community": 14
     },
     {
       "label": "._closeout()",
@@ -6609,7 +6809,7 @@
       "source_file": "scripts/overlord/test_validate_closeout.py",
       "source_location": "L69",
       "id": "test_validate_closeout_testvalidatecloseout_closeout",
-      "community": 10
+      "community": 14
     },
     {
       "label": ".test_valid_closeout_passes()",
@@ -6617,7 +6817,7 @@
       "source_file": "scripts/overlord/test_validate_closeout.py",
       "source_location": "L109",
       "id": "test_validate_closeout_testvalidatecloseout_test_valid_closeout_passes",
-      "community": 10
+      "community": 14
     },
     {
       "label": ".test_missing_referenced_artifact_fails()",
@@ -6625,7 +6825,7 @@
       "source_file": "scripts/overlord/test_validate_closeout.py",
       "source_location": "L115",
       "id": "test_validate_closeout_testvalidatecloseout_test_missing_referenced_artifact_fails",
-      "community": 10
+      "community": 14
     },
     {
       "label": ".test_residual_without_issue_ref_fails()",
@@ -6633,7 +6833,7 @@
       "source_file": "scripts/overlord/test_validate_closeout.py",
       "source_location": "L122",
       "id": "test_validate_closeout_testvalidatecloseout_test_residual_without_issue_ref_fails",
-      "community": 10
+      "community": 14
     },
     {
       "label": ".test_handoff_without_lifecycle_record_fails()",
@@ -6641,7 +6841,7 @@
       "source_file": "scripts/overlord/test_validate_closeout.py",
       "source_location": "L128",
       "id": "test_validate_closeout_testvalidatecloseout_test_handoff_without_lifecycle_record_fails",
-      "community": 10
+      "community": 14
     },
     {
       "label": ".test_placeholder_text_in_required_section_fails()",
@@ -6649,7 +6849,7 @@
       "source_file": "scripts/overlord/test_validate_closeout.py",
       "source_location": "L134",
       "id": "test_validate_closeout_testvalidatecloseout_test_placeholder_text_in_required_section_fails",
-      "community": 10
+      "community": 14
     },
     {
       "label": ".test_gate_evidence_requires_artifact_or_command_result()",
@@ -6657,7 +6857,7 @@
       "source_file": "scripts/overlord/test_validate_closeout.py",
       "source_location": "L143",
       "id": "test_validate_closeout_testvalidatecloseout_test_gate_evidence_requires_artifact_or_command_result",
-      "community": 10
+      "community": 14
     },
     {
       "label": ".test_hook_invokes_validator_before_graph_refresh()",
@@ -6665,7 +6865,7 @@
       "source_file": "scripts/overlord/test_validate_closeout.py",
       "source_location": "L152",
       "id": "test_validate_closeout_testvalidatecloseout_test_hook_invokes_validator_before_graph_refresh",
-      "community": 10
+      "community": 14
     },
     {
       "label": "test_validate_governed_repos.py",
@@ -6673,7 +6873,7 @@
       "source_file": "scripts/overlord/test_validate_governed_repos.py",
       "source_location": "L1",
       "id": "test_validate_governed_repos",
-      "community": 40
+      "community": 38
     },
     {
       "label": "GovernedReposValidationTests",
@@ -6681,7 +6881,7 @@
       "source_file": "scripts/overlord/test_validate_governed_repos.py",
       "source_location": "L65",
       "id": "test_validate_governed_repos_governedreposvalidationtests",
-      "community": 40
+      "community": 38
     },
     {
       "label": ".write_registry()",
@@ -6689,7 +6889,7 @@
       "source_file": "scripts/overlord/test_validate_governed_repos.py",
       "source_location": "L66",
       "id": "test_validate_governed_repos_governedreposvalidationtests_write_registry",
-      "community": 40
+      "community": 38
     },
     {
       "label": ".assert_invalid()",
@@ -6697,7 +6897,7 @@
       "source_file": "scripts/overlord/test_validate_governed_repos.py",
       "source_location": "L73",
       "id": "test_validate_governed_repos_governedreposvalidationtests_assert_invalid",
-      "community": 40
+      "community": 38
     },
     {
       "label": ".test_valid_registry_classification_passes()",
@@ -6705,7 +6905,7 @@
       "source_file": "scripts/overlord/test_validate_governed_repos.py",
       "source_location": "L77",
       "id": "test_validate_governed_repos_governedreposvalidationtests_test_valid_registry_classification_passes",
-      "community": 40
+      "community": 38
     },
     {
       "label": ".test_missing_classification_fails()",
@@ -6713,7 +6913,7 @@
       "source_file": "scripts/overlord/test_validate_governed_repos.py",
       "source_location": "L80",
       "id": "test_validate_governed_repos_governedreposvalidationtests_test_missing_classification_fails",
-      "community": 40
+      "community": 38
     },
     {
       "label": ".test_extra_repository_field_fails()",
@@ -6721,7 +6921,7 @@
       "source_file": "scripts/overlord/test_validate_governed_repos.py",
       "source_location": "L85",
       "id": "test_validate_governed_repos_governedreposvalidationtests_test_extra_repository_field_fails",
-      "community": 40
+      "community": 38
     },
     {
       "label": ".test_extra_classification_field_fails()",
@@ -6729,7 +6929,7 @@
       "source_file": "scripts/overlord/test_validate_governed_repos.py",
       "source_location": "L90",
       "id": "test_validate_governed_repos_governedreposvalidationtests_test_extra_classification_field_fails",
-      "community": 40
+      "community": 38
     },
     {
       "label": ".test_missing_root_field_fails()",
@@ -6737,7 +6937,7 @@
       "source_file": "scripts/overlord/test_validate_governed_repos.py",
       "source_location": "L95",
       "id": "test_validate_governed_repos_governedreposvalidationtests_test_missing_root_field_fails",
-      "community": 40
+      "community": 38
     },
     {
       "label": ".test_invalid_lifecycle_status_fails()",
@@ -6745,7 +6945,7 @@
       "source_file": "scripts/overlord/test_validate_governed_repos.py",
       "source_location": "L100",
       "id": "test_validate_governed_repos_governedreposvalidationtests_test_invalid_lifecycle_status_fails",
-      "community": 40
+      "community": 38
     },
     {
       "label": ".test_invalid_governance_status_fails()",
@@ -6753,7 +6953,7 @@
       "source_file": "scripts/overlord/test_validate_governed_repos.py",
       "source_location": "L105",
       "id": "test_validate_governed_repos_governedreposvalidationtests_test_invalid_governance_status_fails",
-      "community": 40
+      "community": 38
     },
     {
       "label": ".test_empty_issue_refs_fails()",
@@ -6761,7 +6961,7 @@
       "source_file": "scripts/overlord/test_validate_governed_repos.py",
       "source_location": "L110",
       "id": "test_validate_governed_repos_governedreposvalidationtests_test_empty_issue_refs_fails",
-      "community": 40
+      "community": 38
     },
     {
       "label": ".test_bad_review_date_fails()",
@@ -6769,7 +6969,7 @@
       "source_file": "scripts/overlord/test_validate_governed_repos.py",
       "source_location": "L115",
       "id": "test_validate_governed_repos_governedreposvalidationtests_test_bad_review_date_fails",
-      "community": 40
+      "community": 38
     },
     {
       "label": ".test_non_boolean_subsystem_value_fails()",
@@ -6777,7 +6977,7 @@
       "source_file": "scripts/overlord/test_validate_governed_repos.py",
       "source_location": "L120",
       "id": "test_validate_governed_repos_governedreposvalidationtests_test_non_boolean_subsystem_value_fails",
-      "community": 40
+      "community": 38
     },
     {
       "label": "test_validate_handoff_package.py",
@@ -6929,7 +7129,7 @@
       "source_file": "scripts/overlord/test_validate_structured_agent_cycle_plan.py",
       "source_location": "L1",
       "id": "test_validate_structured_agent_cycle_plan",
-      "community": 20
+      "community": 23
     },
     {
       "label": "_plan()",
@@ -6937,7 +7137,7 @@
       "source_file": "scripts/overlord/test_validate_structured_agent_cycle_plan.py",
       "source_location": "L15",
       "id": "test_validate_structured_agent_cycle_plan_plan",
-      "community": 20
+      "community": 23
     },
     {
       "label": "TestGovernanceSurfacePlanGate",
@@ -6945,7 +7145,7 @@
       "source_file": "scripts/overlord/test_validate_structured_agent_cycle_plan.py",
       "source_location": "L72",
       "id": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate",
-      "community": 20
+      "community": 23
     },
     {
       "label": "._run()",
@@ -6953,7 +7153,7 @@
       "source_file": "scripts/overlord/test_validate_structured_agent_cycle_plan.py",
       "source_location": "L73",
       "id": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate_run",
-      "community": 20
+      "community": 23
     },
     {
       "label": "._run_with_scope_gate()",
@@ -6961,7 +7161,7 @@
       "source_file": "scripts/overlord/test_validate_structured_agent_cycle_plan.py",
       "source_location": "L93",
       "id": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate_run_with_scope_gate",
-      "community": 20
+      "community": 23
     },
     {
       "label": "._write_scope()",
@@ -6969,7 +7169,7 @@
       "source_file": "scripts/overlord/test_validate_structured_agent_cycle_plan.py",
       "source_location": "L114",
       "id": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate_write_scope",
-      "community": 20
+      "community": 23
     },
     {
       "label": ".test_non_issue_branch_with_governance_surface_change_fails()",
@@ -6977,7 +7177,7 @@
       "source_file": "scripts/overlord/test_validate_structured_agent_cycle_plan.py",
       "source_location": "L130",
       "id": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate_test_non_issue_branch_with_governance_surface_change_fails",
-      "community": 20
+      "community": 23
     },
     {
       "label": ".test_non_issue_branch_does_not_validate_unmatched_plans_for_readiness()",
@@ -6985,7 +7185,7 @@
       "source_file": "scripts/overlord/test_validate_structured_agent_cycle_plan.py",
       "source_location": "L136",
       "id": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate_test_non_issue_branch_does_not_validate_unmatched_plans_for_readiness",
-      "community": 20
+      "community": 23
     },
     {
       "label": ".test_github_scripts_are_governance_surface()",
@@ -6993,7 +7193,7 @@
       "source_file": "scripts/overlord/test_validate_structured_agent_cycle_plan.py",
       "source_location": "L147",
       "id": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate_test_github_scripts_are_governance_surface",
-      "community": 20
+      "community": 23
     },
     {
       "label": ".test_github_workflows_with_leading_dot_are_governance_surface()",
@@ -7001,7 +7201,7 @@
       "source_file": "scripts/overlord/test_validate_structured_agent_cycle_plan.py",
       "source_location": "L153",
       "id": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate_test_github_workflows_with_leading_dot_are_governance_surface",
-      "community": 20
+      "community": 23
     },
     {
       "label": ".test_launchd_and_orchestrator_paths_are_governance_surface()",
@@ -7009,7 +7209,7 @@
       "source_file": "scripts/overlord/test_validate_structured_agent_cycle_plan.py",
       "source_location": "L159",
       "id": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate_test_launchd_and_orchestrator_paths_are_governance_surface",
-      "community": 20
+      "community": 23
     },
     {
       "label": ".test_lam_runtime_paths_are_governance_surface()",
@@ -7017,7 +7217,7 @@
       "source_file": "scripts/overlord/test_validate_structured_agent_cycle_plan.py",
       "source_location": "L166",
       "id": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate_test_lam_runtime_paths_are_governance_surface",
-      "community": 20
+      "community": 23
     },
     {
       "label": ".test_packet_paths_are_governance_surface()",
@@ -7025,7 +7225,7 @@
       "source_file": "scripts/overlord/test_validate_structured_agent_cycle_plan.py",
       "source_location": "L172",
       "id": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate_test_packet_paths_are_governance_surface",
-      "community": 20
+      "community": 23
     },
     {
       "label": ".test_self_learning_paths_are_governance_surface()",
@@ -7033,7 +7233,7 @@
       "source_file": "scripts/overlord/test_validate_structured_agent_cycle_plan.py",
       "source_location": "L188",
       "id": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate_test_self_learning_paths_are_governance_surface",
-      "community": 20
+      "community": 23
     },
     {
       "label": ".test_pilot_gate_and_metrics_paths_are_governance_surface()",
@@ -7041,7 +7241,7 @@
       "source_file": "scripts/overlord/test_validate_structured_agent_cycle_plan.py",
       "source_location": "L202",
       "id": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate_test_pilot_gate_and_metrics_paths_are_governance_surface",
-      "community": 20
+      "community": 23
     },
     {
       "label": ".test_riskfix_branch_without_issue_number_gets_specific_issue_hint()",
@@ -7049,7 +7249,7 @@
       "source_file": "scripts/overlord/test_validate_structured_agent_cycle_plan.py",
       "source_location": "L216",
       "id": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate_test_riskfix_branch_without_issue_number_gets_specific_issue_hint",
-      "community": 20
+      "community": 23
     },
     {
       "label": ".test_non_governance_surface_change_without_plan_passes()",
@@ -7057,7 +7257,7 @@
       "source_file": "scripts/overlord/test_validate_structured_agent_cycle_plan.py",
       "source_location": "L222",
       "id": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate_test_non_governance_surface_change_without_plan_passes",
-      "community": 20
+      "community": 23
     },
     {
       "label": ".test_issue_branch_requires_matching_plan()",
@@ -7065,7 +7265,7 @@
       "source_file": "scripts/overlord/test_validate_structured_agent_cycle_plan.py",
       "source_location": "L227",
       "id": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate_test_issue_branch_requires_matching_plan",
-      "community": 20
+      "community": 23
     },
     {
       "label": ".test_issue_branch_matching_approved_plan_passes()",
@@ -7073,7 +7273,7 @@
       "source_file": "scripts/overlord/test_validate_structured_agent_cycle_plan.py",
       "source_location": "L233",
       "id": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate_test_issue_branch_matching_approved_plan_passes",
-      "community": 20
+      "community": 23
     },
     {
       "label": ".test_planner_boundary_scope_gate_requires_issue_specific_scope()",
@@ -7081,7 +7281,7 @@
       "source_file": "scripts/overlord/test_validate_structured_agent_cycle_plan.py",
       "source_location": "L242",
       "id": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate_test_planner_boundary_scope_gate_requires_issue_specific_scope",
-      "community": 20
+      "community": 23
     },
     {
       "label": ".test_planner_boundary_scope_gate_accepts_matching_scope()",
@@ -7089,7 +7289,7 @@
       "source_file": "scripts/overlord/test_validate_structured_agent_cycle_plan.py",
       "source_location": "L260",
       "id": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate_test_planner_boundary_scope_gate_accepts_matching_scope",
-      "community": 20
+      "community": 23
     },
     {
       "label": ".test_matching_plan_must_be_implementation_ready()",
@@ -7097,7 +7297,7 @@
       "source_file": "scripts/overlord/test_validate_structured_agent_cycle_plan.py",
       "source_location": "L278",
       "id": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate_test_matching_plan_must_be_implementation_ready",
-      "community": 20
+      "community": 23
     },
     {
       "label": ".test_required_alternate_review_must_be_accepted()",
@@ -7105,7 +7305,7 @@
       "source_file": "scripts/overlord/test_validate_structured_agent_cycle_plan.py",
       "source_location": "L288",
       "id": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate_test_required_alternate_review_must_be_accepted",
-      "community": 20
+      "community": 23
     },
     {
       "label": ".test_malformed_json_reports_structured_fail_without_traceback()",
@@ -7113,7 +7313,7 @@
       "source_file": "scripts/overlord/test_validate_structured_agent_cycle_plan.py",
       "source_location": "L298",
       "id": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate_test_malformed_json_reports_structured_fail_without_traceback",
-      "community": 20
+      "community": 23
     },
     {
       "label": ".test_malformed_matching_plan_does_not_crash_governance_surface_gate()",
@@ -7121,7 +7321,7 @@
       "source_file": "scripts/overlord/test_validate_structured_agent_cycle_plan.py",
       "source_location": "L314",
       "id": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate_test_malformed_matching_plan_does_not_crash_governance_surface_gate",
-      "community": 20
+      "community": 23
     },
     {
       "label": ".test_plan_read_error_reports_structured_fail_without_traceback()",
@@ -7129,7 +7329,7 @@
       "source_file": "scripts/overlord/test_validate_structured_agent_cycle_plan.py",
       "source_location": "L327",
       "id": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate_test_plan_read_error_reports_structured_fail_without_traceback",
-      "community": 20
+      "community": 23
     },
     {
       "label": "test_verify_governance_consumer.py",
@@ -7137,119 +7337,327 @@
       "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L1",
       "id": "test_verify_governance_consumer",
-      "community": 39
+      "community": 8
     },
     {
       "label": "TestVerifyGovernanceConsumer",
       "file_type": "code",
       "source_file": "scripts/overlord/test_verify_governance_consumer.py",
-      "source_location": "L35",
+      "source_location": "L36",
       "id": "test_verify_governance_consumer_testverifygovernanceconsumer",
-      "community": 39
+      "community": 8
     },
     {
       "label": ".setUp()",
       "file_type": "code",
       "source_file": "scripts/overlord/test_verify_governance_consumer.py",
-      "source_location": "L36",
+      "source_location": "L37",
       "id": "test_verify_governance_consumer_testverifygovernanceconsumer_setup",
-      "community": 39
+      "community": 8
     },
     {
       "label": ".tearDown()",
       "file_type": "code",
       "source_file": "scripts/overlord/test_verify_governance_consumer.py",
-      "source_location": "L49",
+      "source_location": "L50",
       "id": "test_verify_governance_consumer_testverifygovernanceconsumer_teardown",
-      "community": 39
+      "community": 8
     },
     {
       "label": "._deploy()",
       "file_type": "code",
       "source_file": "scripts/overlord/test_verify_governance_consumer.py",
-      "source_location": "L52",
+      "source_location": "L53",
       "id": "test_verify_governance_consumer_testverifygovernanceconsumer_deploy",
-      "community": 39
+      "community": 8
     },
     {
       "label": "._invoke()",
       "file_type": "code",
       "source_file": "scripts/overlord/test_verify_governance_consumer.py",
-      "source_location": "L68",
+      "source_location": "L71",
       "id": "test_verify_governance_consumer_testverifygovernanceconsumer_invoke",
-      "community": 39
+      "community": 8
     },
     {
       "label": "._base_args()",
       "file_type": "code",
       "source_file": "scripts/overlord/test_verify_governance_consumer.py",
-      "source_location": "L75",
+      "source_location": "L78",
       "id": "test_verify_governance_consumer_testverifygovernanceconsumer_base_args",
-      "community": 39
+      "community": 8
     },
     {
       "label": "._record()",
       "file_type": "code",
       "source_file": "scripts/overlord/test_verify_governance_consumer.py",
-      "source_location": "L87",
+      "source_location": "L90",
       "id": "test_verify_governance_consumer_testverifygovernanceconsumer_record",
-      "community": 39
+      "community": 8
     },
     {
       "label": "._shim()",
       "file_type": "code",
       "source_file": "scripts/overlord/test_verify_governance_consumer.py",
-      "source_location": "L90",
+      "source_location": "L93",
       "id": "test_verify_governance_consumer_testverifygovernanceconsumer_shim",
-      "community": 39
+      "community": 8
+    },
+    {
+      "label": "._read_record()",
+      "file_type": "code",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
+      "source_location": "L96",
+      "id": "test_verify_governance_consumer_testverifygovernanceconsumer_read_record",
+      "community": 8
+    },
+    {
+      "label": "._write_record()",
+      "file_type": "code",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
+      "source_location": "L99",
+      "id": "test_verify_governance_consumer_testverifygovernanceconsumer_write_record",
+      "community": 8
+    },
+    {
+      "label": "._valid_override()",
+      "file_type": "code",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
+      "source_location": "L102",
+      "id": "test_verify_governance_consumer_testverifygovernanceconsumer_valid_override",
+      "community": 8
+    },
+    {
+      "label": "._next_package_version()",
+      "file_type": "code",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
+      "source_location": "L110",
+      "id": "test_verify_governance_consumer_testverifygovernanceconsumer_next_package_version",
+      "community": 8
+    },
+    {
+      "label": "._required_constraints()",
+      "file_type": "code",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
+      "source_location": "L114",
+      "id": "test_verify_governance_consumer_testverifygovernanceconsumer_required_constraints",
+      "community": 8
     },
     {
       "label": ".test_verify_passes_for_deployed_pinned_consumer_record()",
       "file_type": "code",
       "source_file": "scripts/overlord/test_verify_governance_consumer.py",
-      "source_location": "L93",
+      "source_location": "L118",
       "id": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_passes_for_deployed_pinned_consumer_record",
-      "community": 39
+      "community": 8
     },
     {
       "label": ".test_verify_fails_when_record_missing()",
       "file_type": "code",
       "source_file": "scripts/overlord/test_verify_governance_consumer.py",
-      "source_location": "L104",
+      "source_location": "L130",
       "id": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_when_record_missing",
-      "community": 39
+      "community": 8
+    },
+    {
+      "label": ".test_verify_fails_when_record_is_malformed_shape()",
+      "file_type": "code",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
+      "source_location": "L137",
+      "id": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_when_record_is_malformed_shape",
+      "community": 8
     },
     {
       "label": ".test_verify_fails_when_governance_ref_is_not_sha()",
       "file_type": "code",
       "source_file": "scripts/overlord/test_verify_governance_consumer.py",
-      "source_location": "L111",
+      "source_location": "L148",
       "id": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_when_governance_ref_is_not_sha",
-      "community": 39
+      "community": 8
     },
     {
       "label": ".test_verify_fails_when_shim_missing_marker()",
       "file_type": "code",
       "source_file": "scripts/overlord/test_verify_governance_consumer.py",
-      "source_location": "L128",
+      "source_location": "L165",
       "id": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_when_shim_missing_marker",
-      "community": 39
+      "community": 8
     },
     {
       "label": ".test_verify_fails_when_expected_profile_mismatches()",
       "file_type": "code",
       "source_file": "scripts/overlord/test_verify_governance_consumer.py",
-      "source_location": "L138",
+      "source_location": "L175",
       "id": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_when_expected_profile_mismatches",
-      "community": 39
+      "community": 8
     },
     {
       "label": ".test_verify_fails_when_managed_file_record_omits_expected_path()",
       "file_type": "code",
       "source_file": "scripts/overlord/test_verify_governance_consumer.py",
-      "source_location": "L154",
+      "source_location": "L191",
       "id": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_when_managed_file_record_omits_expected_path",
-      "community": 39
+      "community": 8
+    },
+    {
+      "label": ".test_verify_fails_when_profile_is_unknown()",
+      "file_type": "code",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
+      "source_location": "L203",
+      "id": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_when_profile_is_unknown",
+      "community": 8
+    },
+    {
+      "label": ".test_verify_fails_when_profile_is_missing()",
+      "file_type": "code",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
+      "source_location": "L220",
+      "id": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_when_profile_is_missing",
+      "community": 8
+    },
+    {
+      "label": ".test_verify_fails_for_mutable_governance_workflow_ref()",
+      "file_type": "code",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
+      "source_location": "L233",
+      "id": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_for_mutable_governance_workflow_ref",
+      "community": 8
+    },
+    {
+      "label": ".test_verify_fails_workflow_ref_is_tag()",
+      "file_type": "code",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
+      "source_location": "L248",
+      "id": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_workflow_ref_is_tag",
+      "community": 8
+    },
+    {
+      "label": ".test_verify_fails_workflow_ref_is_short_sha()",
+      "file_type": "code",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
+      "source_location": "L265",
+      "id": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_workflow_ref_is_short_sha",
+      "community": 8
+    },
+    {
+      "label": ".test_verify_fails_workflow_ref_sha_mismatch()",
+      "file_type": "code",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
+      "source_location": "L282",
+      "id": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_workflow_ref_sha_mismatch",
+      "community": 8
+    },
+    {
+      "label": ".test_verify_fails_for_managed_hook_checksum_drift()",
+      "file_type": "code",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
+      "source_location": "L300",
+      "id": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_for_managed_hook_checksum_drift",
+      "community": 8
+    },
+    {
+      "label": ".test_verify_fails_for_managed_hook_missing_marker()",
+      "file_type": "code",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
+      "source_location": "L321",
+      "id": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_for_managed_hook_missing_marker",
+      "community": 8
+    },
+    {
+      "label": ".test_verify_fails_for_invalid_override_metadata_and_reports_observed_override()",
+      "file_type": "code",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
+      "source_location": "L336",
+      "id": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_for_invalid_override_metadata_and_reports_observed_override",
+      "community": 8
+    },
+    {
+      "label": ".test_verify_fails_override_empty_owner()",
+      "file_type": "code",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
+      "source_location": "L350",
+      "id": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_override_empty_owner",
+      "community": 8
+    },
+    {
+      "label": ".test_verify_fails_override_non_string_reason()",
+      "file_type": "code",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
+      "source_location": "L365",
+      "id": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_override_non_string_reason",
+      "community": 8
+    },
+    {
+      "label": ".test_verify_fails_override_empty_expires_at()",
+      "file_type": "code",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
+      "source_location": "L380",
+      "id": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_override_empty_expires_at",
+      "community": 8
+    },
+    {
+      "label": ".test_verify_fails_override_weakens_healthcareplatform_hipaa()",
+      "file_type": "code",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
+      "source_location": "L399",
+      "id": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_override_weakens_healthcareplatform_hipaa",
+      "community": 8
+    },
+    {
+      "label": ".test_verify_fails_override_disables_seek_plan_mode()",
+      "file_type": "code",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
+      "source_location": "L413",
+      "id": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_override_disables_seek_plan_mode",
+      "community": 8
+    },
+    {
+      "label": ".test_verify_fails_override_routes_pii_away_from_lam()",
+      "file_type": "code",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
+      "source_location": "L427",
+      "id": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_override_routes_pii_away_from_lam",
+      "community": 8
+    },
+    {
+      "label": ".test_verify_fails_override_core_fork_without_exception()",
+      "file_type": "code",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
+      "source_location": "L441",
+      "id": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_override_core_fork_without_exception",
+      "community": 8
+    },
+    {
+      "label": ".test_verify_fails_override_disables_ci_required_gate()",
+      "file_type": "code",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
+      "source_location": "L455",
+      "id": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_override_disables_ci_required_gate",
+      "community": 8
+    },
+    {
+      "label": ".test_verify_fails_override_dry_run_as_live_evidence()",
+      "file_type": "code",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
+      "source_location": "L469",
+      "id": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_override_dry_run_as_live_evidence",
+      "community": 8
+    },
+    {
+      "label": ".test_verify_fails_when_healthcareplatform_v2_profile_weakens_constraints()",
+      "file_type": "code",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
+      "source_location": "L483",
+      "id": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_when_healthcareplatform_v2_profile_weakens_constraints",
+      "community": 8
+    },
+    {
+      "label": ".test_verify_passes_for_valid_v2_managed_consumer()",
+      "file_type": "code",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
+      "source_location": "L509",
+      "id": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_passes_for_valid_v2_managed_consumer",
+      "community": 8
     },
     {
       "label": "test_workflow_local_coverage.py",
@@ -7257,7 +7665,7 @@
       "source_file": "scripts/overlord/test_workflow_local_coverage.py",
       "source_location": "L1",
       "id": "test_workflow_local_coverage",
-      "community": 25
+      "community": 27
     },
     {
       "label": "_write()",
@@ -7265,7 +7673,7 @@
       "source_file": "scripts/overlord/test_workflow_local_coverage.py",
       "source_location": "L12",
       "id": "test_workflow_local_coverage_write",
-      "community": 25
+      "community": 27
     },
     {
       "label": "_inventory()",
@@ -7273,7 +7681,7 @@
       "source_file": "scripts/overlord/test_workflow_local_coverage.py",
       "source_location": "L17",
       "id": "test_workflow_local_coverage_inventory",
-      "community": 25
+      "community": 27
     },
     {
       "label": "_entry()",
@@ -7281,7 +7689,7 @@
       "source_file": "scripts/overlord/test_workflow_local_coverage.py",
       "source_location": "L27",
       "id": "test_workflow_local_coverage_entry",
-      "community": 25
+      "community": 27
     },
     {
       "label": "TestWorkflowLocalCoverage",
@@ -7289,7 +7697,7 @@
       "source_file": "scripts/overlord/test_workflow_local_coverage.py",
       "source_location": "L39",
       "id": "test_workflow_local_coverage_testworkflowlocalcoverage",
-      "community": 25
+      "community": 27
     },
     {
       "label": ".test_repository_inventory_passes()",
@@ -7297,7 +7705,7 @@
       "source_file": "scripts/overlord/test_workflow_local_coverage.py",
       "source_location": "L40",
       "id": "test_workflow_local_coverage_testworkflowlocalcoverage_test_repository_inventory_passes",
-      "community": 25
+      "community": 27
     },
     {
       "label": ".test_rejects_workflow_missing_from_inventory()",
@@ -7305,7 +7713,7 @@
       "source_file": "scripts/overlord/test_workflow_local_coverage.py",
       "source_location": "L45",
       "id": "test_workflow_local_coverage_testworkflowlocalcoverage_test_rejects_workflow_missing_from_inventory",
-      "community": 25
+      "community": 27
     },
     {
       "label": ".test_rejects_inventory_entry_without_workflow_file()",
@@ -7313,7 +7721,7 @@
       "source_file": "scripts/overlord/test_workflow_local_coverage.py",
       "source_location": "L60",
       "id": "test_workflow_local_coverage_testworkflowlocalcoverage_test_rejects_inventory_entry_without_workflow_file",
-      "community": 25
+      "community": 27
     },
     {
       "label": ".test_rejects_deterministic_workflow_without_local_first_coverage()",
@@ -7321,7 +7729,7 @@
       "source_file": "scripts/overlord/test_workflow_local_coverage.py",
       "source_location": "L72",
       "id": "test_workflow_local_coverage_testworkflowlocalcoverage_test_rejects_deterministic_workflow_without_local_first_coverage",
-      "community": 25
+      "community": 27
     },
     {
       "label": ".test_rejects_missing_command_path()",
@@ -7329,7 +7737,7 @@
       "source_file": "scripts/overlord/test_workflow_local_coverage.py",
       "source_location": "L90",
       "id": "test_workflow_local_coverage_testworkflowlocalcoverage_test_rejects_missing_command_path",
-      "community": 25
+      "community": 27
     },
     {
       "label": ".test_rejects_missing_required_snippet()",
@@ -7337,7 +7745,7 @@
       "source_file": "scripts/overlord/test_workflow_local_coverage.py",
       "source_location": "L108",
       "id": "test_workflow_local_coverage_testworkflowlocalcoverage_test_rejects_missing_required_snippet",
-      "community": 25
+      "community": 27
     },
     {
       "label": ".test_accepts_github_only_with_rationale()",
@@ -7345,7 +7753,7 @@
       "source_file": "scripts/overlord/test_workflow_local_coverage.py",
       "source_location": "L123",
       "id": "test_workflow_local_coverage_testworkflowlocalcoverage_test_accepts_github_only_with_rationale",
-      "community": 25
+      "community": 27
     },
     {
       "label": "validate_backlog_gh_sync.py",
@@ -7353,7 +7761,7 @@
       "source_file": "scripts/overlord/validate_backlog_gh_sync.py",
       "source_location": "L1",
       "id": "validate_backlog_gh_sync",
-      "community": 28
+      "community": 29
     },
     {
       "label": "main()",
@@ -7361,7 +7769,7 @@
       "source_file": "scripts/overlord/validate_backlog_gh_sync.py",
       "source_location": "L13",
       "id": "validate_backlog_gh_sync_main",
-      "community": 28
+      "community": 29
     },
     {
       "label": "validate_closeout.py",
@@ -7369,7 +7777,7 @@
       "source_file": "scripts/overlord/validate_closeout.py",
       "source_location": "L1",
       "id": "validate_closeout",
-      "community": 10
+      "community": 14
     },
     {
       "label": "_repo_rel()",
@@ -7377,7 +7785,7 @@
       "source_file": "scripts/overlord/validate_closeout.py",
       "source_location": "L44",
       "id": "validate_closeout_repo_rel",
-      "community": 10
+      "community": 14
     },
     {
       "label": "_sections()",
@@ -7385,7 +7793,7 @@
       "source_file": "scripts/overlord/validate_closeout.py",
       "source_location": "L51",
       "id": "validate_closeout_sections",
-      "community": 10
+      "community": 14
     },
     {
       "label": "_extract_repo_refs()",
@@ -7393,7 +7801,7 @@
       "source_file": "scripts/overlord/validate_closeout.py",
       "source_location": "L64",
       "id": "validate_closeout_extract_repo_refs",
-      "community": 10
+      "community": 14
     },
     {
       "label": "_load_json()",
@@ -7401,7 +7809,7 @@
       "source_file": "scripts/overlord/validate_closeout.py",
       "source_location": "L75",
       "id": "validate_closeout_load_json",
-      "community": 10
+      "community": 14
     },
     {
       "label": "_validate_residuals()",
@@ -7409,7 +7817,7 @@
       "source_file": "scripts/overlord/validate_closeout.py",
       "source_location": "L83",
       "id": "validate_closeout_validate_residuals",
-      "community": 10
+      "community": 14
     },
     {
       "label": "_validate_refs()",
@@ -7417,7 +7825,7 @@
       "source_file": "scripts/overlord/validate_closeout.py",
       "source_location": "L98",
       "id": "validate_closeout_validate_refs",
-      "community": 10
+      "community": 14
     },
     {
       "label": "_validate_handoff_refs()",
@@ -7425,7 +7833,7 @@
       "source_file": "scripts/overlord/validate_closeout.py",
       "source_location": "L125",
       "id": "validate_closeout_validate_handoff_refs",
-      "community": 10
+      "community": 14
     },
     {
       "label": "validate_closeout()",
@@ -7433,7 +7841,7 @@
       "source_file": "scripts/overlord/validate_closeout.py",
       "source_location": "L154",
       "id": "validate_closeout_validate_closeout",
-      "community": 10
+      "community": 14
     },
     {
       "label": "build_parser()",
@@ -7441,7 +7849,7 @@
       "source_file": "scripts/overlord/validate_closeout.py",
       "source_location": "L177",
       "id": "validate_closeout_build_parser",
-      "community": 10
+      "community": 14
     },
     {
       "label": "main()",
@@ -7449,7 +7857,7 @@
       "source_file": "scripts/overlord/validate_closeout.py",
       "source_location": "L184",
       "id": "validate_closeout_main",
-      "community": 10
+      "community": 14
     },
     {
       "label": "validate_governed_repos.py",
@@ -7513,7 +7921,7 @@
       "source_file": "scripts/overlord/validate_handoff_package.py",
       "source_location": "L1",
       "id": "validate_handoff_package",
-      "community": 10
+      "community": 14
     },
     {
       "label": "_is_url()",
@@ -7521,7 +7929,7 @@
       "source_file": "scripts/overlord/validate_handoff_package.py",
       "source_location": "L64",
       "id": "validate_handoff_package_is_url",
-      "community": 10
+      "community": 14
     },
     {
       "label": "_normalize_repo_path()",
@@ -7529,7 +7937,7 @@
       "source_file": "scripts/overlord/validate_handoff_package.py",
       "source_location": "L68",
       "id": "validate_handoff_package_normalize_repo_path",
-      "community": 10
+      "community": 14
     },
     {
       "label": "_repo_file_exists()",
@@ -7537,7 +7945,7 @@
       "source_file": "scripts/overlord/validate_handoff_package.py",
       "source_location": "L80",
       "id": "validate_handoff_package_repo_file_exists",
-      "community": 10
+      "community": 14
     },
     {
       "label": "_load_json()",
@@ -7545,7 +7953,7 @@
       "source_file": "scripts/overlord/validate_handoff_package.py",
       "source_location": "L86",
       "id": "validate_handoff_package_load_json",
-      "community": 10
+      "community": 14
     },
     {
       "label": "_read_json_ref()",
@@ -7553,7 +7961,7 @@
       "source_file": "scripts/overlord/validate_handoff_package.py",
       "source_location": "L90",
       "id": "validate_handoff_package_read_json_ref",
-      "community": 10
+      "community": 14
     },
     {
       "label": "_validate_ref_array()",
@@ -7561,7 +7969,7 @@
       "source_file": "scripts/overlord/validate_handoff_package.py",
       "source_location": "L105",
       "id": "validate_handoff_package_validate_ref_array",
-      "community": 10
+      "community": 14
     },
     {
       "label": "_validate_acceptance_criteria()",
@@ -7569,7 +7977,7 @@
       "source_file": "scripts/overlord/validate_handoff_package.py",
       "source_location": "L126",
       "id": "validate_handoff_package_validate_acceptance_criteria",
-      "community": 10
+      "community": 14
     },
     {
       "label": "validate_package()",
@@ -7577,7 +7985,7 @@
       "source_file": "scripts/overlord/validate_handoff_package.py",
       "source_location": "L169",
       "id": "validate_handoff_package_validate_package",
-      "community": 10
+      "community": 14
     },
     {
       "label": "_discover_package_files()",
@@ -7585,7 +7993,7 @@
       "source_file": "scripts/overlord/validate_handoff_package.py",
       "source_location": "L263",
       "id": "validate_handoff_package_discover_package_files",
-      "community": 10
+      "community": 14
     },
     {
       "label": "main()",
@@ -7593,7 +8001,7 @@
       "source_file": "scripts/overlord/validate_handoff_package.py",
       "source_location": "L272",
       "id": "validate_handoff_package_main",
-      "community": 10
+      "community": 14
     },
     {
       "label": "validate_registry_surfaces.py",
@@ -7601,7 +8009,7 @@
       "source_file": "scripts/overlord/validate_registry_surfaces.py",
       "source_location": "L1",
       "id": "validate_registry_surfaces",
-      "community": 57
+      "community": 58
     },
     {
       "label": "fail()",
@@ -7609,7 +8017,7 @@
       "source_file": "scripts/overlord/validate_registry_surfaces.py",
       "source_location": "L21",
       "id": "validate_registry_surfaces_fail",
-      "community": 57
+      "community": 58
     },
     {
       "label": "check()",
@@ -7617,7 +8025,7 @@
       "source_file": "scripts/overlord/validate_registry_surfaces.py",
       "source_location": "L26",
       "id": "validate_registry_surfaces_check",
-      "community": 57
+      "community": 58
     },
     {
       "label": "read_text()",
@@ -7625,7 +8033,7 @@
       "source_file": "scripts/overlord/validate_registry_surfaces.py",
       "source_location": "L31",
       "id": "validate_registry_surfaces_read_text",
-      "community": 57
+      "community": 58
     },
     {
       "label": "repos_for_static_checkout()",
@@ -7633,7 +8041,7 @@
       "source_file": "scripts/overlord/validate_registry_surfaces.py",
       "source_location": "L35",
       "id": "validate_registry_surfaces_repos_for_static_checkout",
-      "community": 57
+      "community": 58
     },
     {
       "label": "validate_static_checkout_workflow()",
@@ -7641,7 +8049,7 @@
       "source_file": "scripts/overlord/validate_registry_surfaces.py",
       "source_location": "L45",
       "id": "validate_registry_surfaces_validate_static_checkout_workflow",
-      "community": 57
+      "community": 58
     },
     {
       "label": "validate_runtime_registry_consumers()",
@@ -7649,7 +8057,7 @@
       "source_file": "scripts/overlord/validate_registry_surfaces.py",
       "source_location": "L58",
       "id": "validate_registry_surfaces_validate_runtime_registry_consumers",
-      "community": 57
+      "community": 58
     },
     {
       "label": "validate_docs_surfaces()",
@@ -7657,7 +8065,7 @@
       "source_file": "scripts/overlord/validate_registry_surfaces.py",
       "source_location": "L95",
       "id": "validate_registry_surfaces_validate_docs_surfaces",
-      "community": 57
+      "community": 58
     },
     {
       "label": "validate_subsystem_expectations()",
@@ -7665,7 +8073,7 @@
       "source_file": "scripts/overlord/validate_registry_surfaces.py",
       "source_location": "L111",
       "id": "validate_registry_surfaces_validate_subsystem_expectations",
-      "community": 57
+      "community": 58
     },
     {
       "label": "main()",
@@ -7673,7 +8081,7 @@
       "source_file": "scripts/overlord/validate_registry_surfaces.py",
       "source_location": "L128",
       "id": "validate_registry_surfaces_main",
-      "community": 57
+      "community": 58
     },
     {
       "label": "validate_structured_agent_cycle_plan.py",
@@ -7681,7 +8089,7 @@
       "source_file": "scripts/overlord/validate_structured_agent_cycle_plan.py",
       "source_location": "L1",
       "id": "validate_structured_agent_cycle_plan",
-      "community": 41
+      "community": 39
     },
     {
       "label": "_display_path()",
@@ -7689,7 +8097,7 @@
       "source_file": "scripts/overlord/validate_structured_agent_cycle_plan.py",
       "source_location": "L53",
       "id": "validate_structured_agent_cycle_plan_display_path",
-      "community": 41
+      "community": 39
     },
     {
       "label": "_load_json_safe()",
@@ -7697,7 +8105,7 @@
       "source_file": "scripts/overlord/validate_structured_agent_cycle_plan.py",
       "source_location": "L60",
       "id": "validate_structured_agent_cycle_plan_load_json_safe",
-      "community": 41
+      "community": 39
     },
     {
       "label": "_find_plan_files()",
@@ -7705,7 +8113,7 @@
       "source_file": "scripts/overlord/validate_structured_agent_cycle_plan.py",
       "source_location": "L68",
       "id": "validate_structured_agent_cycle_plan_find_plan_files",
-      "community": 41
+      "community": 39
     },
     {
       "label": "_require()",
@@ -7713,7 +8121,7 @@
       "source_file": "scripts/overlord/validate_structured_agent_cycle_plan.py",
       "source_location": "L72",
       "id": "validate_structured_agent_cycle_plan_require",
-      "community": 41
+      "community": 39
     },
     {
       "label": "_branch_issue_number()",
@@ -7721,7 +8129,7 @@
       "source_file": "scripts/overlord/validate_structured_agent_cycle_plan.py",
       "source_location": "L77",
       "id": "validate_structured_agent_cycle_plan_branch_issue_number",
-      "community": 41
+      "community": 39
     },
     {
       "label": "_is_governance_surface()",
@@ -7729,7 +8137,7 @@
       "source_file": "scripts/overlord/validate_structured_agent_cycle_plan.py",
       "source_location": "L82",
       "id": "validate_structured_agent_cycle_plan_is_governance_surface",
-      "community": 41
+      "community": 39
     },
     {
       "label": "_read_changed_files()",
@@ -7737,7 +8145,7 @@
       "source_file": "scripts/overlord/validate_structured_agent_cycle_plan.py",
       "source_location": "L91",
       "id": "validate_structured_agent_cycle_plan_read_changed_files",
-      "community": 41
+      "community": 39
     },
     {
       "label": "_matching_plan_payloads()",
@@ -7745,7 +8153,7 @@
       "source_file": "scripts/overlord/validate_structured_agent_cycle_plan.py",
       "source_location": "L97",
       "id": "validate_structured_agent_cycle_plan_matching_plan_payloads",
-      "community": 41
+      "community": 39
     },
     {
       "label": "_matching_execution_scopes()",
@@ -7753,7 +8161,7 @@
       "source_file": "scripts/overlord/validate_structured_agent_cycle_plan.py",
       "source_location": "L111",
       "id": "validate_structured_agent_cycle_plan_matching_execution_scopes",
-      "community": 41
+      "community": 39
     },
     {
       "label": "_validate_planner_boundary_scope_presence()",
@@ -7761,7 +8169,7 @@
       "source_file": "scripts/overlord/validate_structured_agent_cycle_plan.py",
       "source_location": "L120",
       "id": "validate_structured_agent_cycle_plan_validate_planner_boundary_scope_presence",
-      "community": 41
+      "community": 39
     },
     {
       "label": "_validate_implementation_ready_plan()",
@@ -7769,7 +8177,7 @@
       "source_file": "scripts/overlord/validate_structured_agent_cycle_plan.py",
       "source_location": "L152",
       "id": "validate_structured_agent_cycle_plan_validate_implementation_ready_plan",
-      "community": 41
+      "community": 39
     },
     {
       "label": "_validate_file()",
@@ -7777,7 +8185,7 @@
       "source_file": "scripts/overlord/validate_structured_agent_cycle_plan.py",
       "source_location": "L177",
       "id": "validate_structured_agent_cycle_plan_validate_file",
-      "community": 41
+      "community": 39
     },
     {
       "label": "main()",
@@ -7785,7 +8193,7 @@
       "source_file": "scripts/overlord/validate_structured_agent_cycle_plan.py",
       "source_location": "L255",
       "id": "validate_structured_agent_cycle_plan_main",
-      "community": 41
+      "community": 39
     },
     {
       "label": "verify_governance_consumer.py",
@@ -7793,167 +8201,287 @@
       "source_file": "scripts/overlord/verify_governance_consumer.py",
       "source_location": "L1",
       "id": "verify_governance_consumer",
-      "community": 26
+      "community": 13
     },
     {
       "label": "ConsumerVerifyError",
       "file_type": "code",
       "source_file": "scripts/overlord/verify_governance_consumer.py",
-      "source_location": "L22",
+      "source_location": "L76",
       "id": "verify_governance_consumer_consumerverifyerror",
-      "community": 26
+      "community": 13
     },
     {
       "label": "ConsumerRecord",
       "file_type": "code",
       "source_file": "scripts/overlord/verify_governance_consumer.py",
-      "source_location": "L27",
+      "source_location": "L81",
       "id": "verify_governance_consumer_consumerrecord",
-      "community": 26
+      "community": 13
     },
     {
       "label": "_fail()",
       "file_type": "code",
       "source_file": "scripts/overlord/verify_governance_consumer.py",
-      "source_location": "L32",
+      "source_location": "L86",
       "id": "verify_governance_consumer_fail",
-      "community": 26
+      "community": 13
     },
     {
       "label": "_run_git()",
       "file_type": "code",
       "source_file": "scripts/overlord/verify_governance_consumer.py",
-      "source_location": "L36",
+      "source_location": "L90",
       "id": "verify_governance_consumer_run_git",
-      "community": 26
+      "community": 13
     },
     {
       "label": "_git_root()",
       "file_type": "code",
       "source_file": "scripts/overlord/verify_governance_consumer.py",
-      "source_location": "L40",
+      "source_location": "L94",
       "id": "verify_governance_consumer_git_root",
-      "community": 26
+      "community": 13
     },
     {
       "label": "_load_json()",
       "file_type": "code",
       "source_file": "scripts/overlord/verify_governance_consumer.py",
-      "source_location": "L47",
+      "source_location": "L101",
       "id": "verify_governance_consumer_load_json",
-      "community": 26
+      "community": 13
     },
     {
       "label": "_consumer_record_relpath()",
       "file_type": "code",
       "source_file": "scripts/overlord/verify_governance_consumer.py",
-      "source_location": "L59",
+      "source_location": "L113",
       "id": "verify_governance_consumer_consumer_record_relpath",
-      "community": 26
+      "community": 13
     },
     {
       "label": "_required_record_fields()",
       "file_type": "code",
       "source_file": "scripts/overlord/verify_governance_consumer.py",
-      "source_location": "L68",
+      "source_location": "L122",
       "id": "verify_governance_consumer_required_record_fields",
-      "community": 26
+      "community": 13
     },
     {
       "label": "_initial_package_version()",
       "file_type": "code",
       "source_file": "scripts/overlord/verify_governance_consumer.py",
-      "source_location": "L89",
+      "source_location": "L143",
       "id": "verify_governance_consumer_initial_package_version",
-      "community": 26
+      "community": 13
     },
     {
       "label": "_profile_desired_state()",
       "file_type": "code",
       "source_file": "scripts/overlord/verify_governance_consumer.py",
-      "source_location": "L98",
+      "source_location": "L152",
       "id": "verify_governance_consumer_profile_desired_state",
-      "community": 26
+      "community": 13
+    },
+    {
+      "label": "_profile_contract()",
+      "file_type": "code",
+      "source_file": "scripts/overlord/verify_governance_consumer.py",
+      "source_location": "L160",
+      "id": "verify_governance_consumer_profile_contract",
+      "community": 13
+    },
+    {
+      "label": "_manifest_profiles()",
+      "file_type": "code",
+      "source_file": "scripts/overlord/verify_governance_consumer.py",
+      "source_location": "L165",
+      "id": "verify_governance_consumer_manifest_profiles",
+      "community": 13
+    },
+    {
+      "label": "_known_profiles()",
+      "file_type": "code",
+      "source_file": "scripts/overlord/verify_governance_consumer.py",
+      "source_location": "L170",
+      "id": "verify_governance_consumer_known_profiles",
+      "community": 13
+    },
+    {
+      "label": "_next_package_version()",
+      "file_type": "code",
+      "source_file": "scripts/overlord/verify_governance_consumer.py",
+      "source_location": "L178",
+      "id": "verify_governance_consumer_next_package_version",
+      "community": 13
+    },
+    {
+      "label": "_is_v2_record()",
+      "file_type": "code",
+      "source_file": "scripts/overlord/verify_governance_consumer.py",
+      "source_location": "L187",
+      "id": "verify_governance_consumer_is_v2_record",
+      "community": 13
+    },
+    {
+      "label": "_profile_required_constraints()",
+      "file_type": "code",
+      "source_file": "scripts/overlord/verify_governance_consumer.py",
+      "source_location": "L197",
+      "id": "verify_governance_consumer_profile_required_constraints",
+      "community": 13
+    },
+    {
+      "label": "_record_constraints()",
+      "file_type": "code",
+      "source_file": "scripts/overlord/verify_governance_consumer.py",
+      "source_location": "L207",
+      "id": "verify_governance_consumer_record_constraints",
+      "community": 13
     },
     {
       "label": "_expected_managed_paths()",
       "file_type": "code",
       "source_file": "scripts/overlord/verify_governance_consumer.py",
-      "source_location": "L106",
+      "source_location": "L219",
       "id": "verify_governance_consumer_expected_managed_paths",
-      "community": 26
+      "community": 13
     },
     {
       "label": "_managed_paths()",
       "file_type": "code",
       "source_file": "scripts/overlord/verify_governance_consumer.py",
-      "source_location": "L113",
+      "source_location": "L226",
       "id": "verify_governance_consumer_managed_paths",
-      "community": 26
+      "community": 13
     },
     {
       "label": "_managed_file_type()",
       "file_type": "code",
       "source_file": "scripts/overlord/verify_governance_consumer.py",
-      "source_location": "L124",
+      "source_location": "L237",
       "id": "verify_governance_consumer_managed_file_type",
-      "community": 26
+      "community": 13
+    },
+    {
+      "label": "_managed_file_entry()",
+      "file_type": "code",
+      "source_file": "scripts/overlord/verify_governance_consumer.py",
+      "source_location": "L247",
+      "id": "verify_governance_consumer_managed_file_entry",
+      "community": 13
+    },
+    {
+      "label": "_managed_markers()",
+      "file_type": "code",
+      "source_file": "scripts/overlord/verify_governance_consumer.py",
+      "source_location": "L257",
+      "id": "verify_governance_consumer_managed_markers",
+      "community": 13
+    },
+    {
+      "label": "_expected_checksum()",
+      "file_type": "code",
+      "source_file": "scripts/overlord/verify_governance_consumer.py",
+      "source_location": "L266",
+      "id": "verify_governance_consumer_expected_checksum",
+      "community": 13
+    },
+    {
+      "label": "_non_empty_string()",
+      "file_type": "code",
+      "source_file": "scripts/overlord/verify_governance_consumer.py",
+      "source_location": "L274",
+      "id": "verify_governance_consumer_non_empty_string",
+      "community": 13
+    },
+    {
+      "label": "_override_text()",
+      "file_type": "code",
+      "source_file": "scripts/overlord/verify_governance_consumer.py",
+      "source_location": "L278",
+      "id": "verify_governance_consumer_override_text",
+      "community": 13
+    },
+    {
+      "label": "_forbidden_override_failures()",
+      "file_type": "code",
+      "source_file": "scripts/overlord/verify_governance_consumer.py",
+      "source_location": "L282",
+      "id": "verify_governance_consumer_forbidden_override_failures",
+      "community": 13
     },
     {
       "label": "_is_relative_to()",
       "file_type": "code",
       "source_file": "scripts/overlord/verify_governance_consumer.py",
-      "source_location": "L134",
+      "source_location": "L295",
       "id": "verify_governance_consumer_is_relative_to",
-      "community": 26
+      "community": 13
     },
     {
       "label": "_load_consumer_record()",
       "file_type": "code",
       "source_file": "scripts/overlord/verify_governance_consumer.py",
-      "source_location": "L142",
+      "source_location": "L303",
       "id": "verify_governance_consumer_load_consumer_record",
-      "community": 26
+      "community": 13
+    },
+    {
+      "label": "_override_records()",
+      "file_type": "code",
+      "source_file": "scripts/overlord/verify_governance_consumer.py",
+      "source_location": "L312",
+      "id": "verify_governance_consumer_override_records",
+      "community": 13
+    },
+    {
+      "label": "_workflow_ref_failures()",
+      "file_type": "code",
+      "source_file": "scripts/overlord/verify_governance_consumer.py",
+      "source_location": "L343",
+      "id": "verify_governance_consumer_workflow_ref_failures",
+      "community": 13
     },
     {
       "label": "_validate_record()",
       "file_type": "code",
       "source_file": "scripts/overlord/verify_governance_consumer.py",
-      "source_location": "L151",
+      "source_location": "L363",
       "id": "verify_governance_consumer_validate_record",
-      "community": 26
+      "community": 13
     },
     {
       "label": "verify()",
       "file_type": "code",
       "source_file": "scripts/overlord/verify_governance_consumer.py",
-      "source_location": "L229",
+      "source_location": "L470",
       "id": "verify_governance_consumer_verify",
-      "community": 26
+      "community": 13
     },
     {
       "label": "print_json()",
       "file_type": "code",
       "source_file": "scripts/overlord/verify_governance_consumer.py",
-      "source_location": "L264",
+      "source_location": "L506",
       "id": "verify_governance_consumer_print_json",
-      "community": 26
+      "community": 13
     },
     {
       "label": "build_parser()",
       "file_type": "code",
       "source_file": "scripts/overlord/verify_governance_consumer.py",
-      "source_location": "L269",
+      "source_location": "L511",
       "id": "verify_governance_consumer_build_parser",
-      "community": 26
+      "community": 13
     },
     {
       "label": "main()",
       "file_type": "code",
       "source_file": "scripts/overlord/verify_governance_consumer.py",
-      "source_location": "L283",
+      "source_location": "L525",
       "id": "verify_governance_consumer_main",
-      "community": 26
+      "community": 13
     },
     {
       "label": "emit.py",
@@ -7961,7 +8489,7 @@
       "source_file": "scripts/packet/emit.py",
       "source_location": "L1",
       "id": "emit",
-      "community": 42
+      "community": 40
     },
     {
       "label": "emit_packet()",
@@ -7969,7 +8497,7 @@
       "source_file": "scripts/packet/emit.py",
       "source_location": "L14",
       "id": "emit_emit_packet",
-      "community": 42
+      "community": 40
     },
     {
       "label": "build_governance()",
@@ -7977,7 +8505,7 @@
       "source_file": "scripts/packet/emit.py",
       "source_location": "L73",
       "id": "emit_build_governance",
-      "community": 42
+      "community": 40
     },
     {
       "label": "emit_dispatch_packet()",
@@ -7985,7 +8513,7 @@
       "source_file": "scripts/packet/emit.py",
       "source_location": "L100",
       "id": "emit_emit_dispatch_packet",
-      "community": 42
+      "community": 40
     },
     {
       "label": "main()",
@@ -7993,7 +8521,7 @@
       "source_file": "scripts/packet/emit.py",
       "source_location": "L150",
       "id": "emit_main",
-      "community": 42
+      "community": 40
     },
     {
       "label": "Emit a minimal or dispatch-ready packet YAML file. Returns path to written file.",
@@ -8001,7 +8529,7 @@
       "source_file": "scripts/packet/emit.py",
       "source_location": "L28",
       "id": "emit_rationale_28",
-      "community": 42
+      "community": 40
     },
     {
       "label": "Build a governance block dict for inclusion in a dispatch-ready packet.",
@@ -8009,7 +8537,7 @@
       "source_file": "scripts/packet/emit.py",
       "source_location": "L84",
       "id": "emit_rationale_84",
-      "community": 42
+      "community": 40
     },
     {
       "label": "Emit a dispatch-ready packet that includes a complete governance block.",
@@ -8017,7 +8545,7 @@
       "source_file": "scripts/packet/emit.py",
       "source_location": "L122",
       "id": "emit_rationale_122",
-      "community": 42
+      "community": 40
     },
     {
       "label": "test_emit.py",
@@ -8025,7 +8553,7 @@
       "source_file": "scripts/packet/test_emit.py",
       "source_location": "L1",
       "id": "test_emit",
-      "community": 42
+      "community": 40
     },
     {
       "label": "TestPacketEmitter",
@@ -8033,7 +8561,7 @@
       "source_file": "scripts/packet/test_emit.py",
       "source_location": "L16",
       "id": "test_emit_testpacketemitter",
-      "community": 42
+      "community": 40
     },
     {
       "label": ".test_emit_dispatch_packet_writes_complete_governance_block()",
@@ -8041,7 +8569,7 @@
       "source_file": "scripts/packet/test_emit.py",
       "source_location": "L17",
       "id": "test_emit_testpacketemitter_test_emit_dispatch_packet_writes_complete_governance_block",
-      "community": 42
+      "community": 40
     },
     {
       "label": ".test_emit_packet_without_governance_preserves_historical_shape()",
@@ -8049,7 +8577,7 @@
       "source_file": "scripts/packet/test_emit.py",
       "source_location": "L50",
       "id": "test_emit_testpacketemitter_test_emit_packet_without_governance_preserves_historical_shape",
-      "community": 42
+      "community": 40
     },
     {
       "label": ".test_cli_rejects_partial_governance_flags()",
@@ -8057,7 +8585,7 @@
       "source_file": "scripts/packet/test_emit.py",
       "source_location": "L66",
       "id": "test_emit_testpacketemitter_test_cli_rejects_partial_governance_flags",
-      "community": 42
+      "community": 40
     },
     {
       "label": ".test_cli_passes_full_governance_block_to_emitter()",
@@ -8065,7 +8593,7 @@
       "source_file": "scripts/packet/test_emit.py",
       "source_location": "L91",
       "id": "test_emit_testpacketemitter_test_cli_passes_full_governance_block_to_emitter",
-      "community": 42
+      "community": 40
     },
     {
       "label": "test_hitl_relay_schema.py",
@@ -8633,7 +9161,7 @@
       "source_file": "scripts/packet/test_validate_hitl_relay.py",
       "source_location": "L1",
       "id": "test_validate_hitl_relay",
-      "community": 13
+      "community": 17
     },
     {
       "label": "_load()",
@@ -8641,7 +9169,7 @@
       "source_file": "scripts/packet/test_validate_hitl_relay.py",
       "source_location": "L19",
       "id": "test_validate_hitl_relay_load",
-      "community": 13
+      "community": 17
     },
     {
       "label": "test_valid_examples_pass_policy_validation()",
@@ -8649,7 +9177,7 @@
       "source_file": "scripts/packet/test_validate_hitl_relay.py",
       "source_location": "L23",
       "id": "test_validate_hitl_relay_test_valid_examples_pass_policy_validation",
-      "community": 13
+      "community": 17
     },
     {
       "label": "test_invalid_examples_fail_policy_validation()",
@@ -8657,7 +9185,7 @@
       "source_file": "scripts/packet/test_validate_hitl_relay.py",
       "source_location": "L30",
       "id": "test_validate_hitl_relay_test_invalid_examples_fail_policy_validation",
-      "community": 13
+      "community": 17
     },
     {
       "label": "test_session_instruction_requires_matching_target_session()",
@@ -8665,7 +9193,7 @@
       "source_file": "scripts/packet/test_validate_hitl_relay.py",
       "source_location": "L38",
       "id": "test_validate_hitl_relay_test_session_instruction_requires_matching_target_session",
-      "community": 13
+      "community": 17
     },
     {
       "label": "test_low_confidence_non_clarify_decision_fails_closed()",
@@ -8673,7 +9201,7 @@
       "source_file": "scripts/packet/test_validate_hitl_relay.py",
       "source_location": "L46",
       "id": "test_validate_hitl_relay_test_low_confidence_non_clarify_decision_fails_closed",
-      "community": 13
+      "community": 17
     },
     {
       "label": "test_low_confidence_clarify_decision_passes_without_instruction()",
@@ -8681,7 +9209,7 @@
       "source_file": "scripts/packet/test_validate_hitl_relay.py",
       "source_location": "L54",
       "id": "test_validate_hitl_relay_test_low_confidence_clarify_decision_passes_without_instruction",
-      "community": 13
+      "community": 17
     },
     {
       "label": "test_duplicate_reply_cannot_produce_instruction()",
@@ -8689,7 +9217,7 @@
       "source_file": "scripts/packet/test_validate_hitl_relay.py",
       "source_location": "L64",
       "id": "test_validate_hitl_relay_test_duplicate_reply_cannot_produce_instruction",
-      "community": 13
+      "community": 17
     },
     {
       "label": "test_expired_reply_cannot_produce_instruction()",
@@ -8697,7 +9225,7 @@
       "source_file": "scripts/packet/test_validate_hitl_relay.py",
       "source_location": "L72",
       "id": "test_validate_hitl_relay_test_expired_reply_cannot_produce_instruction",
-      "community": 13
+      "community": 17
     },
     {
       "label": "test_pii_external_channel_fails_closed()",
@@ -8705,7 +9233,7 @@
       "source_file": "scripts/packet/test_validate_hitl_relay.py",
       "source_location": "L80",
       "id": "test_validate_hitl_relay_test_pii_external_channel_fails_closed",
-      "community": 13
+      "community": 17
     },
     {
       "label": "test_stale_session_requires_resume_packet()",
@@ -8713,7 +9241,7 @@
       "source_file": "scripts/packet/test_validate_hitl_relay.py",
       "source_location": "L90",
       "id": "test_validate_hitl_relay_test_stale_session_requires_resume_packet",
-      "community": 13
+      "community": 17
     },
     {
       "label": "test_response_requires_notification_and_response_ids()",
@@ -8721,7 +9249,7 @@
       "source_file": "scripts/packet/test_validate_hitl_relay.py",
       "source_location": "L98",
       "id": "test_validate_hitl_relay_test_response_requires_notification_and_response_ids",
-      "community": 13
+      "community": 17
     },
     {
       "label": "validate.py",
@@ -8729,7 +9257,7 @@
       "source_file": "scripts/packet/validate.py",
       "source_location": "L1",
       "id": "validate",
-      "community": 15
+      "community": 18
     },
     {
       "label": "_load_packet()",
@@ -8737,7 +9265,7 @@
       "source_file": "scripts/packet/validate.py",
       "source_location": "L57",
       "id": "validate_load_packet",
-      "community": 15
+      "community": 18
     },
     {
       "label": "_load_schema()",
@@ -8745,7 +9273,7 @@
       "source_file": "scripts/packet/validate.py",
       "source_location": "L65",
       "id": "validate_load_schema",
-      "community": 15
+      "community": 18
     },
     {
       "label": "_find_packet_file()",
@@ -8753,7 +9281,7 @@
       "source_file": "scripts/packet/validate.py",
       "source_location": "L79",
       "id": "validate_find_packet_file",
-      "community": 15
+      "community": 18
     },
     {
       "label": "_resolve_chain()",
@@ -8761,7 +9289,7 @@
       "source_file": "scripts/packet/validate.py",
       "source_location": "L89",
       "id": "validate_resolve_chain",
-      "community": 15
+      "community": 18
     },
     {
       "label": "load_pii_patterns()",
@@ -8769,7 +9297,7 @@
       "source_file": "scripts/packet/validate.py",
       "source_location": "L115",
       "id": "validate_load_pii_patterns",
-      "community": 15
+      "community": 18
     },
     {
       "label": "validate_dual_planner()",
@@ -8777,7 +9305,7 @@
       "source_file": "scripts/packet/validate.py",
       "source_location": "L137",
       "id": "validate_validate_dual_planner",
-      "community": 15
+      "community": 18
     },
     {
       "label": "validate_no_self_approval()",
@@ -8785,7 +9313,7 @@
       "source_file": "scripts/packet/validate.py",
       "source_location": "L180",
       "id": "validate_validate_no_self_approval",
-      "community": 15
+      "community": 18
     },
     {
       "label": "validate_tier_escalation_valid()",
@@ -8793,7 +9321,7 @@
       "source_file": "scripts/packet/validate.py",
       "source_location": "L213",
       "id": "validate_validate_tier_escalation_valid",
-      "community": 15
+      "community": 18
     },
     {
       "label": "validate_local_family_diversity()",
@@ -8801,7 +9329,7 @@
       "source_file": "scripts/packet/validate.py",
       "source_location": "L231",
       "id": "validate_validate_local_family_diversity",
-      "community": 15
+      "community": 18
     },
     {
       "label": "validate_fallback_logged()",
@@ -8809,7 +9337,7 @@
       "source_file": "scripts/packet/validate.py",
       "source_location": "L257",
       "id": "validate_validate_fallback_logged",
-      "community": 15
+      "community": 18
     },
     {
       "label": "validate_schema()",
@@ -8817,7 +9345,7 @@
       "source_file": "scripts/packet/validate.py",
       "source_location": "L294",
       "id": "validate_validate_schema",
-      "community": 15
+      "community": 18
     },
     {
       "label": "validate_planning_floor()",
@@ -8825,7 +9353,7 @@
       "source_file": "scripts/packet/validate.py",
       "source_location": "L309",
       "id": "validate_validate_planning_floor",
-      "community": 15
+      "community": 18
     },
     {
       "label": "validate_pii_floor()",
@@ -8833,7 +9361,7 @@
       "source_file": "scripts/packet/validate.py",
       "source_location": "L325",
       "id": "validate_validate_pii_floor",
-      "community": 15
+      "community": 18
     },
     {
       "label": "validate_packet()",
@@ -8841,7 +9369,7 @@
       "source_file": "scripts/packet/validate.py",
       "source_location": "L362",
       "id": "validate_validate_packet",
-      "community": 15
+      "community": 18
     },
     {
       "label": "_run_cli()",
@@ -8849,7 +9377,7 @@
       "source_file": "scripts/packet/validate.py",
       "source_location": "L393",
       "id": "validate_run_cli",
-      "community": 15
+      "community": 18
     },
     {
       "label": "Load a YAML packet; return None if missing or malformed.",
@@ -8857,7 +9385,7 @@
       "source_file": "scripts/packet/validate.py",
       "source_location": "L58",
       "id": "validate_rationale_58",
-      "community": 15
+      "community": 18
     },
     {
       "label": "Load the packet schema from docs/schemas/som-packet.schema.yml.",
@@ -8865,7 +9393,7 @@
       "source_file": "scripts/packet/validate.py",
       "source_location": "L66",
       "id": "validate_rationale_66",
-      "community": 15
+      "community": 18
     },
     {
       "label": "Locate a packet file by ID (supports YYYY-MM-DD-<id>.yml naming).",
@@ -8873,7 +9401,7 @@
       "source_file": "scripts/packet/validate.py",
       "source_location": "L80",
       "id": "validate_rationale_80",
-      "community": 15
+      "community": 18
     },
     {
       "label": "Walk parent_packet_id links backwards; return ordered list [packet, parent, ...]",
@@ -8881,7 +9409,7 @@
       "source_file": "scripts/packet/validate.py",
       "source_location": "L90",
       "id": "validate_rationale_90",
-      "community": 15
+      "community": 18
     },
     {
       "label": "Load and compile PII patterns from pii-patterns.yml.",
@@ -8889,7 +9417,7 @@
       "source_file": "scripts/packet/validate.py",
       "source_location": "L116",
       "id": "validate_rationale_116",
-      "community": 15
+      "community": 18
     },
     {
       "label": "Enforce cross-family independence for tier-1 dual-planner packets.      When pri",
@@ -8897,7 +9425,7 @@
       "source_file": "scripts/packet/validate.py",
       "source_location": "L141",
       "id": "validate_rationale_141",
-      "community": 15
+      "community": 18
     },
     {
       "label": "Refuse if any consecutive pair in the parent chain shares model_id across differ",
@@ -8905,7 +9433,7 @@
       "source_file": "scripts/packet/validate.py",
       "source_location": "L184",
       "id": "validate_rationale_184",
-      "community": 15
+      "community": 18
     },
     {
       "label": "Enforce expected handoff sequence with no tier jumps.",
@@ -8913,7 +9441,7 @@
       "source_file": "scripts/packet/validate.py",
       "source_location": "L214",
       "id": "validate_rationale_214",
-      "community": 15
+      "community": 18
     },
     {
       "label": "Enforce LAM family diversity for LAM-only handoffs.",
@@ -8921,7 +9449,7 @@
       "source_file": "scripts/packet/validate.py",
       "source_location": "L235",
       "id": "validate_rationale_235",
-      "community": 15
+      "community": 18
     },
     {
       "label": "Require explicit fallback references to resolve in raw/model-fallbacks.",
@@ -8929,7 +9457,7 @@
       "source_file": "scripts/packet/validate.py",
       "source_location": "L258",
       "id": "validate_rationale_258",
-      "community": 15
+      "community": 18
     },
     {
       "label": "Validate packet shape against docs/schemas/som-packet.schema.yml.",
@@ -8937,7 +9465,7 @@
       "source_file": "scripts/packet/validate.py",
       "source_location": "L295",
       "id": "validate_rationale_295",
-      "community": 15
+      "community": 18
     },
     {
       "label": "Refuse tier-1 packets whose model is below the planning floor.",
@@ -8945,7 +9473,7 @@
       "source_file": "scripts/packet/validate.py",
       "source_location": "L310",
       "id": "validate_rationale_310",
-      "community": 15
+      "community": 18
     },
     {
       "label": "Refuse if PII artifacts appear outside LAM-role packets, or if the pattern file",
@@ -8953,7 +9481,7 @@
       "source_file": "scripts/packet/validate.py",
       "source_location": "L326",
       "id": "validate_rationale_326",
-      "community": 15
+      "community": 18
     },
     {
       "label": "Run all validators against a packet dict.      Returns (all_passed, list_of_fail",
@@ -8961,7 +9489,7 @@
       "source_file": "scripts/packet/validate.py",
       "source_location": "L366",
       "id": "validate_rationale_366",
-      "community": 15
+      "community": 18
     },
     {
       "label": "CLI entrypoint for validating packet files.",
@@ -8969,7 +9497,7 @@
       "source_file": "scripts/packet/validate.py",
       "source_location": "L394",
       "id": "validate_rationale_394",
-      "community": 15
+      "community": 18
     },
     {
       "label": "validate_hitl_relay.py",
@@ -8977,7 +9505,7 @@
       "source_file": "scripts/packet/validate_hitl_relay.py",
       "source_location": "L1",
       "id": "validate_hitl_relay",
-      "community": 13
+      "community": 17
     },
     {
       "label": "load_packet()",
@@ -8985,7 +9513,7 @@
       "source_file": "scripts/packet/validate_hitl_relay.py",
       "source_location": "L22",
       "id": "validate_hitl_relay_load_packet",
-      "community": 13
+      "community": 17
     },
     {
       "label": "_schema_validator()",
@@ -8993,7 +9521,7 @@
       "source_file": "scripts/packet/validate_hitl_relay.py",
       "source_location": "L26",
       "id": "validate_hitl_relay_schema_validator",
-      "community": 13
+      "community": 17
     },
     {
       "label": "validate_schema()",
@@ -9001,7 +9529,7 @@
       "source_file": "scripts/packet/validate_hitl_relay.py",
       "source_location": "L32",
       "id": "validate_hitl_relay_validate_schema",
-      "community": 13
+      "community": 17
     },
     {
       "label": "_packet_type()",
@@ -9009,7 +9537,7 @@
       "source_file": "scripts/packet/validate_hitl_relay.py",
       "source_location": "L37",
       "id": "validate_hitl_relay_packet_type",
-      "community": 13
+      "community": 17
     },
     {
       "label": "_correlation()",
@@ -9017,7 +9545,7 @@
       "source_file": "scripts/packet/validate_hitl_relay.py",
       "source_location": "L41",
       "id": "validate_hitl_relay_correlation",
-      "community": 13
+      "community": 17
     },
     {
       "label": "_session()",
@@ -9025,7 +9553,7 @@
       "source_file": "scripts/packet/validate_hitl_relay.py",
       "source_location": "L46",
       "id": "validate_hitl_relay_session",
-      "community": 13
+      "community": 17
     },
     {
       "label": "_policy()",
@@ -9033,7 +9561,7 @@
       "source_file": "scripts/packet/validate_hitl_relay.py",
       "source_location": "L51",
       "id": "validate_hitl_relay_policy",
-      "community": 13
+      "community": 17
     },
     {
       "label": "_operator_reply()",
@@ -9041,7 +9569,7 @@
       "source_file": "scripts/packet/validate_hitl_relay.py",
       "source_location": "L56",
       "id": "validate_hitl_relay_operator_reply",
-      "community": 13
+      "community": 17
     },
     {
       "label": "_decision()",
@@ -9049,7 +9577,7 @@
       "source_file": "scripts/packet/validate_hitl_relay.py",
       "source_location": "L61",
       "id": "validate_hitl_relay_decision",
-      "community": 13
+      "community": 17
     },
     {
       "label": "_instruction()",
@@ -9057,7 +9585,7 @@
       "source_file": "scripts/packet/validate_hitl_relay.py",
       "source_location": "L66",
       "id": "validate_hitl_relay_instruction",
-      "community": 13
+      "community": 17
     },
     {
       "label": "validate_policy_refs()",
@@ -9065,7 +9593,7 @@
       "source_file": "scripts/packet/validate_hitl_relay.py",
       "source_location": "L71",
       "id": "validate_hitl_relay_validate_policy_refs",
-      "community": 13
+      "community": 17
     },
     {
       "label": "validate_correlation()",
@@ -9073,7 +9601,7 @@
       "source_file": "scripts/packet/validate_hitl_relay.py",
       "source_location": "L83",
       "id": "validate_hitl_relay_validate_correlation",
-      "community": 13
+      "community": 17
     },
     {
       "label": "validate_operator_reply()",
@@ -9081,7 +9609,7 @@
       "source_file": "scripts/packet/validate_hitl_relay.py",
       "source_location": "L96",
       "id": "validate_hitl_relay_validate_operator_reply",
-      "community": 13
+      "community": 17
     },
     {
       "label": "validate_pii_channel_policy()",
@@ -9089,7 +9617,7 @@
       "source_file": "scripts/packet/validate_hitl_relay.py",
       "source_location": "L113",
       "id": "validate_hitl_relay_validate_pii_channel_policy",
-      "community": 13
+      "community": 17
     },
     {
       "label": "validate_normalized_decision()",
@@ -9097,7 +9625,7 @@
       "source_file": "scripts/packet/validate_hitl_relay.py",
       "source_location": "L124",
       "id": "validate_hitl_relay_validate_normalized_decision",
-      "community": 13
+      "community": 17
     },
     {
       "label": "validate_instruction()",
@@ -9105,7 +9633,7 @@
       "source_file": "scripts/packet/validate_hitl_relay.py",
       "source_location": "L142",
       "id": "validate_hitl_relay_validate_instruction",
-      "community": 13
+      "community": 17
     },
     {
       "label": "validate_resume()",
@@ -9113,7 +9641,7 @@
       "source_file": "scripts/packet/validate_hitl_relay.py",
       "source_location": "L161",
       "id": "validate_hitl_relay_validate_resume",
-      "community": 13
+      "community": 17
     },
     {
       "label": "validate_hitl_packet()",
@@ -9121,7 +9649,7 @@
       "source_file": "scripts/packet/validate_hitl_relay.py",
       "source_location": "L170",
       "id": "validate_hitl_relay_validate_hitl_packet",
-      "community": 13
+      "community": 17
     },
     {
       "label": "_run_cli()",
@@ -9129,7 +9657,7 @@
       "source_file": "scripts/packet/validate_hitl_relay.py",
       "source_location": "L187",
       "id": "validate_hitl_relay_run_cli",
-      "community": 13
+      "community": 17
     },
     {
       "label": "live_health_monitor.py",
@@ -9137,7 +9665,7 @@
       "source_file": "scripts/remote-mcp/live_health_monitor.py",
       "source_location": "L1",
       "id": "live_health_monitor",
-      "community": 11
+      "community": 19
     },
     {
       "label": "_env_has_live_markers()",
@@ -9145,7 +9673,7 @@
       "source_file": "scripts/remote-mcp/live_health_monitor.py",
       "source_location": "L42",
       "id": "live_health_monitor_env_has_live_markers",
-      "community": 11
+      "community": 19
     },
     {
       "label": "_scan_evidence_dir()",
@@ -9153,7 +9681,7 @@
       "source_file": "scripts/remote-mcp/live_health_monitor.py",
       "source_location": "L46",
       "id": "live_health_monitor_scan_evidence_dir",
-      "community": 11
+      "community": 19
     },
     {
       "label": "_stage_d_args()",
@@ -9161,7 +9689,7 @@
       "source_file": "scripts/remote-mcp/live_health_monitor.py",
       "source_location": "L86",
       "id": "live_health_monitor_stage_d_args",
-      "community": 11
+      "community": 19
     },
     {
       "label": "_run_fixture()",
@@ -9169,7 +9697,7 @@
       "source_file": "scripts/remote-mcp/live_health_monitor.py",
       "source_location": "L103",
       "id": "live_health_monitor_run_fixture",
-      "community": 11
+      "community": 19
     },
     {
       "label": "_run_live()",
@@ -9177,7 +9705,7 @@
       "source_file": "scripts/remote-mcp/live_health_monitor.py",
       "source_location": "L109",
       "id": "live_health_monitor_run_live",
-      "community": 11
+      "community": 19
     },
     {
       "label": "build_parser()",
@@ -9185,7 +9713,7 @@
       "source_file": "scripts/remote-mcp/live_health_monitor.py",
       "source_location": "L122",
       "id": "live_health_monitor_build_parser",
-      "community": 11
+      "community": 19
     },
     {
       "label": "main()",
@@ -9193,7 +9721,7 @@
       "source_file": "scripts/remote-mcp/live_health_monitor.py",
       "source_location": "L144",
       "id": "live_health_monitor_main",
-      "community": 11
+      "community": 19
     },
     {
       "label": "monitor_alert.py",
@@ -9273,7 +9801,7 @@
       "source_file": "scripts/remote-mcp/operator_connectivity.py",
       "source_location": "L1",
       "id": "operator_connectivity",
-      "community": 2
+      "community": 3
     },
     {
       "label": "Check",
@@ -9281,7 +9809,7 @@
       "source_file": "scripts/remote-mcp/operator_connectivity.py",
       "source_location": "L41",
       "id": "operator_connectivity_check",
-      "community": 2
+      "community": 3
     },
     {
       "label": ".to_dict()",
@@ -9289,7 +9817,7 @@
       "source_file": "scripts/remote-mcp/operator_connectivity.py",
       "source_location": "L46",
       "id": "operator_connectivity_check_to_dict",
-      "community": 2
+      "community": 3
     },
     {
       "label": "_FixtureMcpHandler",
@@ -9297,7 +9825,7 @@
       "source_file": "scripts/remote-mcp/operator_connectivity.py",
       "source_location": "L50",
       "id": "operator_connectivity_fixturemcphandler",
-      "community": 2
+      "community": 3
     },
     {
       "label": "BaseHTTPRequestHandler",
@@ -9305,7 +9833,7 @@
       "source_file": "",
       "source_location": "",
       "id": "basehttprequesthandler",
-      "community": 2
+      "community": 3
     },
     {
       "label": ".log_message()",
@@ -9313,7 +9841,7 @@
       "source_file": "scripts/remote-mcp/operator_connectivity.py",
       "source_location": "L53",
       "id": "operator_connectivity_fixturemcphandler_log_message",
-      "community": 2
+      "community": 3
     },
     {
       "label": ".do_POST()",
@@ -9321,7 +9849,7 @@
       "source_file": "scripts/remote-mcp/operator_connectivity.py",
       "source_location": "L56",
       "id": "operator_connectivity_fixturemcphandler_do_post",
-      "community": 2
+      "community": 3
     },
     {
       "label": "._write_json()",
@@ -9329,7 +9857,7 @@
       "source_file": "scripts/remote-mcp/operator_connectivity.py",
       "source_location": "L76",
       "id": "operator_connectivity_fixturemcphandler_write_json",
-      "community": 2
+      "community": 3
     },
     {
       "label": "_fixture_server()",
@@ -9337,7 +9865,7 @@
       "source_file": "scripts/remote-mcp/operator_connectivity.py",
       "source_location": "L86",
       "id": "operator_connectivity_fixture_server",
-      "community": 2
+      "community": 3
     },
     {
       "label": "_missing_groups()",
@@ -9345,7 +9873,7 @@
       "source_file": "scripts/remote-mcp/operator_connectivity.py",
       "source_location": "L98",
       "id": "operator_connectivity_missing_groups",
-      "community": 2
+      "community": 3
     },
     {
       "label": "_launchctl_loaded()",
@@ -9353,7 +9881,7 @@
       "source_file": "scripts/remote-mcp/operator_connectivity.py",
       "source_location": "L106",
       "id": "operator_connectivity_launchctl_loaded",
-      "community": 2
+      "community": 3
     },
     {
       "label": "_launchd_checks()",
@@ -9361,7 +9889,7 @@
       "source_file": "scripts/remote-mcp/operator_connectivity.py",
       "source_location": "L116",
       "id": "operator_connectivity_launchd_checks",
-      "community": 2
+      "community": 3
     },
     {
       "label": "_call_fixture()",
@@ -9369,7 +9897,7 @@
       "source_file": "scripts/remote-mcp/operator_connectivity.py",
       "source_location": "L149",
       "id": "operator_connectivity_call_fixture",
-      "community": 2
+      "community": 3
     },
     {
       "label": "_call_live()",
@@ -9377,7 +9905,7 @@
       "source_file": "scripts/remote-mcp/operator_connectivity.py",
       "source_location": "L168",
       "id": "operator_connectivity_call_live",
-      "community": 2
+      "community": 3
     },
     {
       "label": "build_payload()",
@@ -9385,7 +9913,7 @@
       "source_file": "scripts/remote-mcp/operator_connectivity.py",
       "source_location": "L183",
       "id": "operator_connectivity_build_payload",
-      "community": 2
+      "community": 3
     },
     {
       "label": "build_parser()",
@@ -9393,7 +9921,7 @@
       "source_file": "scripts/remote-mcp/operator_connectivity.py",
       "source_location": "L223",
       "id": "operator_connectivity_build_parser",
-      "community": 2
+      "community": 3
     },
     {
       "label": "main()",
@@ -9401,7 +9929,7 @@
       "source_file": "scripts/remote-mcp/operator_connectivity.py",
       "source_location": "L230",
       "id": "operator_connectivity_main",
-      "community": 2
+      "community": 3
     },
     {
       "label": "operator_inbound_preflight.py",
@@ -9409,7 +9937,7 @@
       "source_file": "scripts/remote-mcp/operator_inbound_preflight.py",
       "source_location": "L1",
       "id": "operator_inbound_preflight",
-      "community": 33
+      "community": 32
     },
     {
       "label": "Check",
@@ -9417,7 +9945,7 @@
       "source_file": "scripts/remote-mcp/operator_inbound_preflight.py",
       "source_location": "L32",
       "id": "operator_inbound_preflight_check",
-      "community": 33
+      "community": 32
     },
     {
       "label": ".to_dict()",
@@ -9425,7 +9953,7 @@
       "source_file": "scripts/remote-mcp/operator_inbound_preflight.py",
       "source_location": "L37",
       "id": "operator_inbound_preflight_check_to_dict",
-      "community": 33
+      "community": 32
     },
     {
       "label": "_missing_groups()",
@@ -9433,7 +9961,7 @@
       "source_file": "scripts/remote-mcp/operator_inbound_preflight.py",
       "source_location": "L41",
       "id": "operator_inbound_preflight_missing_groups",
-      "community": 33
+      "community": 32
     },
     {
       "label": "_fixture_request()",
@@ -9441,7 +9969,7 @@
       "source_file": "scripts/remote-mcp/operator_inbound_preflight.py",
       "source_location": "L49",
       "id": "operator_inbound_preflight_fixture_request",
-      "community": 33
+      "community": 32
     },
     {
       "label": "_packet_summary()",
@@ -9449,7 +9977,7 @@
       "source_file": "scripts/remote-mcp/operator_inbound_preflight.py",
       "source_location": "L68",
       "id": "operator_inbound_preflight_packet_summary",
-      "community": 33
+      "community": 32
     },
     {
       "label": "_call_fixture()",
@@ -9457,7 +9985,7 @@
       "source_file": "scripts/remote-mcp/operator_inbound_preflight.py",
       "source_location": "L81",
       "id": "operator_inbound_preflight_call_fixture",
-      "community": 33
+      "community": 32
     },
     {
       "label": "_latest_live_instruction()",
@@ -9465,7 +9993,7 @@
       "source_file": "scripts/remote-mcp/operator_inbound_preflight.py",
       "source_location": "L121",
       "id": "operator_inbound_preflight_latest_live_instruction",
-      "community": 33
+      "community": 32
     },
     {
       "label": "_call_live()",
@@ -9473,7 +10001,7 @@
       "source_file": "scripts/remote-mcp/operator_inbound_preflight.py",
       "source_location": "L143",
       "id": "operator_inbound_preflight_call_live",
-      "community": 33
+      "community": 32
     },
     {
       "label": "build_payload()",
@@ -9481,7 +10009,7 @@
       "source_file": "scripts/remote-mcp/operator_inbound_preflight.py",
       "source_location": "L154",
       "id": "operator_inbound_preflight_build_payload",
-      "community": 33
+      "community": 32
     },
     {
       "label": "build_parser()",
@@ -9489,7 +10017,7 @@
       "source_file": "scripts/remote-mcp/operator_inbound_preflight.py",
       "source_location": "L200",
       "id": "operator_inbound_preflight_build_parser",
-      "community": 33
+      "community": 32
     },
     {
       "label": "main()",
@@ -9497,7 +10025,7 @@
       "source_file": "scripts/remote-mcp/operator_inbound_preflight.py",
       "source_location": "L207",
       "id": "operator_inbound_preflight_main",
-      "community": 33
+      "community": 32
     },
     {
       "label": "stage_d_smoke.py",
@@ -9505,7 +10033,7 @@
       "source_file": "scripts/remote-mcp/stage_d_smoke.py",
       "source_location": "L1",
       "id": "stage_d_smoke",
-      "community": 11
+      "community": 19
     },
     {
       "label": "ProofResult",
@@ -9513,7 +10041,7 @@
       "source_file": "scripts/remote-mcp/stage_d_smoke.py",
       "source_location": "L39",
       "id": "stage_d_smoke_proofresult",
-      "community": 11
+      "community": 19
     },
     {
       "label": ".to_dict()",
@@ -9521,7 +10049,7 @@
       "source_file": "scripts/remote-mcp/stage_d_smoke.py",
       "source_location": "L44",
       "id": "stage_d_smoke_proofresult_to_dict",
-      "community": 11
+      "community": 19
     },
     {
       "label": "StageDConfig",
@@ -9529,7 +10057,7 @@
       "source_file": "scripts/remote-mcp/stage_d_smoke.py",
       "source_location": "L49",
       "id": "stage_d_smoke_stagedconfig",
-      "community": 11
+      "community": 19
     },
     {
       "label": "from_env()",
@@ -9537,7 +10065,7 @@
       "source_file": "scripts/remote-mcp/stage_d_smoke.py",
       "source_location": "L66",
       "id": "stage_d_smoke_from_env",
-      "community": 11
+      "community": 19
     },
     {
       "label": ".validate_live()",
@@ -9545,7 +10073,7 @@
       "source_file": "scripts/remote-mcp/stage_d_smoke.py",
       "source_location": "L87",
       "id": "stage_d_smoke_stagedconfig_validate_live",
-      "community": 11
+      "community": 19
     },
     {
       "label": "_temporary_resolver()",
@@ -9553,7 +10081,7 @@
       "source_file": "scripts/remote-mcp/stage_d_smoke.py",
       "source_location": "L107",
       "id": "stage_d_smoke_temporary_resolver",
-      "community": 11
+      "community": 19
     },
     {
       "label": "_safe_json_response()",
@@ -9561,7 +10089,7 @@
       "source_file": "scripts/remote-mcp/stage_d_smoke.py",
       "source_location": "L126",
       "id": "stage_d_smoke_safe_json_response",
-      "community": 11
+      "community": 19
     },
     {
       "label": "_request()",
@@ -9569,7 +10097,7 @@
       "source_file": "scripts/remote-mcp/stage_d_smoke.py",
       "source_location": "L134",
       "id": "stage_d_smoke_request",
-      "community": 11
+      "community": 19
     },
     {
       "label": "_expect()",
@@ -9577,7 +10105,7 @@
       "source_file": "scripts/remote-mcp/stage_d_smoke.py",
       "source_location": "L175",
       "id": "stage_d_smoke_expect",
-      "community": 11
+      "community": 19
     },
     {
       "label": "_verify_audit_valid()",
@@ -9585,7 +10113,7 @@
       "source_file": "scripts/remote-mcp/stage_d_smoke.py",
       "source_location": "L179",
       "id": "stage_d_smoke_verify_audit_valid",
-      "community": 11
+      "community": 19
     },
     {
       "label": "_verify_audit_tamper_fails()",
@@ -9593,7 +10121,7 @@
       "source_file": "scripts/remote-mcp/stage_d_smoke.py",
       "source_location": "L190",
       "id": "stage_d_smoke_verify_audit_tamper_fails",
-      "community": 11
+      "community": 19
     },
     {
       "label": "_run_stdio_proof()",
@@ -9601,7 +10129,7 @@
       "source_file": "scripts/remote-mcp/stage_d_smoke.py",
       "source_location": "L217",
       "id": "stage_d_smoke_run_stdio_proof",
-      "community": 11
+      "community": 19
     },
     {
       "label": "run_stage_d()",
@@ -9609,7 +10137,7 @@
       "source_file": "scripts/remote-mcp/stage_d_smoke.py",
       "source_location": "L228",
       "id": "stage_d_smoke_run_stage_d",
-      "community": 11
+      "community": 19
     },
     {
       "label": "_write_fixture_entry()",
@@ -9617,7 +10145,7 @@
       "source_file": "scripts/remote-mcp/stage_d_smoke.py",
       "source_location": "L273",
       "id": "stage_d_smoke_write_fixture_entry",
-      "community": 11
+      "community": 19
     },
     {
       "label": "_build_fixture_server()",
@@ -9625,7 +10153,7 @@
       "source_file": "scripts/remote-mcp/stage_d_smoke.py",
       "source_location": "L318",
       "id": "stage_d_smoke_build_fixture_server",
-      "community": 11
+      "community": 19
     },
     {
       "label": "run_fixture()",
@@ -9633,7 +10161,7 @@
       "source_file": "scripts/remote-mcp/stage_d_smoke.py",
       "source_location": "L375",
       "id": "stage_d_smoke_run_fixture",
-      "community": 11
+      "community": 19
     },
     {
       "label": "build_parser()",
@@ -9641,7 +10169,7 @@
       "source_file": "scripts/remote-mcp/stage_d_smoke.py",
       "source_location": "L414",
       "id": "stage_d_smoke_build_parser",
-      "community": 11
+      "community": 19
     },
     {
       "label": "main()",
@@ -9649,7 +10177,7 @@
       "source_file": "scripts/remote-mcp/stage_d_smoke.py",
       "source_location": "L431",
       "id": "stage_d_smoke_main",
-      "community": 11
+      "community": 19
     },
     {
       "label": "test_live_health_monitor.py",
@@ -9657,7 +10185,7 @@
       "source_file": "scripts/remote-mcp/tests/test_live_health_monitor.py",
       "source_location": "L1",
       "id": "test_live_health_monitor",
-      "community": 11
+      "community": 19
     },
     {
       "label": "test_fixture_monitor_e2e_passes_and_scans_evidence()",
@@ -9665,7 +10193,7 @@
       "source_file": "scripts/remote-mcp/tests/test_live_health_monitor.py",
       "source_location": "L17",
       "id": "test_live_health_monitor_test_fixture_monitor_e2e_passes_and_scans_evidence",
-      "community": 11
+      "community": 19
     },
     {
       "label": "test_live_monitor_fails_fast_without_required_configuration()",
@@ -9673,7 +10201,7 @@
       "source_file": "scripts/remote-mcp/tests/test_live_health_monitor.py",
       "source_location": "L46",
       "id": "test_live_health_monitor_test_live_monitor_fails_fast_without_required_configuration",
-      "community": 11
+      "community": 19
     },
     {
       "label": "test_evidence_scan_rejects_sensitive_material()",
@@ -9681,7 +10209,7 @@
       "source_file": "scripts/remote-mcp/tests/test_live_health_monitor.py",
       "source_location": "L60",
       "id": "test_live_health_monitor_test_evidence_scan_rejects_sensitive_material",
-      "community": 11
+      "community": 19
     },
     {
       "label": "test_monitor_alert.py",
@@ -9745,7 +10273,7 @@
       "source_file": "scripts/remote-mcp/tests/test_operator_connectivity.py",
       "source_location": "L1",
       "id": "test_operator_connectivity",
-      "community": 2
+      "community": 3
     },
     {
       "label": "test_fixture_preflight_proves_request_response_without_live_secrets()",
@@ -9753,7 +10281,7 @@
       "source_file": "scripts/remote-mcp/tests/test_operator_connectivity.py",
       "source_location": "L18",
       "id": "test_operator_connectivity_test_fixture_preflight_proves_request_response_without_live_secrets",
-      "community": 2
+      "community": 3
     },
     {
       "label": "test_live_preflight_fails_closed_before_request_when_config_missing()",
@@ -9761,7 +10289,7 @@
       "source_file": "scripts/remote-mcp/tests/test_operator_connectivity.py",
       "source_location": "L28",
       "id": "test_operator_connectivity_test_live_preflight_fails_closed_before_request_when_config_missing",
-      "community": 2
+      "community": 3
     },
     {
       "label": "test_cli_writes_json_output()",
@@ -9769,7 +10297,7 @@
       "source_file": "scripts/remote-mcp/tests/test_operator_connectivity.py",
       "source_location": "L49",
       "id": "test_operator_connectivity_test_cli_writes_json_output",
-      "community": 2
+      "community": 3
     },
     {
       "label": "test_launchctl_absence_is_non_blocking()",
@@ -9777,7 +10305,7 @@
       "source_file": "scripts/remote-mcp/tests/test_operator_connectivity.py",
       "source_location": "L74",
       "id": "test_operator_connectivity_test_launchctl_absence_is_non_blocking",
-      "community": 2
+      "community": 3
     },
     {
       "label": "test_operator_inbound_preflight.py",
@@ -9785,7 +10313,7 @@
       "source_file": "scripts/remote-mcp/tests/test_operator_inbound_preflight.py",
       "source_location": "L1",
       "id": "test_operator_inbound_preflight",
-      "community": 33
+      "community": 32
     },
     {
       "label": "test_fixture_preflight_proves_session_inbox_receive_path()",
@@ -9793,7 +10321,7 @@
       "source_file": "scripts/remote-mcp/tests/test_operator_inbound_preflight.py",
       "source_location": "L18",
       "id": "test_operator_inbound_preflight_test_fixture_preflight_proves_session_inbox_receive_path",
-      "community": 33
+      "community": 32
     },
     {
       "label": "test_live_preflight_fails_closed_when_config_missing()",
@@ -9801,7 +10329,7 @@
       "source_file": "scripts/remote-mcp/tests/test_operator_inbound_preflight.py",
       "source_location": "L31",
       "id": "test_operator_inbound_preflight_test_live_preflight_fails_closed_when_config_missing",
-      "community": 33
+      "community": 32
     },
     {
       "label": "test_live_preflight_fails_when_session_inbox_has_no_instruction()",
@@ -9809,7 +10337,7 @@
       "source_file": "scripts/remote-mcp/tests/test_operator_inbound_preflight.py",
       "source_location": "L47",
       "id": "test_operator_inbound_preflight_test_live_preflight_fails_when_session_inbox_has_no_instruction",
-      "community": 33
+      "community": 32
     },
     {
       "label": "test_cli_writes_json_output()",
@@ -9817,7 +10345,7 @@
       "source_file": "scripts/remote-mcp/tests/test_operator_inbound_preflight.py",
       "source_location": "L62",
       "id": "test_operator_inbound_preflight_test_cli_writes_json_output",
-      "community": 33
+      "community": 32
     },
     {
       "label": "test_stage_d_smoke.py",
@@ -9825,7 +10353,7 @@
       "source_file": "scripts/remote-mcp/tests/test_stage_d_smoke.py",
       "source_location": "L1",
       "id": "test_stage_d_smoke",
-      "community": 11
+      "community": 2
     },
     {
       "label": "test_stage_d_fixture_e2e_passes()",
@@ -9833,7 +10361,7 @@
       "source_file": "scripts/remote-mcp/tests/test_stage_d_smoke.py",
       "source_location": "L20",
       "id": "test_stage_d_smoke_test_stage_d_fixture_e2e_passes",
-      "community": 11
+      "community": 2
     },
     {
       "label": "test_stage_d_live_mode_fails_fast_without_required_env()",
@@ -9841,7 +10369,7 @@
       "source_file": "scripts/remote-mcp/tests/test_stage_d_smoke.py",
       "source_location": "L61",
       "id": "test_stage_d_smoke_test_stage_d_live_mode_fails_fast_without_required_env",
-      "community": 11
+      "community": 2
     },
     {
       "label": "test_stage_d_request_adds_configured_user_agent()",
@@ -9849,7 +10377,7 @@
       "source_file": "scripts/remote-mcp/tests/test_stage_d_smoke.py",
       "source_location": "L74",
       "id": "test_stage_d_smoke_test_stage_d_request_adds_configured_user_agent",
-      "community": 11
+      "community": 2
     },
     {
       "label": "test_verify_audit.py",
@@ -9857,7 +10385,7 @@
       "source_file": "scripts/remote-mcp/tests/test_verify_audit.py",
       "source_location": "L1",
       "id": "test_verify_audit",
-      "community": 3
+      "community": 2
     },
     {
       "label": "_build_entry()",
@@ -9865,7 +10393,7 @@
       "source_file": "scripts/remote-mcp/tests/test_verify_audit.py",
       "source_location": "L19",
       "id": "test_verify_audit_build_entry",
-      "community": 3
+      "community": 2
     },
     {
       "label": "_write_audit_file()",
@@ -9873,7 +10401,7 @@
       "source_file": "scripts/remote-mcp/tests/test_verify_audit.py",
       "source_location": "L48",
       "id": "test_verify_audit_write_audit_file",
-      "community": 3
+      "community": 2
     },
     {
       "label": "_make_chain_entries()",
@@ -9881,7 +10409,7 @@
       "source_file": "scripts/remote-mcp/tests/test_verify_audit.py",
       "source_location": "L64",
       "id": "test_verify_audit_make_chain_entries",
-      "community": 3
+      "community": 2
     },
     {
       "label": "test_verify_audit_valid_chain_passes()",
@@ -9889,7 +10417,7 @@
       "source_file": "scripts/remote-mcp/tests/test_verify_audit.py",
       "source_location": "L82",
       "id": "test_verify_audit_test_verify_audit_valid_chain_passes",
-      "community": 3
+      "community": 2
     },
     {
       "label": "test_verify_audit_tamper_detects_chain_break()",
@@ -9897,7 +10425,7 @@
       "source_file": "scripts/remote-mcp/tests/test_verify_audit.py",
       "source_location": "L98",
       "id": "test_verify_audit_test_verify_audit_tamper_detects_chain_break",
-      "community": 3
+      "community": 2
     },
     {
       "label": "test_verify_audit_require_hmac_key_fails_when_missing()",
@@ -9905,7 +10433,7 @@
       "source_file": "scripts/remote-mcp/tests/test_verify_audit.py",
       "source_location": "L120",
       "id": "test_verify_audit_test_verify_audit_require_hmac_key_fails_when_missing",
-      "community": 3
+      "community": 2
     },
     {
       "label": "test_verify_audit_absent_dir_is_noop()",
@@ -9913,7 +10441,7 @@
       "source_file": "scripts/remote-mcp/tests/test_verify_audit.py",
       "source_location": "L144",
       "id": "test_verify_audit_test_verify_audit_absent_dir_is_noop",
-      "community": 3
+      "community": 2
     },
     {
       "label": "verify_audit.py",
@@ -9921,7 +10449,7 @@
       "source_file": "scripts/windows-ollama/verify_audit.py",
       "source_location": "L1",
       "id": "verify_audit",
-      "community": 3
+      "community": 2
     },
     {
       "label": "canonical_json()",
@@ -9929,7 +10457,7 @@
       "source_file": "scripts/windows-ollama/verify_audit.py",
       "source_location": "L15",
       "id": "verify_audit_canonical_json",
-      "community": 3
+      "community": 2
     },
     {
       "label": "compute_sha256()",
@@ -9937,7 +10465,7 @@
       "source_file": "scripts/windows-ollama/verify_audit.py",
       "source_location": "L25",
       "id": "verify_audit_compute_sha256",
-      "community": 3
+      "community": 2
     },
     {
       "label": "compute_entry_hmac()",
@@ -9945,7 +10473,7 @@
       "source_file": "scripts/windows-ollama/verify_audit.py",
       "source_location": "L32",
       "id": "verify_audit_compute_entry_hmac",
-      "community": 3
+      "community": 2
     },
     {
       "label": "compute_entry_hash()",
@@ -9953,7 +10481,7 @@
       "source_file": "scripts/remote-mcp/verify_audit.py",
       "source_location": "L63",
       "id": "verify_audit_compute_entry_hash",
-      "community": 3
+      "community": 2
     },
     {
       "label": "_read_jsonl()",
@@ -9961,7 +10489,7 @@
       "source_file": "scripts/remote-mcp/verify_audit.py",
       "source_location": "L69",
       "id": "verify_audit_read_jsonl",
-      "community": 3
+      "community": 2
     },
     {
       "label": "_validate_schema()",
@@ -9969,7 +10497,7 @@
       "source_file": "scripts/remote-mcp/verify_audit.py",
       "source_location": "L87",
       "id": "verify_audit_validate_schema",
-      "community": 3
+      "community": 2
     },
     {
       "label": "_verify_sequence()",
@@ -9977,7 +10505,7 @@
       "source_file": "scripts/remote-mcp/verify_audit.py",
       "source_location": "L108",
       "id": "verify_audit_verify_sequence",
-      "community": 3
+      "community": 2
     },
     {
       "label": "_verify_chain()",
@@ -9985,7 +10513,7 @@
       "source_file": "scripts/remote-mcp/verify_audit.py",
       "source_location": "L119",
       "id": "verify_audit_verify_chain",
-      "community": 3
+      "community": 2
     },
     {
       "label": "_verify_manifest()",
@@ -9993,7 +10521,7 @@
       "source_file": "scripts/remote-mcp/verify_audit.py",
       "source_location": "L131",
       "id": "verify_audit_verify_manifest",
-      "community": 3
+      "community": 2
     },
     {
       "label": "_collect_file_errors()",
@@ -10001,7 +10529,7 @@
       "source_file": "scripts/remote-mcp/verify_audit.py",
       "source_location": "L178",
       "id": "verify_audit_collect_file_errors",
-      "community": 3
+      "community": 2
     },
     {
       "label": "verify_audit_dir()",
@@ -10009,7 +10537,7 @@
       "source_file": "scripts/windows-ollama/verify_audit.py",
       "source_location": "L52",
       "id": "verify_audit_verify_audit_dir",
-      "community": 3
+      "community": 2
     },
     {
       "label": "parse_args()",
@@ -10017,7 +10545,7 @@
       "source_file": "scripts/remote-mcp/verify_audit.py",
       "source_location": "L235",
       "id": "verify_audit_parse_args",
-      "community": 3
+      "community": 2
     },
     {
       "label": "main()",
@@ -10025,7 +10553,7 @@
       "source_file": "scripts/windows-ollama/verify_audit.py",
       "source_location": "L180",
       "id": "verify_audit_main",
-      "community": 3
+      "community": 2
     },
     {
       "label": "Return canonical JSON bytes for cryptographic checks.",
@@ -10033,7 +10561,7 @@
       "source_file": "scripts/remote-mcp/verify_audit.py",
       "source_location": "L44",
       "id": "verify_audit_rationale_44",
-      "community": 3
+      "community": 2
     },
     {
       "label": "Compute SHA-256 hex digest.",
@@ -10041,7 +10569,7 @@
       "source_file": "scripts/remote-mcp/verify_audit.py",
       "source_location": "L51",
       "id": "verify_audit_rationale_51",
-      "community": 3
+      "community": 2
     },
     {
       "label": "Compute entry HMAC over every field except `entry_hmac` itself.",
@@ -10049,7 +10577,7 @@
       "source_file": "scripts/remote-mcp/verify_audit.py",
       "source_location": "L58",
       "id": "verify_audit_rationale_58",
-      "community": 3
+      "community": 2
     },
     {
       "label": "Compute chain hash for one entry.",
@@ -10057,7 +10585,7 @@
       "source_file": "scripts/remote-mcp/verify_audit.py",
       "source_location": "L64",
       "id": "verify_audit_rationale_64",
-      "community": 3
+      "community": 2
     },
     {
       "label": "Read a JSONL file into (line_no, payload) tuples.",
@@ -10065,7 +10593,7 @@
       "source_file": "scripts/remote-mcp/verify_audit.py",
       "source_location": "L70",
       "id": "verify_audit_rationale_70",
-      "community": 3
+      "community": 2
     },
     {
       "label": "Validate required fields and coarse types.",
@@ -10073,7 +10601,7 @@
       "source_file": "scripts/remote-mcp/verify_audit.py",
       "source_location": "L88",
       "id": "verify_audit_rationale_88",
-      "community": 3
+      "community": 2
     },
     {
       "label": "Verify all JSONL files under an audit directory.     Returns (success, errors).",
@@ -10081,7 +10609,7 @@
       "source_file": "scripts/remote-mcp/verify_audit.py",
       "source_location": "L217",
       "id": "verify_audit_rationale_217",
-      "community": 3
+      "community": 2
     },
     {
       "label": "som_client.py",
@@ -10089,7 +10617,7 @@
       "source_file": "scripts/som-client/som_client.py",
       "source_location": "L1",
       "id": "som_client",
-      "community": 2
+      "community": 3
     },
     {
       "label": "SomClientError",
@@ -10097,7 +10625,7 @@
       "source_file": "scripts/som-client/som_client.py",
       "source_location": "L31",
       "id": "som_client_somclienterror",
-      "community": 2
+      "community": 3
     },
     {
       "label": ".__init__()",
@@ -10105,7 +10633,7 @@
       "source_file": "scripts/som-client/som_client.py",
       "source_location": "L34",
       "id": "som_client_somclienterror_init",
-      "community": 2
+      "community": 3
     },
     {
       "label": ".to_dict()",
@@ -10113,7 +10641,7 @@
       "source_file": "scripts/som-client/som_client.py",
       "source_location": "L47",
       "id": "som_client_somclienterror_to_dict",
-      "community": 2
+      "community": 3
     },
     {
       "label": "_decode_jwt_payload()",
@@ -10121,7 +10649,7 @@
       "source_file": "scripts/som-client/som_client.py",
       "source_location": "L56",
       "id": "som_client_decode_jwt_payload",
-      "community": 2
+      "community": 3
     },
     {
       "label": "_unix_now()",
@@ -10129,7 +10657,7 @@
       "source_file": "scripts/som-client/som_client.py",
       "source_location": "L70",
       "id": "som_client_unix_now",
-      "community": 2
+      "community": 3
     },
     {
       "label": "SomClientConfig",
@@ -10137,7 +10665,7 @@
       "source_file": "scripts/som-client/som_client.py",
       "source_location": "L75",
       "id": "som_client_somclientconfig",
-      "community": 2
+      "community": 3
     },
     {
       "label": "SomClient",
@@ -10145,7 +10673,7 @@
       "source_file": "scripts/som-client/som_client.py",
       "source_location": "L90",
       "id": "som_client_somclient",
-      "community": 2
+      "community": 3
     },
     {
       "label": ".__init__()",
@@ -10153,7 +10681,7 @@
       "source_file": "scripts/som-client/som_client.py",
       "source_location": "L93",
       "id": "som_client_somclient_init",
-      "community": 2
+      "community": 3
     },
     {
       "label": "from_env()",
@@ -10161,7 +10689,7 @@
       "source_file": "scripts/som-client/som_client.py",
       "source_location": "L98",
       "id": "som_client_from_env",
-      "community": 2
+      "community": 3
     },
     {
       "label": "._current_token()",
@@ -10169,7 +10697,7 @@
       "source_file": "scripts/som-client/som_client.py",
       "source_location": "L114",
       "id": "som_client_somclient_current_token",
-      "community": 2
+      "community": 3
     },
     {
       "label": "._headers()",
@@ -10177,7 +10705,7 @@
       "source_file": "scripts/som-client/som_client.py",
       "source_location": "L132",
       "id": "som_client_somclient_headers",
-      "community": 2
+      "community": 3
     },
     {
       "label": "._request()",
@@ -10185,7 +10713,7 @@
       "source_file": "scripts/som-client/som_client.py",
       "source_location": "L152",
       "id": "som_client_somclient_request",
-      "community": 2
+      "community": 3
     },
     {
       "label": "._call_tool()",
@@ -10193,7 +10721,7 @@
       "source_file": "scripts/som-client/som_client.py",
       "source_location": "L219",
       "id": "som_client_somclient_call_tool",
-      "community": 2
+      "community": 3
     },
     {
       "label": ".ping()",
@@ -10201,7 +10729,7 @@
       "source_file": "scripts/som-client/som_client.py",
       "source_location": "L250",
       "id": "som_client_somclient_ping",
-      "community": 2
+      "community": 3
     },
     {
       "label": ".handoff()",
@@ -10209,7 +10737,7 @@
       "source_file": "scripts/som-client/som_client.py",
       "source_location": "L253",
       "id": "som_client_somclient_handoff",
-      "community": 2
+      "community": 3
     },
     {
       "label": ".chain()",
@@ -10217,7 +10745,7 @@
       "source_file": "scripts/som-client/som_client.py",
       "source_location": "L265",
       "id": "som_client_somclient_chain",
-      "community": 2
+      "community": 3
     },
     {
       "label": ".log_fallback()",
@@ -10225,7 +10753,7 @@
       "source_file": "scripts/som-client/som_client.py",
       "source_location": "L268",
       "id": "som_client_somclient_log_fallback",
-      "community": 2
+      "community": 3
     },
     {
       "label": ".lam_probe()",
@@ -10233,7 +10761,7 @@
       "source_file": "scripts/som-client/som_client.py",
       "source_location": "L271",
       "id": "som_client_somclient_lam_probe",
-      "community": 2
+      "community": 3
     },
     {
       "label": ".lam_embed()",
@@ -10241,7 +10769,7 @@
       "source_file": "scripts/som-client/som_client.py",
       "source_location": "L274",
       "id": "som_client_somclient_lam_embed",
-      "community": 2
+      "community": 3
     },
     {
       "label": "build_parser()",
@@ -10249,7 +10777,7 @@
       "source_file": "scripts/som-client/som_client.py",
       "source_location": "L281",
       "id": "som_client_build_parser",
-      "community": 2
+      "community": 3
     },
     {
       "label": "main()",
@@ -10257,7 +10785,7 @@
       "source_file": "scripts/som-client/som_client.py",
       "source_location": "L286",
       "id": "som_client_main",
-      "community": 2
+      "community": 3
     },
     {
       "label": "Error raised for client-side protocol and transport failures.",
@@ -10265,7 +10793,7 @@
       "source_file": "scripts/som-client/som_client.py",
       "source_location": "L32",
       "id": "som_client_rationale_32",
-      "community": 2
+      "community": 3
     },
     {
       "label": "Decode JWT payload without verifying signature.",
@@ -10273,7 +10801,7 @@
       "source_file": "scripts/som-client/som_client.py",
       "source_location": "L57",
       "id": "som_client_rationale_57",
-      "community": 2
+      "community": 3
     },
     {
       "label": "Minimal HTTP client for Remote MCP Bridge tools.",
@@ -10281,7 +10809,7 @@
       "source_file": "scripts/som-client/som_client.py",
       "source_location": "L91",
       "id": "som_client_rationale_91",
-      "community": 2
+      "community": 3
     },
     {
       "label": "Build a client from well-known environment variables.",
@@ -10297,7 +10825,7 @@
       "source_file": "scripts/som-client/tests/test_som_client.py",
       "source_location": "L1",
       "id": "test_som_client",
-      "community": 2
+      "community": 3
     },
     {
       "label": "_build_success_response()",
@@ -10305,7 +10833,7 @@
       "source_file": "scripts/som-client/tests/test_som_client.py",
       "source_location": "L23",
       "id": "test_som_client_build_success_response",
-      "community": 2
+      "community": 3
     },
     {
       "label": "_build_http_error()",
@@ -10313,7 +10841,7 @@
       "source_file": "scripts/som-client/tests/test_som_client.py",
       "source_location": "L32",
       "id": "test_som_client_build_http_error",
-      "community": 2
+      "community": 3
     },
     {
       "label": "test_som_client_sends_cf_and_bearer_headers()",
@@ -10321,7 +10849,7 @@
       "source_file": "scripts/som-client/tests/test_som_client.py",
       "source_location": "L46",
       "id": "test_som_client_test_som_client_sends_cf_and_bearer_headers",
-      "community": 2
+      "community": 3
     },
     {
       "label": "test_som_client_accepts_remote_mcp_jwt_fallback()",
@@ -10329,7 +10857,7 @@
       "source_file": "scripts/som-client/tests/test_som_client.py",
       "source_location": "L70",
       "id": "test_som_client_test_som_client_accepts_remote_mcp_jwt_fallback",
-      "community": 2
+      "community": 3
     },
     {
       "label": "test_som_client_bridge_protocol_uses_stage_bc_shape()",
@@ -10337,7 +10865,7 @@
       "source_file": "scripts/som-client/tests/test_som_client.py",
       "source_location": "L88",
       "id": "test_som_client_test_som_client_bridge_protocol_uses_stage_bc_shape",
-      "community": 2
+      "community": 3
     },
     {
       "label": "test_som_client_retries_on_429()",
@@ -10345,7 +10873,7 @@
       "source_file": "scripts/som-client/tests/test_som_client.py",
       "source_location": "L109",
       "id": "test_som_client_test_som_client_retries_on_429",
-      "community": 2
+      "community": 3
     },
     {
       "label": "test_som_client_payload_safe_errors()",
@@ -10353,7 +10881,7 @@
       "source_file": "scripts/som-client/tests/test_som_client.py",
       "source_location": "L141",
       "id": "test_som_client_test_som_client_payload_safe_errors",
-      "community": 2
+      "community": 3
     },
     {
       "label": "test_bootstrap_repo_env_contract.py",
@@ -10361,7 +10889,7 @@
       "source_file": "scripts/test_bootstrap_repo_env_contract.py",
       "source_location": "L1",
       "id": "test_bootstrap_repo_env_contract",
-      "community": 45
+      "community": 43
     },
     {
       "label": "check()",
@@ -10369,7 +10897,7 @@
       "source_file": "scripts/test_bootstrap_repo_env_contract.py",
       "source_location": "L17",
       "id": "test_bootstrap_repo_env_contract_check",
-      "community": 45
+      "community": 43
     },
     {
       "label": "main()",
@@ -10377,7 +10905,7 @@
       "source_file": "scripts/test_bootstrap_repo_env_contract.py",
       "source_location": "L22",
       "id": "test_bootstrap_repo_env_contract_main",
-      "community": 45
+      "community": 43
     },
     {
       "label": "run_synthetic_lam_bootstrap()",
@@ -10385,7 +10913,7 @@
       "source_file": "scripts/test_bootstrap_repo_env_contract.py",
       "source_location": "L93",
       "id": "test_bootstrap_repo_env_contract_run_synthetic_lam_bootstrap",
-      "community": 45
+      "community": 43
     },
     {
       "label": "run_sibling_worktree_lam_bootstrap()",
@@ -10393,7 +10921,7 @@
       "source_file": "scripts/test_bootstrap_repo_env_contract.py",
       "source_location": "L168",
       "id": "test_bootstrap_repo_env_contract_run_sibling_worktree_lam_bootstrap",
-      "community": 45
+      "community": 43
     },
     {
       "label": "run_nested_var_worktree_lam_bootstrap()",
@@ -10401,7 +10929,7 @@
       "source_file": "scripts/test_bootstrap_repo_env_contract.py",
       "source_location": "L218",
       "id": "test_bootstrap_repo_env_contract_run_nested_var_worktree_lam_bootstrap",
-      "community": 45
+      "community": 43
     },
     {
       "label": "run_synthetic_seek_bootstrap()",
@@ -10409,7 +10937,7 @@
       "source_file": "scripts/test_bootstrap_repo_env_contract.py",
       "source_location": "L263",
       "id": "test_bootstrap_repo_env_contract_run_synthetic_seek_bootstrap",
-      "community": 45
+      "community": 43
     },
     {
       "label": "run_synthetic_stampede_bootstrap()",
@@ -10417,7 +10945,7 @@
       "source_file": "scripts/test_bootstrap_repo_env_contract.py",
       "source_location": "L322",
       "id": "test_bootstrap_repo_env_contract_run_synthetic_stampede_bootstrap",
-      "community": 45
+      "community": 43
     },
     {
       "label": "Exercise lam bootstrap with command-like vault values and missing optional keys.",
@@ -10425,7 +10953,7 @@
       "source_file": "scripts/test_bootstrap_repo_env_contract.py",
       "source_location": "L94",
       "id": "test_bootstrap_repo_env_contract_rationale_94",
-      "community": 45
+      "community": 43
     },
     {
       "label": "Exercise vault discovery from sibling governance worktrees.",
@@ -10433,7 +10961,7 @@
       "source_file": "scripts/test_bootstrap_repo_env_contract.py",
       "source_location": "L169",
       "id": "test_bootstrap_repo_env_contract_rationale_169",
-      "community": 45
+      "community": 43
     },
     {
       "label": "Exercise vault discovery from HLDPRO/var/worktrees/* governance worktrees.",
@@ -10441,7 +10969,7 @@
       "source_file": "scripts/test_bootstrap_repo_env_contract.py",
       "source_location": "L219",
       "id": "test_bootstrap_repo_env_contract_rationale_219",
-      "community": 45
+      "community": 43
     },
     {
       "label": "Exercise Seek/Ponder bootstrap aliases without leaking synthetic values.",
@@ -10449,7 +10977,7 @@
       "source_file": "scripts/test_bootstrap_repo_env_contract.py",
       "source_location": "L264",
       "id": "test_bootstrap_repo_env_contract_rationale_264",
-      "community": 45
+      "community": 43
     },
     {
       "label": "Exercise Stampede bootstrap with production Tradier mapping and redaction.",
@@ -10457,7 +10985,7 @@
       "source_file": "scripts/test_bootstrap_repo_env_contract.py",
       "source_location": "L323",
       "id": "test_bootstrap_repo_env_contract_rationale_323",
-      "community": 45
+      "community": 43
     },
     {
       "label": "test_cli_session_supervisor.py",
@@ -10465,7 +10993,7 @@
       "source_file": "scripts/test_cli_session_supervisor.py",
       "source_location": "L1",
       "id": "test_cli_session_supervisor",
-      "community": 53
+      "community": 54
     },
     {
       "label": "write_fake()",
@@ -10473,7 +11001,7 @@
       "source_file": "scripts/test_cli_session_supervisor.py",
       "source_location": "L12",
       "id": "test_cli_session_supervisor_write_fake",
-      "community": 53
+      "community": 54
     },
     {
       "label": "run_supervisor()",
@@ -10481,7 +11009,7 @@
       "source_file": "scripts/test_cli_session_supervisor.py",
       "source_location": "L18",
       "id": "test_cli_session_supervisor_run_supervisor",
-      "community": 53
+      "community": 54
     },
     {
       "label": "events()",
@@ -10489,7 +11017,7 @@
       "source_file": "scripts/test_cli_session_supervisor.py",
       "source_location": "L58",
       "id": "test_cli_session_supervisor_events",
-      "community": 53
+      "community": 54
     },
     {
       "label": "test_success_event_captures_stdout_and_schema_fields()",
@@ -10497,7 +11025,7 @@
       "source_file": "scripts/test_cli_session_supervisor.py",
       "source_location": "L63",
       "id": "test_cli_session_supervisor_test_success_event_captures_stdout_and_schema_fields",
-      "community": 53
+      "community": 54
     },
     {
       "label": "test_nonzero_failure_is_recorded_without_retry()",
@@ -10505,7 +11033,7 @@
       "source_file": "scripts/test_cli_session_supervisor.py",
       "source_location": "L86",
       "id": "test_cli_session_supervisor_test_nonzero_failure_is_recorded_without_retry",
-      "community": 53
+      "community": 54
     },
     {
       "label": "test_silent_stall_hits_idle_timeout_and_kills_process()",
@@ -10513,7 +11041,7 @@
       "source_file": "scripts/test_cli_session_supervisor.py",
       "source_location": "L104",
       "id": "test_cli_session_supervisor_test_silent_stall_hits_idle_timeout_and_kills_process",
-      "community": 53
+      "community": 54
     },
     {
       "label": "test_intermittent_output_avoids_idle_timeout()",
@@ -10521,7 +11049,7 @@
       "source_file": "scripts/test_cli_session_supervisor.py",
       "source_location": "L121",
       "id": "test_cli_session_supervisor_test_intermittent_output_avoids_idle_timeout",
-      "community": 53
+      "community": 54
     },
     {
       "label": "test_total_timeout_overrides_active_output()",
@@ -10529,7 +11057,7 @@
       "source_file": "scripts/test_cli_session_supervisor.py",
       "source_location": "L140",
       "id": "test_cli_session_supervisor_test_total_timeout_overrides_active_output",
-      "community": 53
+      "community": 54
     },
     {
       "label": "test_retry_once_can_recover_from_timeout()",
@@ -10537,7 +11065,7 @@
       "source_file": "scripts/test_cli_session_supervisor.py",
       "source_location": "L159",
       "id": "test_cli_session_supervisor_test_retry_once_can_recover_from_timeout",
-      "community": 53
+      "community": 54
     },
     {
       "label": "test_retry_halts_after_one_additional_timeout()",
@@ -10545,7 +11073,7 @@
       "source_file": "scripts/test_cli_session_supervisor.py",
       "source_location": "L194",
       "id": "test_cli_session_supervisor_test_retry_halts_after_one_additional_timeout",
-      "community": 53
+      "community": 54
     },
     {
       "label": "test_codex_fire.py",
@@ -11137,7 +11665,7 @@
       "source_file": "scripts/windows-ollama/tests/test_audit.py",
       "source_location": "L1",
       "id": "test_audit",
-      "community": 3
+      "community": 2
     },
     {
       "label": "TestAuditChainIntegrity",
@@ -11145,7 +11673,7 @@
       "source_file": "scripts/windows-ollama/tests/test_audit.py",
       "source_location": "L20",
       "id": "test_audit_testauditchainintegrity",
-      "community": 3
+      "community": 2
     },
     {
       "label": ".test_tamper_line_breaks_chain()",
@@ -11153,7 +11681,7 @@
       "source_file": "scripts/windows-ollama/tests/test_audit.py",
       "source_location": "L23",
       "id": "test_audit_testauditchainintegrity_test_tamper_line_breaks_chain",
-      "community": 3
+      "community": 2
     },
     {
       "label": "TestHmacForgery",
@@ -11161,7 +11689,7 @@
       "source_file": "scripts/windows-ollama/tests/test_audit.py",
       "source_location": "L61",
       "id": "test_audit_testhmacforgery",
-      "community": 3
+      "community": 2
     },
     {
       "label": ".test_hmac_forgery_detected()",
@@ -11169,7 +11697,7 @@
       "source_file": "scripts/windows-ollama/tests/test_audit.py",
       "source_location": "L64",
       "id": "test_audit_testhmacforgery_test_hmac_forgery_detected",
-      "community": 3
+      "community": 2
     },
     {
       "label": "TestManifestMismatch",
@@ -11177,7 +11705,7 @@
       "source_file": "scripts/windows-ollama/tests/test_audit.py",
       "source_location": "L97",
       "id": "test_audit_testmanifestmismatch",
-      "community": 3
+      "community": 2
     },
     {
       "label": ".test_manifest_first_hash_mismatch()",
@@ -11185,7 +11713,7 @@
       "source_file": "scripts/windows-ollama/tests/test_audit.py",
       "source_location": "L100",
       "id": "test_audit_testmanifestmismatch_test_manifest_first_hash_mismatch",
-      "community": 3
+      "community": 2
     },
     {
       "label": "TestFileTruncation",
@@ -11193,7 +11721,7 @@
       "source_file": "scripts/windows-ollama/tests/test_audit.py",
       "source_location": "L130",
       "id": "test_audit_testfiletruncation",
-      "community": 3
+      "community": 2
     },
     {
       "label": ".test_file_truncation_detected()",
@@ -11201,7 +11729,7 @@
       "source_file": "scripts/windows-ollama/tests/test_audit.py",
       "source_location": "L133",
       "id": "test_audit_testfiletruncation_test_file_truncation_detected",
-      "community": 3
+      "community": 2
     },
     {
       "label": "TestReplay",
@@ -11209,7 +11737,7 @@
       "source_file": "scripts/windows-ollama/tests/test_audit.py",
       "source_location": "L164",
       "id": "test_audit_testreplay",
-      "community": 3
+      "community": 2
     },
     {
       "label": ".test_duplicate_line_detected()",
@@ -11217,7 +11745,7 @@
       "source_file": "scripts/windows-ollama/tests/test_audit.py",
       "source_location": "L167",
       "id": "test_audit_testreplay_test_duplicate_line_detected",
-      "community": 3
+      "community": 2
     },
     {
       "label": "Test that tampering with a line breaks the chain.",
@@ -11225,7 +11753,7 @@
       "source_file": "scripts/windows-ollama/tests/test_audit.py",
       "source_location": "L21",
       "id": "test_audit_rationale_21",
-      "community": 3
+      "community": 2
     },
     {
       "label": "Tamper with line N and verify fails at line N+1.",
@@ -11233,7 +11761,7 @@
       "source_file": "scripts/windows-ollama/tests/test_audit.py",
       "source_location": "L24",
       "id": "test_audit_rationale_24",
-      "community": 3
+      "community": 2
     },
     {
       "label": "Test that replacing entry_hmac with wrong value fails verification.",
@@ -11241,7 +11769,7 @@
       "source_file": "scripts/windows-ollama/tests/test_audit.py",
       "source_location": "L62",
       "id": "test_audit_rationale_62",
-      "community": 3
+      "community": 2
     },
     {
       "label": "Replace entry_hmac with wrong value and verify fails.",
@@ -11249,7 +11777,7 @@
       "source_file": "scripts/windows-ollama/tests/test_audit.py",
       "source_location": "L65",
       "id": "test_audit_rationale_65",
-      "community": 3
+      "community": 2
     },
     {
       "label": "Test that modifying manifest fails verification.",
@@ -11257,7 +11785,7 @@
       "source_file": "scripts/windows-ollama/tests/test_audit.py",
       "source_location": "L98",
       "id": "test_audit_rationale_98",
-      "community": 3
+      "community": 2
     },
     {
       "label": "Modify first_hash in manifest and verify fails.",
@@ -11265,7 +11793,7 @@
       "source_file": "scripts/windows-ollama/tests/test_audit.py",
       "source_location": "L101",
       "id": "test_audit_rationale_101",
-      "community": 3
+      "community": 2
     },
     {
       "label": "Test that truncated file (missing last line) breaks manifest.",
@@ -11273,7 +11801,7 @@
       "source_file": "scripts/windows-ollama/tests/test_audit.py",
       "source_location": "L131",
       "id": "test_audit_rationale_131",
-      "community": 3
+      "community": 2
     },
     {
       "label": "Delete last line and verify detects entry_count mismatch.",
@@ -11281,7 +11809,7 @@
       "source_file": "scripts/windows-ollama/tests/test_audit.py",
       "source_location": "L134",
       "id": "test_audit_rationale_134",
-      "community": 3
+      "community": 2
     },
     {
       "label": "Test that duplicate line (replay) breaks seq monotonicity.",
@@ -11289,7 +11817,7 @@
       "source_file": "scripts/windows-ollama/tests/test_audit.py",
       "source_location": "L165",
       "id": "test_audit_rationale_165",
-      "community": 3
+      "community": 2
     },
     {
       "label": "Duplicate a line and verify detects non-monotonic seq.",
@@ -11297,7 +11825,7 @@
       "source_file": "scripts/windows-ollama/tests/test_audit.py",
       "source_location": "L168",
       "id": "test_audit_rationale_168",
-      "community": 3
+      "community": 2
     },
     {
       "label": "test_submit.py",
@@ -11793,7 +12321,7 @@
       "source_file": "scripts/windows-ollama/verify_audit.py",
       "source_location": "L45",
       "id": "verify_audit_verify_hmac",
-      "community": 3
+      "community": 2
     },
     {
       "label": "Return canonical JSON for HMAC computation.",
@@ -11801,7 +12329,7 @@
       "source_file": "scripts/windows-ollama/verify_audit.py",
       "source_location": "L16",
       "id": "verify_audit_rationale_16",
-      "community": 3
+      "community": 2
     },
     {
       "label": "Compute SHA256 hash of bytes.",
@@ -11809,7 +12337,7 @@
       "source_file": "scripts/windows-ollama/verify_audit.py",
       "source_location": "L26",
       "id": "verify_audit_rationale_26",
-      "community": 3
+      "community": 2
     },
     {
       "label": "Compute HMAC-SHA256 over entry without entry_hmac field.",
@@ -11817,7 +12345,7 @@
       "source_file": "scripts/windows-ollama/verify_audit.py",
       "source_location": "L33",
       "id": "verify_audit_rationale_33",
-      "community": 3
+      "community": 2
     },
     {
       "label": "Safely compare HMACs using constant-time comparison.",
@@ -11825,7 +12353,7 @@
       "source_file": "scripts/windows-ollama/verify_audit.py",
       "source_location": "L46",
       "id": "verify_audit_rationale_46",
-      "community": 3
+      "community": 2
     },
     {
       "label": "Verify all audit logs in the directory.     Returns (success: bool, errors: list",
@@ -11833,7 +12361,7 @@
       "source_file": "scripts/windows-ollama/verify_audit.py",
       "source_location": "L53",
       "id": "verify_audit_rationale_53",
-      "community": 3
+      "community": 2
     },
     {
       "label": "test_codex_ingestion.py",
@@ -11841,7 +12369,7 @@
       "source_file": "tests/test_codex_ingestion.py",
       "source_location": "L1",
       "id": "test_codex_ingestion",
-      "community": 6
+      "community": 7
     },
     {
       "label": "ValidateLocationTests",
@@ -11849,7 +12377,7 @@
       "source_file": "tests/test_codex_ingestion.py",
       "source_location": "L15",
       "id": "test_codex_ingestion_validatelocationtests",
-      "community": 6
+      "community": 7
     },
     {
       "label": ".test_rejects_hallucinated_anchor_on_valid_line()",
@@ -11857,7 +12385,7 @@
       "source_file": "tests/test_codex_ingestion.py",
       "source_location": "L16",
       "id": "test_codex_ingestion_validatelocationtests_test_rejects_hallucinated_anchor_on_valid_line",
-      "community": 6
+      "community": 7
     },
     {
       "label": ".test_accepts_matching_anchor_on_valid_line()",
@@ -11865,7 +12393,7 @@
       "source_file": "tests/test_codex_ingestion.py",
       "source_location": "L38",
       "id": "test_codex_ingestion_validatelocationtests_test_accepts_matching_anchor_on_valid_line",
-      "community": 6
+      "community": 7
     },
     {
       "label": "test_progress_github_issue_staleness.py",
@@ -11873,7 +12401,7 @@
       "source_file": "tests/test_progress_github_issue_staleness.py",
       "source_location": "L1",
       "id": "test_progress_github_issue_staleness",
-      "community": 37
+      "community": 34
     },
     {
       "label": "ProgressGithubIssueStalenessTests",
@@ -11881,7 +12409,7 @@
       "source_file": "tests/test_progress_github_issue_staleness.py",
       "source_location": "L16",
       "id": "test_progress_github_issue_staleness_progressgithubissuestalenesstests",
-      "community": 37
+      "community": 34
     },
     {
       "label": ".test_collects_active_sections_and_ignores_done()",
@@ -11889,7 +12417,7 @@
       "source_file": "tests/test_progress_github_issue_staleness.py",
       "source_location": "L17",
       "id": "test_progress_github_issue_staleness_progressgithubissuestalenesstests_test_collects_active_sections_and_ignores_done",
-      "community": 37
+      "community": 34
     },
     {
       "label": ".test_build_summary_reports_missing_open_and_stale_closed()",
@@ -11897,7 +12425,7 @@
       "source_file": "tests/test_progress_github_issue_staleness.py",
       "source_location": "L46",
       "id": "test_progress_github_issue_staleness_progressgithubissuestalenesstests_test_build_summary_reports_missing_open_and_stale_closed",
-      "community": 37
+      "community": 34
     },
     {
       "label": "local_ci_gate.py",
@@ -11905,7 +12433,7 @@
       "source_file": "tools/local-ci-gate/local_ci_gate.py",
       "source_location": "L1",
       "id": "local_ci_gate",
-      "community": 8
+      "community": 11
     },
     {
       "label": "GateError",
@@ -11913,7 +12441,7 @@
       "source_file": "tools/local-ci-gate/local_ci_gate.py",
       "source_location": "L32",
       "id": "local_ci_gate_gateerror",
-      "community": 8
+      "community": 11
     },
     {
       "label": "ChangedFiles",
@@ -11921,7 +12449,7 @@
       "source_file": "tools/local-ci-gate/local_ci_gate.py",
       "source_location": "L37",
       "id": "local_ci_gate_changedfiles",
-      "community": 8
+      "community": 11
     },
     {
       "label": "CheckSpec",
@@ -11929,7 +12457,7 @@
       "source_file": "tools/local-ci-gate/local_ci_gate.py",
       "source_location": "L45",
       "id": "local_ci_gate_checkspec",
-      "community": 8
+      "community": 11
     },
     {
       "label": "Profile",
@@ -11937,7 +12465,7 @@
       "source_file": "tools/local-ci-gate/local_ci_gate.py",
       "source_location": "L55",
       "id": "local_ci_gate_profile",
-      "community": 8
+      "community": 11
     },
     {
       "label": "CheckResult",
@@ -11945,7 +12473,7 @@
       "source_file": "tools/local-ci-gate/local_ci_gate.py",
       "source_location": "L67",
       "id": "local_ci_gate_checkresult",
-      "community": 8
+      "community": 11
     },
     {
       "label": "RunReport",
@@ -11953,7 +12481,7 @@
       "source_file": "tools/local-ci-gate/local_ci_gate.py",
       "source_location": "L79",
       "id": "local_ci_gate_runreport",
-      "community": 8
+      "community": 11
     },
     {
       "label": "_load_yaml()",
@@ -11961,7 +12489,7 @@
       "source_file": "tools/local-ci-gate/local_ci_gate.py",
       "source_location": "L97",
       "id": "local_ci_gate_load_yaml",
-      "community": 8
+      "community": 11
     },
     {
       "label": "_normalize_path()",
@@ -11969,7 +12497,7 @@
       "source_file": "tools/local-ci-gate/local_ci_gate.py",
       "source_location": "L108",
       "id": "local_ci_gate_normalize_path",
-      "community": 8
+      "community": 11
     },
     {
       "label": "_git()",
@@ -11977,7 +12505,7 @@
       "source_file": "tools/local-ci-gate/local_ci_gate.py",
       "source_location": "L114",
       "id": "local_ci_gate_git",
-      "community": 8
+      "community": 11
     },
     {
       "label": "_repo_root()",
@@ -11985,7 +12513,7 @@
       "source_file": "tools/local-ci-gate/local_ci_gate.py",
       "source_location": "L118",
       "id": "local_ci_gate_repo_root",
-      "community": 8
+      "community": 11
     },
     {
       "label": "_current_branch()",
@@ -11993,7 +12521,7 @@
       "source_file": "tools/local-ci-gate/local_ci_gate.py",
       "source_location": "L125",
       "id": "local_ci_gate_current_branch",
-      "community": 8
+      "community": 11
     },
     {
       "label": "_changed_files_from_git()",
@@ -12001,7 +12529,7 @@
       "source_file": "tools/local-ci-gate/local_ci_gate.py",
       "source_location": "L132",
       "id": "local_ci_gate_changed_files_from_git",
-      "community": 8
+      "community": 11
     },
     {
       "label": "_read_changed_files_file()",
@@ -12009,7 +12537,7 @@
       "source_file": "tools/local-ci-gate/local_ci_gate.py",
       "source_location": "L165",
       "id": "local_ci_gate_read_changed_files_file",
-      "community": 8
+      "community": 11
     },
     {
       "label": "resolve_changed_files()",
@@ -12017,7 +12545,7 @@
       "source_file": "tools/local-ci-gate/local_ci_gate.py",
       "source_location": "L174",
       "id": "local_ci_gate_resolve_changed_files",
-      "community": 8
+      "community": 11
     },
     {
       "label": "_is_glob()",
@@ -12025,7 +12553,7 @@
       "source_file": "tools/local-ci-gate/local_ci_gate.py",
       "source_location": "L208",
       "id": "local_ci_gate_is_glob",
-      "community": 8
+      "community": 11
     },
     {
       "label": "_path_matches()",
@@ -12033,7 +12561,7 @@
       "source_file": "tools/local-ci-gate/local_ci_gate.py",
       "source_location": "L212",
       "id": "local_ci_gate_path_matches",
-      "community": 8
+      "community": 11
     },
     {
       "label": "_check_matches_changed_files()",
@@ -12041,7 +12569,7 @@
       "source_file": "tools/local-ci-gate/local_ci_gate.py",
       "source_location": "L226",
       "id": "local_ci_gate_check_matches_changed_files",
-      "community": 8
+      "community": 11
     },
     {
       "label": "_load_checks()",
@@ -12049,7 +12577,7 @@
       "source_file": "tools/local-ci-gate/local_ci_gate.py",
       "source_location": "L236",
       "id": "local_ci_gate_load_checks",
-      "community": 8
+      "community": 11
     },
     {
       "label": "_load_requires_dependencies()",
@@ -12057,7 +12585,7 @@
       "source_file": "tools/local-ci-gate/local_ci_gate.py",
       "source_location": "L281",
       "id": "local_ci_gate_load_requires_dependencies",
-      "community": 8
+      "community": 11
     },
     {
       "label": "load_profile()",
@@ -12065,7 +12593,7 @@
       "source_file": "tools/local-ci-gate/local_ci_gate.py",
       "source_location": "L290",
       "id": "local_ci_gate_load_profile",
-      "community": 8
+      "community": 11
     },
     {
       "label": "_format_command()",
@@ -12073,7 +12601,7 @@
       "source_file": "tools/local-ci-gate/local_ci_gate.py",
       "source_location": "L336",
       "id": "local_ci_gate_format_command",
-      "community": 8
+      "community": 11
     },
     {
       "label": "_branch_issue_number()",
@@ -12081,7 +12609,7 @@
       "source_file": "tools/local-ci-gate/local_ci_gate.py",
       "source_location": "L340",
       "id": "local_ci_gate_branch_issue_number",
-      "community": 8
+      "community": 11
     },
     {
       "label": "_scope_lane_claim_issue()",
@@ -12089,7 +12617,7 @@
       "source_file": "tools/local-ci-gate/local_ci_gate.py",
       "source_location": "L345",
       "id": "local_ci_gate_scope_lane_claim_issue",
-      "community": 8
+      "community": 11
     },
     {
       "label": "_resolve_execution_scope()",
@@ -12097,7 +12625,7 @@
       "source_file": "tools/local-ci-gate/local_ci_gate.py",
       "source_location": "L361",
       "id": "local_ci_gate_resolve_execution_scope",
-      "community": 8
+      "community": 11
     },
     {
       "label": "_command_context()",
@@ -12105,7 +12633,7 @@
       "source_file": "tools/local-ci-gate/local_ci_gate.py",
       "source_location": "L386",
       "id": "local_ci_gate_command_context",
-      "community": 8
+      "community": 11
     },
     {
       "label": "_exec_command()",
@@ -12113,7 +12641,7 @@
       "source_file": "tools/local-ci-gate/local_ci_gate.py",
       "source_location": "L409",
       "id": "local_ci_gate_exec_command",
-      "community": 8
+      "community": 11
     },
     {
       "label": "run_checks()",
@@ -12121,7 +12649,7 @@
       "source_file": "tools/local-ci-gate/local_ci_gate.py",
       "source_location": "L413",
       "id": "local_ci_gate_run_checks",
-      "community": 8
+      "community": 11
     },
     {
       "label": "_summarize_verdict()",
@@ -12129,7 +12657,7 @@
       "source_file": "tools/local-ci-gate/local_ci_gate.py",
       "source_location": "L500",
       "id": "local_ci_gate_summarize_verdict",
-      "community": 8
+      "community": 11
     },
     {
       "label": "_build_summary()",
@@ -12137,7 +12665,7 @@
       "source_file": "tools/local-ci-gate/local_ci_gate.py",
       "source_location": "L516",
       "id": "local_ci_gate_build_summary",
-      "community": 8
+      "community": 11
     },
     {
       "label": "_report_path()",
@@ -12145,7 +12673,7 @@
       "source_file": "tools/local-ci-gate/local_ci_gate.py",
       "source_location": "L531",
       "id": "local_ci_gate_report_path",
-      "community": 8
+      "community": 11
     },
     {
       "label": "_write_report()",
@@ -12153,7 +12681,7 @@
       "source_file": "tools/local-ci-gate/local_ci_gate.py",
       "source_location": "L536",
       "id": "local_ci_gate_write_report",
-      "community": 8
+      "community": 11
     },
     {
       "label": "render_report()",
@@ -12161,7 +12689,7 @@
       "source_file": "tools/local-ci-gate/local_ci_gate.py",
       "source_location": "L600",
       "id": "local_ci_gate_render_report",
-      "community": 8
+      "community": 11
     },
     {
       "label": "_default_report_dir()",
@@ -12169,7 +12697,7 @@
       "source_file": "tools/local-ci-gate/local_ci_gate.py",
       "source_location": "L634",
       "id": "local_ci_gate_default_report_dir",
-      "community": 8
+      "community": 11
     },
     {
       "label": "_print_report()",
@@ -12177,7 +12705,7 @@
       "source_file": "tools/local-ci-gate/local_ci_gate.py",
       "source_location": "L641",
       "id": "local_ci_gate_print_report",
-      "community": 8
+      "community": 11
     },
     {
       "label": "_check_exit_code()",
@@ -12185,7 +12713,7 @@
       "source_file": "tools/local-ci-gate/local_ci_gate.py",
       "source_location": "L645",
       "id": "local_ci_gate_check_exit_code",
-      "community": 8
+      "community": 11
     },
     {
       "label": "_resolve_profile_path()",
@@ -12193,7 +12721,7 @@
       "source_file": "tools/local-ci-gate/local_ci_gate.py",
       "source_location": "L651",
       "id": "local_ci_gate_resolve_profile_path",
-      "community": 8
+      "community": 11
     },
     {
       "label": "build_argument_parser()",
@@ -12201,7 +12729,7 @@
       "source_file": "tools/local-ci-gate/local_ci_gate.py",
       "source_location": "L659",
       "id": "local_ci_gate_build_argument_parser",
-      "community": 8
+      "community": 11
     },
     {
       "label": "main()",
@@ -12209,7 +12737,7 @@
       "source_file": "tools/local-ci-gate/local_ci_gate.py",
       "source_location": "L680",
       "id": "local_ci_gate_main",
-      "community": 8
+      "community": 11
     },
     {
       "label": "test_local_ci_gate.py",
@@ -12217,7 +12745,7 @@
       "source_file": "tools/local-ci-gate/tests/test_local_ci_gate.py",
       "source_location": "L1",
       "id": "test_local_ci_gate",
-      "community": 21
+      "community": 24
     },
     {
       "label": "TestLocalCiGate",
@@ -12225,7 +12753,7 @@
       "source_file": "tools/local-ci-gate/tests/test_local_ci_gate.py",
       "source_location": "L19",
       "id": "test_local_ci_gate_testlocalcigate",
-      "community": 21
+      "community": 24
     },
     {
       "label": ".setUp()",
@@ -12233,7 +12761,7 @@
       "source_file": "tools/local-ci-gate/tests/test_local_ci_gate.py",
       "source_location": "L20",
       "id": "test_local_ci_gate_testlocalcigate_setup",
-      "community": 21
+      "community": 24
     },
     {
       "label": ".tearDown()",
@@ -12241,7 +12769,7 @@
       "source_file": "tools/local-ci-gate/tests/test_local_ci_gate.py",
       "source_location": "L68",
       "id": "test_local_ci_gate_testlocalcigate_teardown",
-      "community": 21
+      "community": 24
     },
     {
       "label": ".test_resolves_changed_files_from_git_and_writes_report()",
@@ -12249,7 +12777,7 @@
       "source_file": "tools/local-ci-gate/tests/test_local_ci_gate.py",
       "source_location": "L71",
       "id": "test_local_ci_gate_testlocalcigate_test_resolves_changed_files_from_git_and_writes_report",
-      "community": 21
+      "community": 24
     },
     {
       "label": ".test_base_ref_changed_files_include_unstaged_tracked_edits()",
@@ -12257,7 +12785,7 @@
       "source_file": "tools/local-ci-gate/tests/test_local_ci_gate.py",
       "source_location": "L89",
       "id": "test_local_ci_gate_testlocalcigate_test_base_ref_changed_files_include_unstaged_tracked_edits",
-      "community": 21
+      "community": 24
     },
     {
       "label": ".test_blocker_and_advisory_statuses_are_distinct()",
@@ -12265,7 +12793,7 @@
       "source_file": "tools/local-ci-gate/tests/test_local_ci_gate.py",
       "source_location": "L96",
       "id": "test_local_ci_gate_testlocalcigate_test_blocker_and_advisory_statuses_are_distinct",
-      "community": 21
+      "community": 24
     },
     {
       "label": ".test_noop_profile_supports_dry_run_without_side_effects()",
@@ -12273,7 +12801,7 @@
       "source_file": "tools/local-ci-gate/tests/test_local_ci_gate.py",
       "source_location": "L113",
       "id": "test_local_ci_gate_testlocalcigate_test_noop_profile_supports_dry_run_without_side_effects",
-      "community": 21
+      "community": 24
     },
     {
       "label": ".test_cli_prints_authoritative_note()",
@@ -12281,7 +12809,7 @@
       "source_file": "tools/local-ci-gate/tests/test_local_ci_gate.py",
       "source_location": "L134",
       "id": "test_local_ci_gate_testlocalcigate_test_cli_prints_authoritative_note",
-      "community": 21
+      "community": 24
     },
     {
       "label": ".test_cli_accepts_managed_shim_run_invocation()",
@@ -12289,7 +12817,7 @@
       "source_file": "tools/local-ci-gate/tests/test_local_ci_gate.py",
       "source_location": "L156",
       "id": "test_local_ci_gate_testlocalcigate_test_cli_accepts_managed_shim_run_invocation",
-      "community": 21
+      "community": 24
     },
     {
       "label": ".test_report_json_is_machine_readable()",
@@ -12297,7 +12825,7 @@
       "source_file": "tools/local-ci-gate/tests/test_local_ci_gate.py",
       "source_location": "L203",
       "id": "test_local_ci_gate_testlocalcigate_test_report_json_is_machine_readable",
-      "community": 21
+      "community": 24
     },
     {
       "label": ".test_profile_rejects_duplicate_check_ids()",
@@ -12305,7 +12833,7 @@
       "source_file": "tools/local-ci-gate/tests/test_local_ci_gate.py",
       "source_location": "L238",
       "id": "test_local_ci_gate_testlocalcigate_test_profile_rejects_duplicate_check_ids",
-      "community": 21
+      "community": 24
     },
     {
       "label": ".test_profile_rejects_malformed_dependency_metadata()",
@@ -12313,7 +12841,7 @@
       "source_file": "tools/local-ci-gate/tests/test_local_ci_gate.py",
       "source_location": "L268",
       "id": "test_local_ci_gate_testlocalcigate_test_profile_rejects_malformed_dependency_metadata",
-      "community": 21
+      "community": 24
     },
     {
       "label": ".test_changed_files_file_accepts_null_separated_entries()",
@@ -12321,7 +12849,7 @@
       "source_file": "tools/local-ci-gate/tests/test_local_ci_gate.py",
       "source_location": "L287",
       "id": "test_local_ci_gate_testlocalcigate_test_changed_files_file_accepts_null_separated_entries",
-      "community": 21
+      "community": 24
     },
     {
       "label": ".test_bundled_profiles_load()",
@@ -12329,7 +12857,7 @@
       "source_file": "tools/local-ci-gate/tests/test_local_ci_gate.py",
       "source_location": "L296",
       "id": "test_local_ci_gate_testlocalcigate_test_bundled_profiles_load",
-      "community": 21
+      "community": 24
     },
     {
       "label": ".test_governance_profile_uses_active_execution_scope_placeholder()",
@@ -12337,7 +12865,7 @@
       "source_file": "tools/local-ci-gate/tests/test_local_ci_gate.py",
       "source_location": "L313",
       "id": "test_local_ci_gate_testlocalcigate_test_governance_profile_uses_active_execution_scope_placeholder",
-      "community": 21
+      "community": 24
     },
     {
       "label": ".test_governance_profile_runs_handoff_validator_for_handoff_paths()",
@@ -12345,7 +12873,7 @@
       "source_file": "tools/local-ci-gate/tests/test_local_ci_gate.py",
       "source_location": "L320",
       "id": "test_local_ci_gate_testlocalcigate_test_governance_profile_runs_handoff_validator_for_handoff_paths",
-      "community": 21
+      "community": 24
     },
     {
       "label": ".test_governance_profile_skips_handoff_validator_for_unrelated_paths()",
@@ -12353,7 +12881,7 @@
       "source_file": "tools/local-ci-gate/tests/test_local_ci_gate.py",
       "source_location": "L336",
       "id": "test_local_ci_gate_testlocalcigate_test_governance_profile_skips_handoff_validator_for_unrelated_paths",
-      "community": 21
+      "community": 24
     },
     {
       "label": ".test_execution_scope_resolution_prefers_active_issue_implementation_scope()",
@@ -12361,7 +12889,7 @@
       "source_file": "tools/local-ci-gate/tests/test_local_ci_gate.py",
       "source_location": "L349",
       "id": "test_local_ci_gate_testlocalcigate_test_execution_scope_resolution_prefers_active_issue_implementation_scope",
-      "community": 21
+      "community": 24
     },
     {
       "label": ".test_execution_scope_resolution_requires_matching_lane_claim()",
@@ -12369,7 +12897,7 @@
       "source_file": "tools/local-ci-gate/tests/test_local_ci_gate.py",
       "source_location": "L361",
       "id": "test_local_ci_gate_testlocalcigate_test_execution_scope_resolution_requires_matching_lane_claim",
-      "community": 21
+      "community": 24
     },
     {
       "label": ".test_knocktracker_profile_scopes_heavy_checks_to_matching_files()",
@@ -12377,7 +12905,7 @@
       "source_file": "tools/local-ci-gate/tests/test_local_ci_gate.py",
       "source_location": "L372",
       "id": "test_local_ci_gate_testlocalcigate_test_knocktracker_profile_scopes_heavy_checks_to_matching_files",
-      "community": 21
+      "community": 24
     },
     {
       "label": ".test_ai_integration_services_profile_scopes_app_builds()",
@@ -12385,7 +12913,7 @@
       "source_file": "tools/local-ci-gate/tests/test_local_ci_gate.py",
       "source_location": "L394",
       "id": "test_local_ci_gate_testlocalcigate_test_ai_integration_services_profile_scopes_app_builds",
-      "community": 21
+      "community": 24
     },
     {
       "label": ".test_local_ai_machine_profile_scopes_contract_checks()",
@@ -12393,7 +12921,7 @@
       "source_file": "tools/local-ci-gate/tests/test_local_ci_gate.py",
       "source_location": "L415",
       "id": "test_local_ci_gate_testlocalcigate_test_local_ai_machine_profile_scopes_contract_checks",
-      "community": 21
+      "community": 24
     }
   ],
   "links": [
@@ -14141,7 +14669,7 @@
       "relation": "inherits",
       "confidence": "EXTRACTED",
       "source_file": "scripts/overlord/verify_governance_consumer.py",
-      "source_location": "L22",
+      "source_location": "L76",
       "weight": 1.0,
       "_src": "verify_governance_consumer_consumerverifyerror",
       "_tgt": "runtimeerror",
@@ -23536,7 +24064,7 @@
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/hldpro-governance/var/worktrees/issue-463-stage6-closeout-439/scripts/overlord/check_plan_preflight.py",
+      "source_file": "scripts/overlord/check_plan_preflight.py",
       "source_location": "L32",
       "weight": 1.0,
       "_src": "check_plan_preflight",
@@ -23548,7 +24076,7 @@
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/hldpro-governance/var/worktrees/issue-463-stage6-closeout-439/scripts/overlord/check_plan_preflight.py",
+      "source_file": "scripts/overlord/check_plan_preflight.py",
       "source_location": "L37",
       "weight": 1.0,
       "_src": "check_plan_preflight",
@@ -23560,7 +24088,7 @@
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/hldpro-governance/var/worktrees/issue-463-stage6-closeout-439/scripts/overlord/check_plan_preflight.py",
+      "source_file": "scripts/overlord/check_plan_preflight.py",
       "source_location": "L47",
       "weight": 1.0,
       "_src": "check_plan_preflight",
@@ -23572,7 +24100,7 @@
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/hldpro-governance/var/worktrees/issue-463-stage6-closeout-439/scripts/overlord/check_plan_preflight.py",
+      "source_file": "scripts/overlord/check_plan_preflight.py",
       "source_location": "L64",
       "weight": 1.0,
       "_src": "check_plan_preflight",
@@ -23584,7 +24112,7 @@
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/hldpro-governance/var/worktrees/issue-463-stage6-closeout-439/scripts/overlord/check_plan_preflight.py",
+      "source_file": "scripts/overlord/check_plan_preflight.py",
       "source_location": "L78",
       "weight": 1.0,
       "_src": "check_plan_preflight",
@@ -23596,7 +24124,7 @@
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/hldpro-governance/var/worktrees/issue-463-stage6-closeout-439/scripts/overlord/check_plan_preflight.py",
+      "source_file": "scripts/overlord/check_plan_preflight.py",
       "source_location": "L131",
       "weight": 1.0,
       "_src": "check_plan_preflight",
@@ -23608,7 +24136,7 @@
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/hldpro-governance/var/worktrees/issue-463-stage6-closeout-439/scripts/overlord/check_plan_preflight.py",
+      "source_file": "scripts/overlord/check_plan_preflight.py",
       "source_location": "L145",
       "weight": 1.0,
       "_src": "check_plan_preflight",
@@ -23620,7 +24148,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/hldpro-governance/var/worktrees/issue-463-stage6-closeout-439/scripts/overlord/check_plan_preflight.py",
+      "source_file": "scripts/overlord/check_plan_preflight.py",
       "source_location": "L92",
       "weight": 0.8,
       "_src": "check_plan_preflight_evaluate",
@@ -23632,7 +24160,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/hldpro-governance/var/worktrees/issue-463-stage6-closeout-439/scripts/overlord/check_plan_preflight.py",
+      "source_file": "scripts/overlord/check_plan_preflight.py",
       "source_location": "L114",
       "weight": 0.8,
       "_src": "check_plan_preflight_evaluate",
@@ -23644,7 +24172,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/hldpro-governance/var/worktrees/issue-463-stage6-closeout-439/scripts/overlord/check_plan_preflight.py",
+      "source_file": "scripts/overlord/check_plan_preflight.py",
       "source_location": "L86",
       "weight": 0.8,
       "_src": "check_plan_preflight_evaluate",
@@ -23656,7 +24184,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/hldpro-governance/var/worktrees/issue-463-stage6-closeout-439/scripts/overlord/check_plan_preflight.py",
+      "source_file": "scripts/overlord/check_plan_preflight.py",
       "source_location": "L109",
       "weight": 0.8,
       "_src": "check_plan_preflight_evaluate",
@@ -23668,7 +24196,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/hldpro-governance/var/worktrees/issue-463-stage6-closeout-439/scripts/overlord/check_plan_preflight.py",
+      "source_file": "scripts/overlord/check_plan_preflight.py",
       "source_location": "L147",
       "weight": 0.8,
       "_src": "check_plan_preflight_main",
@@ -23680,7 +24208,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/hldpro-governance/var/worktrees/issue-463-stage6-closeout-439/scripts/overlord/check_plan_preflight.py",
+      "source_file": "scripts/overlord/check_plan_preflight.py",
       "source_location": "L146",
       "weight": 0.8,
       "_src": "check_plan_preflight_main",
@@ -26848,6 +27376,234 @@
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
+      "source_file": "scripts/overlord/lane_bootstrap.py",
+      "source_location": "L20",
+      "weight": 1.0,
+      "_src": "lane_bootstrap",
+      "_tgt": "lane_bootstrap_lanepolicy",
+      "source": "lane_bootstrap",
+      "target": "lane_bootstrap_lanepolicy",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/overlord/lane_bootstrap.py",
+      "source_location": "L29",
+      "weight": 1.0,
+      "_src": "lane_bootstrap",
+      "_tgt": "lane_bootstrap_load_policy",
+      "source": "lane_bootstrap",
+      "target": "lane_bootstrap_load_policy",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/overlord/lane_bootstrap.py",
+      "source_location": "L43",
+      "weight": 1.0,
+      "_src": "lane_bootstrap",
+      "_tgt": "lane_bootstrap_normalize_slug",
+      "source": "lane_bootstrap",
+      "target": "lane_bootstrap_normalize_slug",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/overlord/lane_bootstrap.py",
+      "source_location": "L50",
+      "weight": 1.0,
+      "_src": "lane_bootstrap",
+      "_tgt": "lane_bootstrap_match",
+      "source": "lane_bootstrap",
+      "target": "lane_bootstrap_match",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/overlord/lane_bootstrap.py",
+      "source_location": "L54",
+      "weight": 1.0,
+      "_src": "lane_bootstrap",
+      "_tgt": "lane_bootstrap_validate_lane",
+      "source": "lane_bootstrap",
+      "target": "lane_bootstrap_validate_lane",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/overlord/lane_bootstrap.py",
+      "source_location": "L94",
+      "weight": 1.0,
+      "_src": "lane_bootstrap",
+      "_tgt": "lane_bootstrap_plan_lane",
+      "source": "lane_bootstrap",
+      "target": "lane_bootstrap_plan_lane",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/overlord/lane_bootstrap.py",
+      "source_location": "L116",
+      "weight": 1.0,
+      "_src": "lane_bootstrap",
+      "_tgt": "lane_bootstrap_cleanup_advice",
+      "source": "lane_bootstrap",
+      "target": "lane_bootstrap_cleanup_advice",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/overlord/lane_bootstrap.py",
+      "source_location": "L130",
+      "weight": 1.0,
+      "_src": "lane_bootstrap",
+      "_tgt": "lane_bootstrap_infer_repo_slug",
+      "source": "lane_bootstrap",
+      "target": "lane_bootstrap_infer_repo_slug",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/overlord/lane_bootstrap.py",
+      "source_location": "L145",
+      "weight": 1.0,
+      "_src": "lane_bootstrap",
+      "_tgt": "lane_bootstrap_parse_args",
+      "source": "lane_bootstrap",
+      "target": "lane_bootstrap_parse_args",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/overlord/lane_bootstrap.py",
+      "source_location": "L168",
+      "weight": 1.0,
+      "_src": "lane_bootstrap",
+      "_tgt": "lane_bootstrap_main",
+      "source": "lane_bootstrap",
+      "target": "lane_bootstrap_main",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/overlord/lane_bootstrap.py",
+      "source_location": "L33",
+      "weight": 0.8,
+      "_src": "lane_bootstrap_load_policy",
+      "_tgt": "lane_bootstrap_lanepolicy",
+      "source": "lane_bootstrap_lanepolicy",
+      "target": "lane_bootstrap_load_policy",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/overlord/lane_bootstrap.py",
+      "source_location": "L172",
+      "weight": 0.8,
+      "_src": "lane_bootstrap_main",
+      "_tgt": "lane_bootstrap_load_policy",
+      "source": "lane_bootstrap_load_policy",
+      "target": "lane_bootstrap_main",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/overlord/lane_bootstrap.py",
+      "source_location": "L103",
+      "weight": 0.8,
+      "_src": "lane_bootstrap_plan_lane",
+      "_tgt": "lane_bootstrap_normalize_slug",
+      "source": "lane_bootstrap_normalize_slug",
+      "target": "lane_bootstrap_plan_lane",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/overlord/lane_bootstrap.py",
+      "source_location": "L55",
+      "weight": 0.8,
+      "_src": "lane_bootstrap_validate_lane",
+      "_tgt": "lane_bootstrap_match",
+      "source": "lane_bootstrap_match",
+      "target": "lane_bootstrap_validate_lane",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/overlord/lane_bootstrap.py",
+      "source_location": "L184",
+      "weight": 0.8,
+      "_src": "lane_bootstrap_main",
+      "_tgt": "lane_bootstrap_validate_lane",
+      "source": "lane_bootstrap_validate_lane",
+      "target": "lane_bootstrap_main",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/overlord/lane_bootstrap.py",
+      "source_location": "L175",
+      "weight": 0.8,
+      "_src": "lane_bootstrap_main",
+      "_tgt": "lane_bootstrap_plan_lane",
+      "source": "lane_bootstrap_plan_lane",
+      "target": "lane_bootstrap_main",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/overlord/lane_bootstrap.py",
+      "source_location": "L191",
+      "weight": 0.8,
+      "_src": "lane_bootstrap_main",
+      "_tgt": "lane_bootstrap_cleanup_advice",
+      "source": "lane_bootstrap_cleanup_advice",
+      "target": "lane_bootstrap_main",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/overlord/lane_bootstrap.py",
+      "source_location": "L171",
+      "weight": 0.8,
+      "_src": "lane_bootstrap_main",
+      "_tgt": "lane_bootstrap_infer_repo_slug",
+      "source": "lane_bootstrap_infer_repo_slug",
+      "target": "lane_bootstrap_main",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/overlord/lane_bootstrap.py",
+      "source_location": "L169",
+      "weight": 0.8,
+      "_src": "lane_bootstrap_main",
+      "_tgt": "lane_bootstrap_parse_args",
+      "source": "lane_bootstrap_parse_args",
+      "target": "lane_bootstrap_main",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
       "source_file": "scripts/overlord/memory_integrity.py",
       "source_location": "L21",
       "weight": 1.0,
@@ -29477,7 +30233,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/overlord/test_branch_switch_guard.py",
-      "source_location": "L34",
+      "source_location": "L36",
       "weight": 0.8,
       "_src": "test_branch_switch_guard_testbranchswitchguard_test_allows_explicit_planning_bootstrap_issue_worktree_add",
       "_tgt": "test_branch_switch_guard_run_hook",
@@ -29489,7 +30245,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/overlord/test_branch_switch_guard.py",
-      "source_location": "L41",
+      "source_location": "L43",
       "weight": 0.8,
       "_src": "test_branch_switch_guard_testbranchswitchguard_test_allows_non_issue_worktree_add",
       "_tgt": "test_branch_switch_guard_run_hook",
@@ -29501,7 +30257,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/overlord/test_branch_switch_guard.py",
-      "source_location": "L53",
+      "source_location": "L55",
       "weight": 0.8,
       "_src": "test_branch_switch_guard_testbranchswitchguard_test_allows_issue_worktree_add_with_matching_claimed_scope",
       "_tgt": "test_branch_switch_guard_run_hook",
@@ -29513,7 +30269,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/overlord/test_branch_switch_guard.py",
-      "source_location": "L69",
+      "source_location": "L71",
       "weight": 0.8,
       "_src": "test_branch_switch_guard_testbranchswitchguard_test_blocks_issue_worktree_add_with_mismatched_claimed_scope",
       "_tgt": "test_branch_switch_guard_run_hook",
@@ -29525,7 +30281,31 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/overlord/test_branch_switch_guard.py",
-      "source_location": "L79",
+      "source_location": "L81",
+      "weight": 0.8,
+      "_src": "test_branch_switch_guard_testbranchswitchguard_test_healthcareplatform_policy_rejects_non_sandbox_branch",
+      "_tgt": "test_branch_switch_guard_run_hook",
+      "source": "test_branch_switch_guard_run_hook",
+      "target": "test_branch_switch_guard_testbranchswitchguard_test_healthcareplatform_policy_rejects_non_sandbox_branch",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/overlord/test_branch_switch_guard.py",
+      "source_location": "L90",
+      "weight": 0.8,
+      "_src": "test_branch_switch_guard_testbranchswitchguard_test_healthcareplatform_policy_accepts_sandbox_pr_pending_lane",
+      "_tgt": "test_branch_switch_guard_run_hook",
+      "source": "test_branch_switch_guard_run_hook",
+      "target": "test_branch_switch_guard_testbranchswitchguard_test_healthcareplatform_policy_accepts_sandbox_pr_pending_lane",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/overlord/test_branch_switch_guard.py",
+      "source_location": "L98",
       "weight": 0.8,
       "_src": "test_branch_switch_guard_testbranchswitchguard_test_still_blocks_branch_checkout",
       "_tgt": "test_branch_switch_guard_run_hook",
@@ -29549,7 +30329,7 @@
       "relation": "method",
       "confidence": "EXTRACTED",
       "source_file": "scripts/overlord/test_branch_switch_guard.py",
-      "source_location": "L33",
+      "source_location": "L35",
       "weight": 1.0,
       "_src": "test_branch_switch_guard_testbranchswitchguard",
       "_tgt": "test_branch_switch_guard_testbranchswitchguard_test_allows_explicit_planning_bootstrap_issue_worktree_add",
@@ -29561,7 +30341,7 @@
       "relation": "method",
       "confidence": "EXTRACTED",
       "source_file": "scripts/overlord/test_branch_switch_guard.py",
-      "source_location": "L40",
+      "source_location": "L42",
       "weight": 1.0,
       "_src": "test_branch_switch_guard_testbranchswitchguard",
       "_tgt": "test_branch_switch_guard_testbranchswitchguard_test_allows_non_issue_worktree_add",
@@ -29573,7 +30353,7 @@
       "relation": "method",
       "confidence": "EXTRACTED",
       "source_file": "scripts/overlord/test_branch_switch_guard.py",
-      "source_location": "L45",
+      "source_location": "L47",
       "weight": 1.0,
       "_src": "test_branch_switch_guard_testbranchswitchguard",
       "_tgt": "test_branch_switch_guard_testbranchswitchguard_test_allows_issue_worktree_add_with_matching_claimed_scope",
@@ -29585,7 +30365,7 @@
       "relation": "method",
       "confidence": "EXTRACTED",
       "source_file": "scripts/overlord/test_branch_switch_guard.py",
-      "source_location": "L61",
+      "source_location": "L63",
       "weight": 1.0,
       "_src": "test_branch_switch_guard_testbranchswitchguard",
       "_tgt": "test_branch_switch_guard_testbranchswitchguard_test_blocks_issue_worktree_add_with_mismatched_claimed_scope",
@@ -29597,7 +30377,31 @@
       "relation": "method",
       "confidence": "EXTRACTED",
       "source_file": "scripts/overlord/test_branch_switch_guard.py",
-      "source_location": "L78",
+      "source_location": "L80",
+      "weight": 1.0,
+      "_src": "test_branch_switch_guard_testbranchswitchguard",
+      "_tgt": "test_branch_switch_guard_testbranchswitchguard_test_healthcareplatform_policy_rejects_non_sandbox_branch",
+      "source": "test_branch_switch_guard_testbranchswitchguard",
+      "target": "test_branch_switch_guard_testbranchswitchguard_test_healthcareplatform_policy_rejects_non_sandbox_branch",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/overlord/test_branch_switch_guard.py",
+      "source_location": "L89",
+      "weight": 1.0,
+      "_src": "test_branch_switch_guard_testbranchswitchguard",
+      "_tgt": "test_branch_switch_guard_testbranchswitchguard_test_healthcareplatform_policy_accepts_sandbox_pr_pending_lane",
+      "source": "test_branch_switch_guard_testbranchswitchguard",
+      "target": "test_branch_switch_guard_testbranchswitchguard_test_healthcareplatform_policy_accepts_sandbox_pr_pending_lane",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/overlord/test_branch_switch_guard.py",
+      "source_location": "L97",
       "weight": 1.0,
       "_src": "test_branch_switch_guard_testbranchswitchguard",
       "_tgt": "test_branch_switch_guard_testbranchswitchguard_test_still_blocks_branch_checkout",
@@ -30136,7 +30940,7 @@
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/hldpro-governance/var/worktrees/issue-463-stage6-closeout-439/scripts/overlord/test_check_plan_preflight.py",
+      "source_file": "scripts/overlord/test_check_plan_preflight.py",
       "source_location": "L17",
       "weight": 1.0,
       "_src": "test_check_plan_preflight",
@@ -30148,7 +30952,7 @@
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/hldpro-governance/var/worktrees/issue-463-stage6-closeout-439/scripts/overlord/test_check_plan_preflight.py",
+      "source_file": "scripts/overlord/test_check_plan_preflight.py",
       "source_location": "L27",
       "weight": 1.0,
       "_src": "test_check_plan_preflight",
@@ -30160,7 +30964,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/hldpro-governance/var/worktrees/issue-463-stage6-closeout-439/scripts/overlord/test_check_plan_preflight.py",
+      "source_file": "scripts/overlord/test_check_plan_preflight.py",
       "source_location": "L31",
       "weight": 0.8,
       "_src": "test_check_plan_preflight_testplanpreflight_test_code_file_without_recent_plan_blocks_with_route_tokens",
@@ -30172,7 +30976,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/hldpro-governance/var/worktrees/issue-463-stage6-closeout-439/scripts/overlord/test_check_plan_preflight.py",
+      "source_file": "scripts/overlord/test_check_plan_preflight.py",
       "source_location": "L42",
       "weight": 0.8,
       "_src": "test_check_plan_preflight_testplanpreflight_test_read_only_intent_is_allowed",
@@ -30184,7 +30988,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/hldpro-governance/var/worktrees/issue-463-stage6-closeout-439/scripts/overlord/test_check_plan_preflight.py",
+      "source_file": "scripts/overlord/test_check_plan_preflight.py",
       "source_location": "L50",
       "weight": 0.8,
       "_src": "test_check_plan_preflight_testplanpreflight_test_trivial_single_line_bypass_is_explicitly_bounded",
@@ -30196,7 +31000,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/hldpro-governance/var/worktrees/issue-463-stage6-closeout-439/scripts/overlord/test_check_plan_preflight.py",
+      "source_file": "scripts/overlord/test_check_plan_preflight.py",
       "source_location": "L64",
       "weight": 0.8,
       "_src": "test_check_plan_preflight_testplanpreflight_test_general_bypass_without_trivial_marker_still_blocks",
@@ -30208,7 +31012,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/hldpro-governance/var/worktrees/issue-463-stage6-closeout-439/scripts/overlord/test_check_plan_preflight.py",
+      "source_file": "scripts/overlord/test_check_plan_preflight.py",
       "source_location": "L76",
       "weight": 0.8,
       "_src": "test_check_plan_preflight_testplanpreflight_test_recent_plan_allows_governed_write",
@@ -30220,7 +31024,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/hldpro-governance/var/worktrees/issue-463-stage6-closeout-439/scripts/overlord/test_check_plan_preflight.py",
+      "source_file": "scripts/overlord/test_check_plan_preflight.py",
       "source_location": "L92",
       "weight": 0.8,
       "_src": "test_check_plan_preflight_testplanpreflight_test_stale_plan_does_not_clear_preflight",
@@ -30232,7 +31036,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/hldpro-governance/var/worktrees/issue-463-stage6-closeout-439/scripts/overlord/test_check_plan_preflight.py",
+      "source_file": "scripts/overlord/test_check_plan_preflight.py",
       "source_location": "L99",
       "weight": 0.8,
       "_src": "test_check_plan_preflight_testplanpreflight_test_bash_write_command_detects_target",
@@ -30244,7 +31048,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/hldpro-governance/var/worktrees/issue-463-stage6-closeout-439/scripts/overlord/test_check_plan_preflight.py",
+      "source_file": "scripts/overlord/test_check_plan_preflight.py",
       "source_location": "L111",
       "weight": 0.8,
       "_src": "test_check_plan_preflight_testplanpreflight_test_python_write_command_is_refused_with_routing_signal",
@@ -30256,7 +31060,7 @@
     {
       "relation": "method",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/hldpro-governance/var/worktrees/issue-463-stage6-closeout-439/scripts/overlord/test_check_plan_preflight.py",
+      "source_file": "scripts/overlord/test_check_plan_preflight.py",
       "source_location": "L28",
       "weight": 1.0,
       "_src": "test_check_plan_preflight_testplanpreflight",
@@ -30268,7 +31072,7 @@
     {
       "relation": "method",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/hldpro-governance/var/worktrees/issue-463-stage6-closeout-439/scripts/overlord/test_check_plan_preflight.py",
+      "source_file": "scripts/overlord/test_check_plan_preflight.py",
       "source_location": "L40",
       "weight": 1.0,
       "_src": "test_check_plan_preflight_testplanpreflight",
@@ -30280,7 +31084,7 @@
     {
       "relation": "method",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/hldpro-governance/var/worktrees/issue-463-stage6-closeout-439/scripts/overlord/test_check_plan_preflight.py",
+      "source_file": "scripts/overlord/test_check_plan_preflight.py",
       "source_location": "L48",
       "weight": 1.0,
       "_src": "test_check_plan_preflight_testplanpreflight",
@@ -30292,7 +31096,7 @@
     {
       "relation": "method",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/hldpro-governance/var/worktrees/issue-463-stage6-closeout-439/scripts/overlord/test_check_plan_preflight.py",
+      "source_file": "scripts/overlord/test_check_plan_preflight.py",
       "source_location": "L62",
       "weight": 1.0,
       "_src": "test_check_plan_preflight_testplanpreflight",
@@ -30304,7 +31108,7 @@
     {
       "relation": "method",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/hldpro-governance/var/worktrees/issue-463-stage6-closeout-439/scripts/overlord/test_check_plan_preflight.py",
+      "source_file": "scripts/overlord/test_check_plan_preflight.py",
       "source_location": "L69",
       "weight": 1.0,
       "_src": "test_check_plan_preflight_testplanpreflight",
@@ -30316,7 +31120,7 @@
     {
       "relation": "method",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/hldpro-governance/var/worktrees/issue-463-stage6-closeout-439/scripts/overlord/test_check_plan_preflight.py",
+      "source_file": "scripts/overlord/test_check_plan_preflight.py",
       "source_location": "L82",
       "weight": 1.0,
       "_src": "test_check_plan_preflight_testplanpreflight",
@@ -30328,7 +31132,7 @@
     {
       "relation": "method",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/hldpro-governance/var/worktrees/issue-463-stage6-closeout-439/scripts/overlord/test_check_plan_preflight.py",
+      "source_file": "scripts/overlord/test_check_plan_preflight.py",
       "source_location": "L97",
       "weight": 1.0,
       "_src": "test_check_plan_preflight_testplanpreflight",
@@ -30340,7 +31144,7 @@
     {
       "relation": "method",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/hldpro-governance/var/worktrees/issue-463-stage6-closeout-439/scripts/overlord/test_check_plan_preflight.py",
+      "source_file": "scripts/overlord/test_check_plan_preflight.py",
       "source_location": "L109",
       "weight": 1.0,
       "_src": "test_check_plan_preflight_testplanpreflight",
@@ -32068,6 +32872,246 @@
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
+      "source_file": "scripts/overlord/test_lane_bootstrap.py",
+      "source_location": "L14",
+      "weight": 1.0,
+      "_src": "test_lane_bootstrap",
+      "_tgt": "test_lane_bootstrap_run_helper",
+      "source": "test_lane_bootstrap",
+      "target": "test_lane_bootstrap_run_helper",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/overlord/test_lane_bootstrap.py",
+      "source_location": "L24",
+      "weight": 1.0,
+      "_src": "test_lane_bootstrap",
+      "_tgt": "test_lane_bootstrap_testlanebootstrap",
+      "source": "test_lane_bootstrap",
+      "target": "test_lane_bootstrap_testlanebootstrap",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/overlord/test_lane_bootstrap.py",
+      "source_location": "L26",
+      "weight": 0.8,
+      "_src": "test_lane_bootstrap_testlanebootstrap_test_valid_healthcareplatform_lane_accepted",
+      "_tgt": "test_lane_bootstrap_run_helper",
+      "source": "test_lane_bootstrap_run_helper",
+      "target": "test_lane_bootstrap_testlanebootstrap_test_valid_healthcareplatform_lane_accepted",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/overlord/test_lane_bootstrap.py",
+      "source_location": "L42",
+      "weight": 0.8,
+      "_src": "test_lane_bootstrap_testlanebootstrap_test_invalid_healthcareplatform_branch_pattern_rejected",
+      "_tgt": "test_lane_bootstrap_run_helper",
+      "source": "test_lane_bootstrap_run_helper",
+      "target": "test_lane_bootstrap_testlanebootstrap_test_invalid_healthcareplatform_branch_pattern_rejected",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/overlord/test_lane_bootstrap.py",
+      "source_location": "L58",
+      "weight": 0.8,
+      "_src": "test_lane_bootstrap_testlanebootstrap_test_invalid_healthcareplatform_worktree_path_rejected",
+      "_tgt": "test_lane_bootstrap_run_helper",
+      "source": "test_lane_bootstrap_run_helper",
+      "target": "test_lane_bootstrap_testlanebootstrap_test_invalid_healthcareplatform_worktree_path_rejected",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/overlord/test_lane_bootstrap.py",
+      "source_location": "L74",
+      "weight": 0.8,
+      "_src": "test_lane_bootstrap_testlanebootstrap_test_branch_worktree_issue_mismatch_rejected",
+      "_tgt": "test_lane_bootstrap_run_helper",
+      "source": "test_lane_bootstrap_run_helper",
+      "target": "test_lane_bootstrap_testlanebootstrap_test_branch_worktree_issue_mismatch_rejected",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/overlord/test_lane_bootstrap.py",
+      "source_location": "L90",
+      "weight": 0.8,
+      "_src": "test_lane_bootstrap_testlanebootstrap_test_branch_worktree_scope_mismatch_rejected",
+      "_tgt": "test_lane_bootstrap_run_helper",
+      "source": "test_lane_bootstrap_run_helper",
+      "target": "test_lane_bootstrap_testlanebootstrap_test_branch_worktree_scope_mismatch_rejected",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/overlord/test_lane_bootstrap.py",
+      "source_location": "L106",
+      "weight": 0.8,
+      "_src": "test_lane_bootstrap_testlanebootstrap_test_standard_repo_lane_policy_accepted",
+      "_tgt": "test_lane_bootstrap_run_helper",
+      "source": "test_lane_bootstrap_run_helper",
+      "target": "test_lane_bootstrap_testlanebootstrap_test_standard_repo_lane_policy_accepted",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/overlord/test_lane_bootstrap.py",
+      "source_location": "L122",
+      "weight": 0.8,
+      "_src": "test_lane_bootstrap_testlanebootstrap_test_plan_generates_healthcareplatform_names",
+      "_tgt": "test_lane_bootstrap_run_helper",
+      "source": "test_lane_bootstrap_run_helper",
+      "target": "test_lane_bootstrap_testlanebootstrap_test_plan_generates_healthcareplatform_names",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/overlord/test_lane_bootstrap.py",
+      "source_location": "L140",
+      "weight": 0.8,
+      "_src": "test_lane_bootstrap_testlanebootstrap_test_dirty_invalid_lane_cleanup_refused",
+      "_tgt": "test_lane_bootstrap_run_helper",
+      "source": "test_lane_bootstrap_run_helper",
+      "target": "test_lane_bootstrap_testlanebootstrap_test_dirty_invalid_lane_cleanup_refused",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/overlord/test_lane_bootstrap.py",
+      "source_location": "L146",
+      "weight": 0.8,
+      "_src": "test_lane_bootstrap_testlanebootstrap_test_clean_invalid_lane_cleanup_documented",
+      "_tgt": "test_lane_bootstrap_run_helper",
+      "source": "test_lane_bootstrap_run_helper",
+      "target": "test_lane_bootstrap_testlanebootstrap_test_clean_invalid_lane_cleanup_documented",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/overlord/test_lane_bootstrap.py",
+      "source_location": "L25",
+      "weight": 1.0,
+      "_src": "test_lane_bootstrap_testlanebootstrap",
+      "_tgt": "test_lane_bootstrap_testlanebootstrap_test_valid_healthcareplatform_lane_accepted",
+      "source": "test_lane_bootstrap_testlanebootstrap",
+      "target": "test_lane_bootstrap_testlanebootstrap_test_valid_healthcareplatform_lane_accepted",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/overlord/test_lane_bootstrap.py",
+      "source_location": "L41",
+      "weight": 1.0,
+      "_src": "test_lane_bootstrap_testlanebootstrap",
+      "_tgt": "test_lane_bootstrap_testlanebootstrap_test_invalid_healthcareplatform_branch_pattern_rejected",
+      "source": "test_lane_bootstrap_testlanebootstrap",
+      "target": "test_lane_bootstrap_testlanebootstrap_test_invalid_healthcareplatform_branch_pattern_rejected",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/overlord/test_lane_bootstrap.py",
+      "source_location": "L57",
+      "weight": 1.0,
+      "_src": "test_lane_bootstrap_testlanebootstrap",
+      "_tgt": "test_lane_bootstrap_testlanebootstrap_test_invalid_healthcareplatform_worktree_path_rejected",
+      "source": "test_lane_bootstrap_testlanebootstrap",
+      "target": "test_lane_bootstrap_testlanebootstrap_test_invalid_healthcareplatform_worktree_path_rejected",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/overlord/test_lane_bootstrap.py",
+      "source_location": "L73",
+      "weight": 1.0,
+      "_src": "test_lane_bootstrap_testlanebootstrap",
+      "_tgt": "test_lane_bootstrap_testlanebootstrap_test_branch_worktree_issue_mismatch_rejected",
+      "source": "test_lane_bootstrap_testlanebootstrap",
+      "target": "test_lane_bootstrap_testlanebootstrap_test_branch_worktree_issue_mismatch_rejected",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/overlord/test_lane_bootstrap.py",
+      "source_location": "L89",
+      "weight": 1.0,
+      "_src": "test_lane_bootstrap_testlanebootstrap",
+      "_tgt": "test_lane_bootstrap_testlanebootstrap_test_branch_worktree_scope_mismatch_rejected",
+      "source": "test_lane_bootstrap_testlanebootstrap",
+      "target": "test_lane_bootstrap_testlanebootstrap_test_branch_worktree_scope_mismatch_rejected",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/overlord/test_lane_bootstrap.py",
+      "source_location": "L105",
+      "weight": 1.0,
+      "_src": "test_lane_bootstrap_testlanebootstrap",
+      "_tgt": "test_lane_bootstrap_testlanebootstrap_test_standard_repo_lane_policy_accepted",
+      "source": "test_lane_bootstrap_testlanebootstrap",
+      "target": "test_lane_bootstrap_testlanebootstrap_test_standard_repo_lane_policy_accepted",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/overlord/test_lane_bootstrap.py",
+      "source_location": "L121",
+      "weight": 1.0,
+      "_src": "test_lane_bootstrap_testlanebootstrap",
+      "_tgt": "test_lane_bootstrap_testlanebootstrap_test_plan_generates_healthcareplatform_names",
+      "source": "test_lane_bootstrap_testlanebootstrap",
+      "target": "test_lane_bootstrap_testlanebootstrap_test_plan_generates_healthcareplatform_names",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/overlord/test_lane_bootstrap.py",
+      "source_location": "L139",
+      "weight": 1.0,
+      "_src": "test_lane_bootstrap_testlanebootstrap",
+      "_tgt": "test_lane_bootstrap_testlanebootstrap_test_dirty_invalid_lane_cleanup_refused",
+      "source": "test_lane_bootstrap_testlanebootstrap",
+      "target": "test_lane_bootstrap_testlanebootstrap_test_dirty_invalid_lane_cleanup_refused",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/overlord/test_lane_bootstrap.py",
+      "source_location": "L145",
+      "weight": 1.0,
+      "_src": "test_lane_bootstrap_testlanebootstrap",
+      "_tgt": "test_lane_bootstrap_testlanebootstrap_test_clean_invalid_lane_cleanup_documented",
+      "source": "test_lane_bootstrap_testlanebootstrap",
+      "target": "test_lane_bootstrap_testlanebootstrap_test_clean_invalid_lane_cleanup_documented",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
       "source_file": "scripts/overlord/test_local_ci_gate_workflow_contract.py",
       "source_location": "L53",
       "weight": 1.0,
@@ -32620,7 +33664,7 @@
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/hldpro-governance/var/worktrees/issue-463-stage6-closeout-439/scripts/overlord/test_schema_guard_hook.py",
+      "source_file": "scripts/overlord/test_schema_guard_hook.py",
       "source_location": "L16",
       "weight": 1.0,
       "_src": "test_schema_guard_hook",
@@ -32632,7 +33676,7 @@
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/hldpro-governance/var/worktrees/issue-463-stage6-closeout-439/scripts/overlord/test_schema_guard_hook.py",
+      "source_file": "scripts/overlord/test_schema_guard_hook.py",
       "source_location": "L20",
       "weight": 1.0,
       "_src": "test_schema_guard_hook",
@@ -32644,7 +33688,7 @@
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/hldpro-governance/var/worktrees/issue-463-stage6-closeout-439/scripts/overlord/test_schema_guard_hook.py",
+      "source_file": "scripts/overlord/test_schema_guard_hook.py",
       "source_location": "L35",
       "weight": 1.0,
       "_src": "test_schema_guard_hook",
@@ -32656,7 +33700,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/hldpro-governance/var/worktrees/issue-463-stage6-closeout-439/scripts/overlord/test_schema_guard_hook.py",
+      "source_file": "scripts/overlord/test_schema_guard_hook.py",
       "source_location": "L37",
       "weight": 0.8,
       "_src": "test_schema_guard_hook_testschemaguardhook_test_blocked_bash_file_write_has_stderr",
@@ -32668,7 +33712,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/hldpro-governance/var/worktrees/issue-463-stage6-closeout-439/scripts/overlord/test_schema_guard_hook.py",
+      "source_file": "scripts/overlord/test_schema_guard_hook.py",
       "source_location": "L48",
       "weight": 0.8,
       "_src": "test_schema_guard_hook_testschemaguardhook_test_trivial_plan_bypass_still_reaches_som_write_block",
@@ -32680,7 +33724,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/hldpro-governance/var/worktrees/issue-463-stage6-closeout-439/scripts/overlord/test_schema_guard_hook.py",
+      "source_file": "scripts/overlord/test_schema_guard_hook.py",
       "source_location": "L59",
       "weight": 0.8,
       "_src": "test_schema_guard_hook_testschemaguardhook_test_missing_schema_has_explicit_stderr",
@@ -32692,7 +33736,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/hldpro-governance/var/worktrees/issue-463-stage6-closeout-439/scripts/overlord/test_schema_guard_hook.py",
+      "source_file": "scripts/overlord/test_schema_guard_hook.py",
       "source_location": "L79",
       "weight": 0.8,
       "_src": "test_schema_guard_hook_testschemaguardhook_test_validator_nonzero_is_summarized",
@@ -32704,7 +33748,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/hldpro-governance/var/worktrees/issue-463-stage6-closeout-439/scripts/overlord/test_schema_guard_hook.py",
+      "source_file": "scripts/overlord/test_schema_guard_hook.py",
       "source_location": "L89",
       "weight": 0.8,
       "_src": "test_schema_guard_hook_testschemaguardhook_test_allowed_read_only_command_remains_allowed",
@@ -32716,7 +33760,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/hldpro-governance/var/worktrees/issue-463-stage6-closeout-439/scripts/overlord/test_schema_guard_hook.py",
+      "source_file": "scripts/overlord/test_schema_guard_hook.py",
       "source_location": "L96",
       "weight": 0.8,
       "_src": "test_schema_guard_hook_testschemaguardhook_test_python_file_write_policy_block_has_stderr",
@@ -32728,7 +33772,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/hldpro-governance/var/worktrees/issue-463-stage6-closeout-439/scripts/overlord/test_schema_guard_hook.py",
+      "source_file": "scripts/overlord/test_schema_guard_hook.py",
       "source_location": "L37",
       "weight": 0.8,
       "_src": "test_schema_guard_hook_testschemaguardhook_test_blocked_bash_file_write_has_stderr",
@@ -32740,7 +33784,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/hldpro-governance/var/worktrees/issue-463-stage6-closeout-439/scripts/overlord/test_schema_guard_hook.py",
+      "source_file": "scripts/overlord/test_schema_guard_hook.py",
       "source_location": "L47",
       "weight": 0.8,
       "_src": "test_schema_guard_hook_testschemaguardhook_test_trivial_plan_bypass_still_reaches_som_write_block",
@@ -32752,7 +33796,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/hldpro-governance/var/worktrees/issue-463-stage6-closeout-439/scripts/overlord/test_schema_guard_hook.py",
+      "source_file": "scripts/overlord/test_schema_guard_hook.py",
       "source_location": "L58",
       "weight": 0.8,
       "_src": "test_schema_guard_hook_testschemaguardhook_test_missing_schema_has_explicit_stderr",
@@ -32764,7 +33808,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/hldpro-governance/var/worktrees/issue-463-stage6-closeout-439/scripts/overlord/test_schema_guard_hook.py",
+      "source_file": "scripts/overlord/test_schema_guard_hook.py",
       "source_location": "L67",
       "weight": 0.8,
       "_src": "test_schema_guard_hook_testschemaguardhook_test_malformed_input_payload_has_stderr",
@@ -32776,7 +33820,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/hldpro-governance/var/worktrees/issue-463-stage6-closeout-439/scripts/overlord/test_schema_guard_hook.py",
+      "source_file": "scripts/overlord/test_schema_guard_hook.py",
       "source_location": "L78",
       "weight": 0.8,
       "_src": "test_schema_guard_hook_testschemaguardhook_test_validator_nonzero_is_summarized",
@@ -32788,7 +33832,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/hldpro-governance/var/worktrees/issue-463-stage6-closeout-439/scripts/overlord/test_schema_guard_hook.py",
+      "source_file": "scripts/overlord/test_schema_guard_hook.py",
       "source_location": "L89",
       "weight": 0.8,
       "_src": "test_schema_guard_hook_testschemaguardhook_test_allowed_read_only_command_remains_allowed",
@@ -32800,7 +33844,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/hldpro-governance/var/worktrees/issue-463-stage6-closeout-439/scripts/overlord/test_schema_guard_hook.py",
+      "source_file": "scripts/overlord/test_schema_guard_hook.py",
       "source_location": "L96",
       "weight": 0.8,
       "_src": "test_schema_guard_hook_testschemaguardhook_test_python_file_write_policy_block_has_stderr",
@@ -32812,7 +33856,7 @@
     {
       "relation": "method",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/hldpro-governance/var/worktrees/issue-463-stage6-closeout-439/scripts/overlord/test_schema_guard_hook.py",
+      "source_file": "scripts/overlord/test_schema_guard_hook.py",
       "source_location": "L36",
       "weight": 1.0,
       "_src": "test_schema_guard_hook_testschemaguardhook",
@@ -32824,7 +33868,7 @@
     {
       "relation": "method",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/hldpro-governance/var/worktrees/issue-463-stage6-closeout-439/scripts/overlord/test_schema_guard_hook.py",
+      "source_file": "scripts/overlord/test_schema_guard_hook.py",
       "source_location": "L46",
       "weight": 1.0,
       "_src": "test_schema_guard_hook_testschemaguardhook",
@@ -32836,7 +33880,7 @@
     {
       "relation": "method",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/hldpro-governance/var/worktrees/issue-463-stage6-closeout-439/scripts/overlord/test_schema_guard_hook.py",
+      "source_file": "scripts/overlord/test_schema_guard_hook.py",
       "source_location": "L57",
       "weight": 1.0,
       "_src": "test_schema_guard_hook_testschemaguardhook",
@@ -32848,7 +33892,7 @@
     {
       "relation": "method",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/hldpro-governance/var/worktrees/issue-463-stage6-closeout-439/scripts/overlord/test_schema_guard_hook.py",
+      "source_file": "scripts/overlord/test_schema_guard_hook.py",
       "source_location": "L66",
       "weight": 1.0,
       "_src": "test_schema_guard_hook_testschemaguardhook",
@@ -32860,7 +33904,7 @@
     {
       "relation": "method",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/hldpro-governance/var/worktrees/issue-463-stage6-closeout-439/scripts/overlord/test_schema_guard_hook.py",
+      "source_file": "scripts/overlord/test_schema_guard_hook.py",
       "source_location": "L72",
       "weight": 1.0,
       "_src": "test_schema_guard_hook_testschemaguardhook",
@@ -32872,7 +33916,7 @@
     {
       "relation": "method",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/hldpro-governance/var/worktrees/issue-463-stage6-closeout-439/scripts/overlord/test_schema_guard_hook.py",
+      "source_file": "scripts/overlord/test_schema_guard_hook.py",
       "source_location": "L88",
       "weight": 1.0,
       "_src": "test_schema_guard_hook_testschemaguardhook",
@@ -32884,7 +33928,7 @@
     {
       "relation": "method",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/hldpro-governance/var/worktrees/issue-463-stage6-closeout-439/scripts/overlord/test_schema_guard_hook.py",
+      "source_file": "scripts/overlord/test_schema_guard_hook.py",
       "source_location": "L95",
       "weight": 1.0,
       "_src": "test_schema_guard_hook_testschemaguardhook",
@@ -34829,7 +35873,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/overlord/test_verify_governance_consumer.py",
-      "source_location": "L35",
+      "source_location": "L36",
       "weight": 1.0,
       "_src": "test_verify_governance_consumer",
       "_tgt": "test_verify_governance_consumer_testverifygovernanceconsumer",
@@ -34841,7 +35885,7 @@
       "relation": "method",
       "confidence": "EXTRACTED",
       "source_file": "scripts/overlord/test_verify_governance_consumer.py",
-      "source_location": "L36",
+      "source_location": "L37",
       "weight": 1.0,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer",
       "_tgt": "test_verify_governance_consumer_testverifygovernanceconsumer_setup",
@@ -34853,7 +35897,7 @@
       "relation": "method",
       "confidence": "EXTRACTED",
       "source_file": "scripts/overlord/test_verify_governance_consumer.py",
-      "source_location": "L49",
+      "source_location": "L50",
       "weight": 1.0,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer",
       "_tgt": "test_verify_governance_consumer_testverifygovernanceconsumer_teardown",
@@ -34865,7 +35909,7 @@
       "relation": "method",
       "confidence": "EXTRACTED",
       "source_file": "scripts/overlord/test_verify_governance_consumer.py",
-      "source_location": "L52",
+      "source_location": "L53",
       "weight": 1.0,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer",
       "_tgt": "test_verify_governance_consumer_testverifygovernanceconsumer_deploy",
@@ -34877,7 +35921,7 @@
       "relation": "method",
       "confidence": "EXTRACTED",
       "source_file": "scripts/overlord/test_verify_governance_consumer.py",
-      "source_location": "L68",
+      "source_location": "L71",
       "weight": 1.0,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer",
       "_tgt": "test_verify_governance_consumer_testverifygovernanceconsumer_invoke",
@@ -34889,7 +35933,7 @@
       "relation": "method",
       "confidence": "EXTRACTED",
       "source_file": "scripts/overlord/test_verify_governance_consumer.py",
-      "source_location": "L75",
+      "source_location": "L78",
       "weight": 1.0,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer",
       "_tgt": "test_verify_governance_consumer_testverifygovernanceconsumer_base_args",
@@ -34901,7 +35945,7 @@
       "relation": "method",
       "confidence": "EXTRACTED",
       "source_file": "scripts/overlord/test_verify_governance_consumer.py",
-      "source_location": "L87",
+      "source_location": "L90",
       "weight": 1.0,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer",
       "_tgt": "test_verify_governance_consumer_testverifygovernanceconsumer_record",
@@ -34913,7 +35957,7 @@
       "relation": "method",
       "confidence": "EXTRACTED",
       "source_file": "scripts/overlord/test_verify_governance_consumer.py",
-      "source_location": "L90",
+      "source_location": "L93",
       "weight": 1.0,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer",
       "_tgt": "test_verify_governance_consumer_testverifygovernanceconsumer_shim",
@@ -34925,7 +35969,67 @@
       "relation": "method",
       "confidence": "EXTRACTED",
       "source_file": "scripts/overlord/test_verify_governance_consumer.py",
-      "source_location": "L93",
+      "source_location": "L96",
+      "weight": 1.0,
+      "_src": "test_verify_governance_consumer_testverifygovernanceconsumer",
+      "_tgt": "test_verify_governance_consumer_testverifygovernanceconsumer_read_record",
+      "source": "test_verify_governance_consumer_testverifygovernanceconsumer",
+      "target": "test_verify_governance_consumer_testverifygovernanceconsumer_read_record",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
+      "source_location": "L99",
+      "weight": 1.0,
+      "_src": "test_verify_governance_consumer_testverifygovernanceconsumer",
+      "_tgt": "test_verify_governance_consumer_testverifygovernanceconsumer_write_record",
+      "source": "test_verify_governance_consumer_testverifygovernanceconsumer",
+      "target": "test_verify_governance_consumer_testverifygovernanceconsumer_write_record",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
+      "source_location": "L102",
+      "weight": 1.0,
+      "_src": "test_verify_governance_consumer_testverifygovernanceconsumer",
+      "_tgt": "test_verify_governance_consumer_testverifygovernanceconsumer_valid_override",
+      "source": "test_verify_governance_consumer_testverifygovernanceconsumer",
+      "target": "test_verify_governance_consumer_testverifygovernanceconsumer_valid_override",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
+      "source_location": "L110",
+      "weight": 1.0,
+      "_src": "test_verify_governance_consumer_testverifygovernanceconsumer",
+      "_tgt": "test_verify_governance_consumer_testverifygovernanceconsumer_next_package_version",
+      "source": "test_verify_governance_consumer_testverifygovernanceconsumer",
+      "target": "test_verify_governance_consumer_testverifygovernanceconsumer_next_package_version",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
+      "source_location": "L114",
+      "weight": 1.0,
+      "_src": "test_verify_governance_consumer_testverifygovernanceconsumer",
+      "_tgt": "test_verify_governance_consumer_testverifygovernanceconsumer_required_constraints",
+      "source": "test_verify_governance_consumer_testverifygovernanceconsumer",
+      "target": "test_verify_governance_consumer_testverifygovernanceconsumer_required_constraints",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
+      "source_location": "L118",
       "weight": 1.0,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer",
       "_tgt": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_passes_for_deployed_pinned_consumer_record",
@@ -34937,7 +36041,7 @@
       "relation": "method",
       "confidence": "EXTRACTED",
       "source_file": "scripts/overlord/test_verify_governance_consumer.py",
-      "source_location": "L104",
+      "source_location": "L130",
       "weight": 1.0,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer",
       "_tgt": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_when_record_missing",
@@ -34949,7 +36053,19 @@
       "relation": "method",
       "confidence": "EXTRACTED",
       "source_file": "scripts/overlord/test_verify_governance_consumer.py",
-      "source_location": "L111",
+      "source_location": "L137",
+      "weight": 1.0,
+      "_src": "test_verify_governance_consumer_testverifygovernanceconsumer",
+      "_tgt": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_when_record_is_malformed_shape",
+      "source": "test_verify_governance_consumer_testverifygovernanceconsumer",
+      "target": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_when_record_is_malformed_shape",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
+      "source_location": "L148",
       "weight": 1.0,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer",
       "_tgt": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_when_governance_ref_is_not_sha",
@@ -34961,7 +36077,7 @@
       "relation": "method",
       "confidence": "EXTRACTED",
       "source_file": "scripts/overlord/test_verify_governance_consumer.py",
-      "source_location": "L128",
+      "source_location": "L165",
       "weight": 1.0,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer",
       "_tgt": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_when_shim_missing_marker",
@@ -34973,7 +36089,7 @@
       "relation": "method",
       "confidence": "EXTRACTED",
       "source_file": "scripts/overlord/test_verify_governance_consumer.py",
-      "source_location": "L138",
+      "source_location": "L175",
       "weight": 1.0,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer",
       "_tgt": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_when_expected_profile_mismatches",
@@ -34985,7 +36101,7 @@
       "relation": "method",
       "confidence": "EXTRACTED",
       "source_file": "scripts/overlord/test_verify_governance_consumer.py",
-      "source_location": "L154",
+      "source_location": "L191",
       "weight": 1.0,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer",
       "_tgt": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_when_managed_file_record_omits_expected_path",
@@ -34994,10 +36110,250 @@
       "confidence_score": 1.0
     },
     {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
+      "source_location": "L203",
+      "weight": 1.0,
+      "_src": "test_verify_governance_consumer_testverifygovernanceconsumer",
+      "_tgt": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_when_profile_is_unknown",
+      "source": "test_verify_governance_consumer_testverifygovernanceconsumer",
+      "target": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_when_profile_is_unknown",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
+      "source_location": "L220",
+      "weight": 1.0,
+      "_src": "test_verify_governance_consumer_testverifygovernanceconsumer",
+      "_tgt": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_when_profile_is_missing",
+      "source": "test_verify_governance_consumer_testverifygovernanceconsumer",
+      "target": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_when_profile_is_missing",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
+      "source_location": "L233",
+      "weight": 1.0,
+      "_src": "test_verify_governance_consumer_testverifygovernanceconsumer",
+      "_tgt": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_for_mutable_governance_workflow_ref",
+      "source": "test_verify_governance_consumer_testverifygovernanceconsumer",
+      "target": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_for_mutable_governance_workflow_ref",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
+      "source_location": "L248",
+      "weight": 1.0,
+      "_src": "test_verify_governance_consumer_testverifygovernanceconsumer",
+      "_tgt": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_workflow_ref_is_tag",
+      "source": "test_verify_governance_consumer_testverifygovernanceconsumer",
+      "target": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_workflow_ref_is_tag",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
+      "source_location": "L265",
+      "weight": 1.0,
+      "_src": "test_verify_governance_consumer_testverifygovernanceconsumer",
+      "_tgt": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_workflow_ref_is_short_sha",
+      "source": "test_verify_governance_consumer_testverifygovernanceconsumer",
+      "target": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_workflow_ref_is_short_sha",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
+      "source_location": "L282",
+      "weight": 1.0,
+      "_src": "test_verify_governance_consumer_testverifygovernanceconsumer",
+      "_tgt": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_workflow_ref_sha_mismatch",
+      "source": "test_verify_governance_consumer_testverifygovernanceconsumer",
+      "target": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_workflow_ref_sha_mismatch",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
+      "source_location": "L300",
+      "weight": 1.0,
+      "_src": "test_verify_governance_consumer_testverifygovernanceconsumer",
+      "_tgt": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_for_managed_hook_checksum_drift",
+      "source": "test_verify_governance_consumer_testverifygovernanceconsumer",
+      "target": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_for_managed_hook_checksum_drift",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
+      "source_location": "L321",
+      "weight": 1.0,
+      "_src": "test_verify_governance_consumer_testverifygovernanceconsumer",
+      "_tgt": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_for_managed_hook_missing_marker",
+      "source": "test_verify_governance_consumer_testverifygovernanceconsumer",
+      "target": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_for_managed_hook_missing_marker",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
+      "source_location": "L336",
+      "weight": 1.0,
+      "_src": "test_verify_governance_consumer_testverifygovernanceconsumer",
+      "_tgt": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_for_invalid_override_metadata_and_reports_observed_override",
+      "source": "test_verify_governance_consumer_testverifygovernanceconsumer",
+      "target": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_for_invalid_override_metadata_and_reports_observed_override",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
+      "source_location": "L350",
+      "weight": 1.0,
+      "_src": "test_verify_governance_consumer_testverifygovernanceconsumer",
+      "_tgt": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_override_empty_owner",
+      "source": "test_verify_governance_consumer_testverifygovernanceconsumer",
+      "target": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_override_empty_owner",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
+      "source_location": "L365",
+      "weight": 1.0,
+      "_src": "test_verify_governance_consumer_testverifygovernanceconsumer",
+      "_tgt": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_override_non_string_reason",
+      "source": "test_verify_governance_consumer_testverifygovernanceconsumer",
+      "target": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_override_non_string_reason",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
+      "source_location": "L380",
+      "weight": 1.0,
+      "_src": "test_verify_governance_consumer_testverifygovernanceconsumer",
+      "_tgt": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_override_empty_expires_at",
+      "source": "test_verify_governance_consumer_testverifygovernanceconsumer",
+      "target": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_override_empty_expires_at",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
+      "source_location": "L399",
+      "weight": 1.0,
+      "_src": "test_verify_governance_consumer_testverifygovernanceconsumer",
+      "_tgt": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_override_weakens_healthcareplatform_hipaa",
+      "source": "test_verify_governance_consumer_testverifygovernanceconsumer",
+      "target": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_override_weakens_healthcareplatform_hipaa",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
+      "source_location": "L413",
+      "weight": 1.0,
+      "_src": "test_verify_governance_consumer_testverifygovernanceconsumer",
+      "_tgt": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_override_disables_seek_plan_mode",
+      "source": "test_verify_governance_consumer_testverifygovernanceconsumer",
+      "target": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_override_disables_seek_plan_mode",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
+      "source_location": "L427",
+      "weight": 1.0,
+      "_src": "test_verify_governance_consumer_testverifygovernanceconsumer",
+      "_tgt": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_override_routes_pii_away_from_lam",
+      "source": "test_verify_governance_consumer_testverifygovernanceconsumer",
+      "target": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_override_routes_pii_away_from_lam",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
+      "source_location": "L441",
+      "weight": 1.0,
+      "_src": "test_verify_governance_consumer_testverifygovernanceconsumer",
+      "_tgt": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_override_core_fork_without_exception",
+      "source": "test_verify_governance_consumer_testverifygovernanceconsumer",
+      "target": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_override_core_fork_without_exception",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
+      "source_location": "L455",
+      "weight": 1.0,
+      "_src": "test_verify_governance_consumer_testverifygovernanceconsumer",
+      "_tgt": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_override_disables_ci_required_gate",
+      "source": "test_verify_governance_consumer_testverifygovernanceconsumer",
+      "target": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_override_disables_ci_required_gate",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
+      "source_location": "L469",
+      "weight": 1.0,
+      "_src": "test_verify_governance_consumer_testverifygovernanceconsumer",
+      "_tgt": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_override_dry_run_as_live_evidence",
+      "source": "test_verify_governance_consumer_testverifygovernanceconsumer",
+      "target": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_override_dry_run_as_live_evidence",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
+      "source_location": "L483",
+      "weight": 1.0,
+      "_src": "test_verify_governance_consumer_testverifygovernanceconsumer",
+      "_tgt": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_when_healthcareplatform_v2_profile_weakens_constraints",
+      "source": "test_verify_governance_consumer_testverifygovernanceconsumer",
+      "target": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_when_healthcareplatform_v2_profile_weakens_constraints",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
+      "source_location": "L509",
+      "weight": 1.0,
+      "_src": "test_verify_governance_consumer_testverifygovernanceconsumer",
+      "_tgt": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_passes_for_valid_v2_managed_consumer",
+      "source": "test_verify_governance_consumer_testverifygovernanceconsumer",
+      "target": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_passes_for_valid_v2_managed_consumer",
+      "confidence_score": 1.0
+    },
+    {
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/overlord/test_verify_governance_consumer.py",
-      "source_location": "L94",
+      "source_location": "L119",
       "weight": 0.8,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_passes_for_deployed_pinned_consumer_record",
       "_tgt": "test_verify_governance_consumer_testverifygovernanceconsumer_deploy",
@@ -35009,7 +36365,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/overlord/test_verify_governance_consumer.py",
-      "source_location": "L112",
+      "source_location": "L149",
       "weight": 0.8,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_when_governance_ref_is_not_sha",
       "_tgt": "test_verify_governance_consumer_testverifygovernanceconsumer_deploy",
@@ -35021,7 +36377,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/overlord/test_verify_governance_consumer.py",
-      "source_location": "L129",
+      "source_location": "L166",
       "weight": 0.8,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_when_shim_missing_marker",
       "_tgt": "test_verify_governance_consumer_testverifygovernanceconsumer_deploy",
@@ -35033,7 +36389,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/overlord/test_verify_governance_consumer.py",
-      "source_location": "L139",
+      "source_location": "L176",
       "weight": 0.8,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_when_expected_profile_mismatches",
       "_tgt": "test_verify_governance_consumer_testverifygovernanceconsumer_deploy",
@@ -35045,7 +36401,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/overlord/test_verify_governance_consumer.py",
-      "source_location": "L155",
+      "source_location": "L192",
       "weight": 0.8,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_when_managed_file_record_omits_expected_path",
       "_tgt": "test_verify_governance_consumer_testverifygovernanceconsumer_deploy",
@@ -35057,7 +36413,247 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/overlord/test_verify_governance_consumer.py",
-      "source_location": "L96",
+      "source_location": "L204",
+      "weight": 0.8,
+      "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_when_profile_is_unknown",
+      "_tgt": "test_verify_governance_consumer_testverifygovernanceconsumer_deploy",
+      "source": "test_verify_governance_consumer_testverifygovernanceconsumer_deploy",
+      "target": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_when_profile_is_unknown",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
+      "source_location": "L221",
+      "weight": 0.8,
+      "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_when_profile_is_missing",
+      "_tgt": "test_verify_governance_consumer_testverifygovernanceconsumer_deploy",
+      "source": "test_verify_governance_consumer_testverifygovernanceconsumer_deploy",
+      "target": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_when_profile_is_missing",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
+      "source_location": "L234",
+      "weight": 0.8,
+      "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_for_mutable_governance_workflow_ref",
+      "_tgt": "test_verify_governance_consumer_testverifygovernanceconsumer_deploy",
+      "source": "test_verify_governance_consumer_testverifygovernanceconsumer_deploy",
+      "target": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_for_mutable_governance_workflow_ref",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
+      "source_location": "L249",
+      "weight": 0.8,
+      "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_workflow_ref_is_tag",
+      "_tgt": "test_verify_governance_consumer_testverifygovernanceconsumer_deploy",
+      "source": "test_verify_governance_consumer_testverifygovernanceconsumer_deploy",
+      "target": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_workflow_ref_is_tag",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
+      "source_location": "L266",
+      "weight": 0.8,
+      "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_workflow_ref_is_short_sha",
+      "_tgt": "test_verify_governance_consumer_testverifygovernanceconsumer_deploy",
+      "source": "test_verify_governance_consumer_testverifygovernanceconsumer_deploy",
+      "target": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_workflow_ref_is_short_sha",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
+      "source_location": "L283",
+      "weight": 0.8,
+      "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_workflow_ref_sha_mismatch",
+      "_tgt": "test_verify_governance_consumer_testverifygovernanceconsumer_deploy",
+      "source": "test_verify_governance_consumer_testverifygovernanceconsumer_deploy",
+      "target": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_workflow_ref_sha_mismatch",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
+      "source_location": "L301",
+      "weight": 0.8,
+      "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_for_managed_hook_checksum_drift",
+      "_tgt": "test_verify_governance_consumer_testverifygovernanceconsumer_deploy",
+      "source": "test_verify_governance_consumer_testverifygovernanceconsumer_deploy",
+      "target": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_for_managed_hook_checksum_drift",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
+      "source_location": "L322",
+      "weight": 0.8,
+      "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_for_managed_hook_missing_marker",
+      "_tgt": "test_verify_governance_consumer_testverifygovernanceconsumer_deploy",
+      "source": "test_verify_governance_consumer_testverifygovernanceconsumer_deploy",
+      "target": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_for_managed_hook_missing_marker",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
+      "source_location": "L337",
+      "weight": 0.8,
+      "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_for_invalid_override_metadata_and_reports_observed_override",
+      "_tgt": "test_verify_governance_consumer_testverifygovernanceconsumer_deploy",
+      "source": "test_verify_governance_consumer_testverifygovernanceconsumer_deploy",
+      "target": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_for_invalid_override_metadata_and_reports_observed_override",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
+      "source_location": "L351",
+      "weight": 0.8,
+      "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_override_empty_owner",
+      "_tgt": "test_verify_governance_consumer_testverifygovernanceconsumer_deploy",
+      "source": "test_verify_governance_consumer_testverifygovernanceconsumer_deploy",
+      "target": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_override_empty_owner",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
+      "source_location": "L366",
+      "weight": 0.8,
+      "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_override_non_string_reason",
+      "_tgt": "test_verify_governance_consumer_testverifygovernanceconsumer_deploy",
+      "source": "test_verify_governance_consumer_testverifygovernanceconsumer_deploy",
+      "target": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_override_non_string_reason",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
+      "source_location": "L381",
+      "weight": 0.8,
+      "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_override_empty_expires_at",
+      "_tgt": "test_verify_governance_consumer_testverifygovernanceconsumer_deploy",
+      "source": "test_verify_governance_consumer_testverifygovernanceconsumer_deploy",
+      "target": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_override_empty_expires_at",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
+      "source_location": "L400",
+      "weight": 0.8,
+      "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_override_weakens_healthcareplatform_hipaa",
+      "_tgt": "test_verify_governance_consumer_testverifygovernanceconsumer_deploy",
+      "source": "test_verify_governance_consumer_testverifygovernanceconsumer_deploy",
+      "target": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_override_weakens_healthcareplatform_hipaa",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
+      "source_location": "L414",
+      "weight": 0.8,
+      "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_override_disables_seek_plan_mode",
+      "_tgt": "test_verify_governance_consumer_testverifygovernanceconsumer_deploy",
+      "source": "test_verify_governance_consumer_testverifygovernanceconsumer_deploy",
+      "target": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_override_disables_seek_plan_mode",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
+      "source_location": "L428",
+      "weight": 0.8,
+      "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_override_routes_pii_away_from_lam",
+      "_tgt": "test_verify_governance_consumer_testverifygovernanceconsumer_deploy",
+      "source": "test_verify_governance_consumer_testverifygovernanceconsumer_deploy",
+      "target": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_override_routes_pii_away_from_lam",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
+      "source_location": "L442",
+      "weight": 0.8,
+      "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_override_core_fork_without_exception",
+      "_tgt": "test_verify_governance_consumer_testverifygovernanceconsumer_deploy",
+      "source": "test_verify_governance_consumer_testverifygovernanceconsumer_deploy",
+      "target": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_override_core_fork_without_exception",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
+      "source_location": "L456",
+      "weight": 0.8,
+      "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_override_disables_ci_required_gate",
+      "_tgt": "test_verify_governance_consumer_testverifygovernanceconsumer_deploy",
+      "source": "test_verify_governance_consumer_testverifygovernanceconsumer_deploy",
+      "target": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_override_disables_ci_required_gate",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
+      "source_location": "L470",
+      "weight": 0.8,
+      "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_override_dry_run_as_live_evidence",
+      "_tgt": "test_verify_governance_consumer_testverifygovernanceconsumer_deploy",
+      "source": "test_verify_governance_consumer_testverifygovernanceconsumer_deploy",
+      "target": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_override_dry_run_as_live_evidence",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
+      "source_location": "L485",
+      "weight": 0.8,
+      "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_when_healthcareplatform_v2_profile_weakens_constraints",
+      "_tgt": "test_verify_governance_consumer_testverifygovernanceconsumer_deploy",
+      "source": "test_verify_governance_consumer_testverifygovernanceconsumer_deploy",
+      "target": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_when_healthcareplatform_v2_profile_weakens_constraints",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
+      "source_location": "L511",
+      "weight": 0.8,
+      "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_passes_for_valid_v2_managed_consumer",
+      "_tgt": "test_verify_governance_consumer_testverifygovernanceconsumer_deploy",
+      "source": "test_verify_governance_consumer_testverifygovernanceconsumer_deploy",
+      "target": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_passes_for_valid_v2_managed_consumer",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
+      "source_location": "L121",
       "weight": 0.8,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_passes_for_deployed_pinned_consumer_record",
       "_tgt": "test_verify_governance_consumer_testverifygovernanceconsumer_invoke",
@@ -35069,7 +36665,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/overlord/test_verify_governance_consumer.py",
-      "source_location": "L105",
+      "source_location": "L131",
       "weight": 0.8,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_when_record_missing",
       "_tgt": "test_verify_governance_consumer_testverifygovernanceconsumer_invoke",
@@ -35081,7 +36677,19 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/overlord/test_verify_governance_consumer.py",
-      "source_location": "L114",
+      "source_location": "L142",
+      "weight": 0.8,
+      "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_when_record_is_malformed_shape",
+      "_tgt": "test_verify_governance_consumer_testverifygovernanceconsumer_invoke",
+      "source": "test_verify_governance_consumer_testverifygovernanceconsumer_invoke",
+      "target": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_when_record_is_malformed_shape",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
+      "source_location": "L151",
       "weight": 0.8,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_when_governance_ref_is_not_sha",
       "_tgt": "test_verify_governance_consumer_testverifygovernanceconsumer_invoke",
@@ -35093,7 +36701,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/overlord/test_verify_governance_consumer.py",
-      "source_location": "L132",
+      "source_location": "L169",
       "weight": 0.8,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_when_shim_missing_marker",
       "_tgt": "test_verify_governance_consumer_testverifygovernanceconsumer_invoke",
@@ -35105,7 +36713,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/overlord/test_verify_governance_consumer.py",
-      "source_location": "L141",
+      "source_location": "L178",
       "weight": 0.8,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_when_expected_profile_mismatches",
       "_tgt": "test_verify_governance_consumer_testverifygovernanceconsumer_invoke",
@@ -35117,7 +36725,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/overlord/test_verify_governance_consumer.py",
-      "source_location": "L160",
+      "source_location": "L197",
       "weight": 0.8,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_when_managed_file_record_omits_expected_path",
       "_tgt": "test_verify_governance_consumer_testverifygovernanceconsumer_invoke",
@@ -35129,7 +36737,247 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/overlord/test_verify_governance_consumer.py",
-      "source_location": "L96",
+      "source_location": "L209",
+      "weight": 0.8,
+      "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_when_profile_is_unknown",
+      "_tgt": "test_verify_governance_consumer_testverifygovernanceconsumer_invoke",
+      "source": "test_verify_governance_consumer_testverifygovernanceconsumer_invoke",
+      "target": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_when_profile_is_unknown",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
+      "source_location": "L226",
+      "weight": 0.8,
+      "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_when_profile_is_missing",
+      "_tgt": "test_verify_governance_consumer_testverifygovernanceconsumer_invoke",
+      "source": "test_verify_governance_consumer_testverifygovernanceconsumer_invoke",
+      "target": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_when_profile_is_missing",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
+      "source_location": "L242",
+      "weight": 0.8,
+      "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_for_mutable_governance_workflow_ref",
+      "_tgt": "test_verify_governance_consumer_testverifygovernanceconsumer_invoke",
+      "source": "test_verify_governance_consumer_testverifygovernanceconsumer_invoke",
+      "target": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_for_mutable_governance_workflow_ref",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
+      "source_location": "L257",
+      "weight": 0.8,
+      "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_workflow_ref_is_tag",
+      "_tgt": "test_verify_governance_consumer_testverifygovernanceconsumer_invoke",
+      "source": "test_verify_governance_consumer_testverifygovernanceconsumer_invoke",
+      "target": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_workflow_ref_is_tag",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
+      "source_location": "L274",
+      "weight": 0.8,
+      "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_workflow_ref_is_short_sha",
+      "_tgt": "test_verify_governance_consumer_testverifygovernanceconsumer_invoke",
+      "source": "test_verify_governance_consumer_testverifygovernanceconsumer_invoke",
+      "target": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_workflow_ref_is_short_sha",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
+      "source_location": "L292",
+      "weight": 0.8,
+      "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_workflow_ref_sha_mismatch",
+      "_tgt": "test_verify_governance_consumer_testverifygovernanceconsumer_invoke",
+      "source": "test_verify_governance_consumer_testverifygovernanceconsumer_invoke",
+      "target": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_workflow_ref_sha_mismatch",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
+      "source_location": "L315",
+      "weight": 0.8,
+      "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_for_managed_hook_checksum_drift",
+      "_tgt": "test_verify_governance_consumer_testverifygovernanceconsumer_invoke",
+      "source": "test_verify_governance_consumer_testverifygovernanceconsumer_invoke",
+      "target": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_for_managed_hook_checksum_drift",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
+      "source_location": "L330",
+      "weight": 0.8,
+      "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_for_managed_hook_missing_marker",
+      "_tgt": "test_verify_governance_consumer_testverifygovernanceconsumer_invoke",
+      "source": "test_verify_governance_consumer_testverifygovernanceconsumer_invoke",
+      "target": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_for_managed_hook_missing_marker",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
+      "source_location": "L342",
+      "weight": 0.8,
+      "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_for_invalid_override_metadata_and_reports_observed_override",
+      "_tgt": "test_verify_governance_consumer_testverifygovernanceconsumer_invoke",
+      "source": "test_verify_governance_consumer_testverifygovernanceconsumer_invoke",
+      "target": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_for_invalid_override_metadata_and_reports_observed_override",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
+      "source_location": "L358",
+      "weight": 0.8,
+      "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_override_empty_owner",
+      "_tgt": "test_verify_governance_consumer_testverifygovernanceconsumer_invoke",
+      "source": "test_verify_governance_consumer_testverifygovernanceconsumer_invoke",
+      "target": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_override_empty_owner",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
+      "source_location": "L373",
+      "weight": 0.8,
+      "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_override_non_string_reason",
+      "_tgt": "test_verify_governance_consumer_testverifygovernanceconsumer_invoke",
+      "source": "test_verify_governance_consumer_testverifygovernanceconsumer_invoke",
+      "target": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_override_non_string_reason",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
+      "source_location": "L392",
+      "weight": 0.8,
+      "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_override_empty_expires_at",
+      "_tgt": "test_verify_governance_consumer_testverifygovernanceconsumer_invoke",
+      "source": "test_verify_governance_consumer_testverifygovernanceconsumer_invoke",
+      "target": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_override_empty_expires_at",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
+      "source_location": "L405",
+      "weight": 0.8,
+      "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_override_weakens_healthcareplatform_hipaa",
+      "_tgt": "test_verify_governance_consumer_testverifygovernanceconsumer_invoke",
+      "source": "test_verify_governance_consumer_testverifygovernanceconsumer_invoke",
+      "target": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_override_weakens_healthcareplatform_hipaa",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
+      "source_location": "L419",
+      "weight": 0.8,
+      "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_override_disables_seek_plan_mode",
+      "_tgt": "test_verify_governance_consumer_testverifygovernanceconsumer_invoke",
+      "source": "test_verify_governance_consumer_testverifygovernanceconsumer_invoke",
+      "target": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_override_disables_seek_plan_mode",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
+      "source_location": "L433",
+      "weight": 0.8,
+      "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_override_routes_pii_away_from_lam",
+      "_tgt": "test_verify_governance_consumer_testverifygovernanceconsumer_invoke",
+      "source": "test_verify_governance_consumer_testverifygovernanceconsumer_invoke",
+      "target": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_override_routes_pii_away_from_lam",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
+      "source_location": "L447",
+      "weight": 0.8,
+      "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_override_core_fork_without_exception",
+      "_tgt": "test_verify_governance_consumer_testverifygovernanceconsumer_invoke",
+      "source": "test_verify_governance_consumer_testverifygovernanceconsumer_invoke",
+      "target": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_override_core_fork_without_exception",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
+      "source_location": "L461",
+      "weight": 0.8,
+      "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_override_disables_ci_required_gate",
+      "_tgt": "test_verify_governance_consumer_testverifygovernanceconsumer_invoke",
+      "source": "test_verify_governance_consumer_testverifygovernanceconsumer_invoke",
+      "target": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_override_disables_ci_required_gate",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
+      "source_location": "L475",
+      "weight": 0.8,
+      "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_override_dry_run_as_live_evidence",
+      "_tgt": "test_verify_governance_consumer_testverifygovernanceconsumer_invoke",
+      "source": "test_verify_governance_consumer_testverifygovernanceconsumer_invoke",
+      "target": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_override_dry_run_as_live_evidence",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
+      "source_location": "L492",
+      "weight": 0.8,
+      "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_when_healthcareplatform_v2_profile_weakens_constraints",
+      "_tgt": "test_verify_governance_consumer_testverifygovernanceconsumer_invoke",
+      "source": "test_verify_governance_consumer_testverifygovernanceconsumer_invoke",
+      "target": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_when_healthcareplatform_v2_profile_weakens_constraints",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
+      "source_location": "L541",
+      "weight": 0.8,
+      "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_passes_for_valid_v2_managed_consumer",
+      "_tgt": "test_verify_governance_consumer_testverifygovernanceconsumer_invoke",
+      "source": "test_verify_governance_consumer_testverifygovernanceconsumer_invoke",
+      "target": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_passes_for_valid_v2_managed_consumer",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
+      "source_location": "L121",
       "weight": 0.8,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_passes_for_deployed_pinned_consumer_record",
       "_tgt": "test_verify_governance_consumer_testverifygovernanceconsumer_base_args",
@@ -35141,7 +36989,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/overlord/test_verify_governance_consumer.py",
-      "source_location": "L105",
+      "source_location": "L131",
       "weight": 0.8,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_when_record_missing",
       "_tgt": "test_verify_governance_consumer_testverifygovernanceconsumer_base_args",
@@ -35153,7 +37001,19 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/overlord/test_verify_governance_consumer.py",
-      "source_location": "L132",
+      "source_location": "L142",
+      "weight": 0.8,
+      "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_when_record_is_malformed_shape",
+      "_tgt": "test_verify_governance_consumer_testverifygovernanceconsumer_base_args",
+      "source": "test_verify_governance_consumer_testverifygovernanceconsumer_base_args",
+      "target": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_when_record_is_malformed_shape",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
+      "source_location": "L169",
       "weight": 0.8,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_when_shim_missing_marker",
       "_tgt": "test_verify_governance_consumer_testverifygovernanceconsumer_base_args",
@@ -35165,7 +37025,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/overlord/test_verify_governance_consumer.py",
-      "source_location": "L160",
+      "source_location": "L197",
       "weight": 0.8,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_when_managed_file_record_omits_expected_path",
       "_tgt": "test_verify_governance_consumer_testverifygovernanceconsumer_base_args",
@@ -35177,7 +37037,235 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/overlord/test_verify_governance_consumer.py",
-      "source_location": "L156",
+      "source_location": "L226",
+      "weight": 0.8,
+      "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_when_profile_is_missing",
+      "_tgt": "test_verify_governance_consumer_testverifygovernanceconsumer_base_args",
+      "source": "test_verify_governance_consumer_testverifygovernanceconsumer_base_args",
+      "target": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_when_profile_is_missing",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
+      "source_location": "L242",
+      "weight": 0.8,
+      "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_for_mutable_governance_workflow_ref",
+      "_tgt": "test_verify_governance_consumer_testverifygovernanceconsumer_base_args",
+      "source": "test_verify_governance_consumer_testverifygovernanceconsumer_base_args",
+      "target": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_for_mutable_governance_workflow_ref",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
+      "source_location": "L257",
+      "weight": 0.8,
+      "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_workflow_ref_is_tag",
+      "_tgt": "test_verify_governance_consumer_testverifygovernanceconsumer_base_args",
+      "source": "test_verify_governance_consumer_testverifygovernanceconsumer_base_args",
+      "target": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_workflow_ref_is_tag",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
+      "source_location": "L274",
+      "weight": 0.8,
+      "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_workflow_ref_is_short_sha",
+      "_tgt": "test_verify_governance_consumer_testverifygovernanceconsumer_base_args",
+      "source": "test_verify_governance_consumer_testverifygovernanceconsumer_base_args",
+      "target": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_workflow_ref_is_short_sha",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
+      "source_location": "L292",
+      "weight": 0.8,
+      "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_workflow_ref_sha_mismatch",
+      "_tgt": "test_verify_governance_consumer_testverifygovernanceconsumer_base_args",
+      "source": "test_verify_governance_consumer_testverifygovernanceconsumer_base_args",
+      "target": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_workflow_ref_sha_mismatch",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
+      "source_location": "L315",
+      "weight": 0.8,
+      "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_for_managed_hook_checksum_drift",
+      "_tgt": "test_verify_governance_consumer_testverifygovernanceconsumer_base_args",
+      "source": "test_verify_governance_consumer_testverifygovernanceconsumer_base_args",
+      "target": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_for_managed_hook_checksum_drift",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
+      "source_location": "L330",
+      "weight": 0.8,
+      "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_for_managed_hook_missing_marker",
+      "_tgt": "test_verify_governance_consumer_testverifygovernanceconsumer_base_args",
+      "source": "test_verify_governance_consumer_testverifygovernanceconsumer_base_args",
+      "target": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_for_managed_hook_missing_marker",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
+      "source_location": "L342",
+      "weight": 0.8,
+      "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_for_invalid_override_metadata_and_reports_observed_override",
+      "_tgt": "test_verify_governance_consumer_testverifygovernanceconsumer_base_args",
+      "source": "test_verify_governance_consumer_testverifygovernanceconsumer_base_args",
+      "target": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_for_invalid_override_metadata_and_reports_observed_override",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
+      "source_location": "L358",
+      "weight": 0.8,
+      "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_override_empty_owner",
+      "_tgt": "test_verify_governance_consumer_testverifygovernanceconsumer_base_args",
+      "source": "test_verify_governance_consumer_testverifygovernanceconsumer_base_args",
+      "target": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_override_empty_owner",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
+      "source_location": "L373",
+      "weight": 0.8,
+      "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_override_non_string_reason",
+      "_tgt": "test_verify_governance_consumer_testverifygovernanceconsumer_base_args",
+      "source": "test_verify_governance_consumer_testverifygovernanceconsumer_base_args",
+      "target": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_override_non_string_reason",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
+      "source_location": "L392",
+      "weight": 0.8,
+      "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_override_empty_expires_at",
+      "_tgt": "test_verify_governance_consumer_testverifygovernanceconsumer_base_args",
+      "source": "test_verify_governance_consumer_testverifygovernanceconsumer_base_args",
+      "target": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_override_empty_expires_at",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
+      "source_location": "L405",
+      "weight": 0.8,
+      "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_override_weakens_healthcareplatform_hipaa",
+      "_tgt": "test_verify_governance_consumer_testverifygovernanceconsumer_base_args",
+      "source": "test_verify_governance_consumer_testverifygovernanceconsumer_base_args",
+      "target": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_override_weakens_healthcareplatform_hipaa",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
+      "source_location": "L419",
+      "weight": 0.8,
+      "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_override_disables_seek_plan_mode",
+      "_tgt": "test_verify_governance_consumer_testverifygovernanceconsumer_base_args",
+      "source": "test_verify_governance_consumer_testverifygovernanceconsumer_base_args",
+      "target": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_override_disables_seek_plan_mode",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
+      "source_location": "L433",
+      "weight": 0.8,
+      "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_override_routes_pii_away_from_lam",
+      "_tgt": "test_verify_governance_consumer_testverifygovernanceconsumer_base_args",
+      "source": "test_verify_governance_consumer_testverifygovernanceconsumer_base_args",
+      "target": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_override_routes_pii_away_from_lam",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
+      "source_location": "L447",
+      "weight": 0.8,
+      "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_override_core_fork_without_exception",
+      "_tgt": "test_verify_governance_consumer_testverifygovernanceconsumer_base_args",
+      "source": "test_verify_governance_consumer_testverifygovernanceconsumer_base_args",
+      "target": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_override_core_fork_without_exception",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
+      "source_location": "L461",
+      "weight": 0.8,
+      "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_override_disables_ci_required_gate",
+      "_tgt": "test_verify_governance_consumer_testverifygovernanceconsumer_base_args",
+      "source": "test_verify_governance_consumer_testverifygovernanceconsumer_base_args",
+      "target": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_override_disables_ci_required_gate",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
+      "source_location": "L475",
+      "weight": 0.8,
+      "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_override_dry_run_as_live_evidence",
+      "_tgt": "test_verify_governance_consumer_testverifygovernanceconsumer_base_args",
+      "source": "test_verify_governance_consumer_testverifygovernanceconsumer_base_args",
+      "target": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_override_dry_run_as_live_evidence",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
+      "source_location": "L97",
+      "weight": 0.8,
+      "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_read_record",
+      "_tgt": "test_verify_governance_consumer_testverifygovernanceconsumer_record",
+      "source": "test_verify_governance_consumer_testverifygovernanceconsumer_record",
+      "target": "test_verify_governance_consumer_testverifygovernanceconsumer_read_record",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
+      "source_location": "L100",
+      "weight": 0.8,
+      "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_write_record",
+      "_tgt": "test_verify_governance_consumer_testverifygovernanceconsumer_record",
+      "source": "test_verify_governance_consumer_testverifygovernanceconsumer_record",
+      "target": "test_verify_governance_consumer_testverifygovernanceconsumer_write_record",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
+      "source_location": "L193",
       "weight": 0.8,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_when_managed_file_record_omits_expected_path",
       "_tgt": "test_verify_governance_consumer_testverifygovernanceconsumer_record",
@@ -35189,12 +37277,540 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/overlord/test_verify_governance_consumer.py",
-      "source_location": "L130",
+      "source_location": "L167",
       "weight": 0.8,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_when_shim_missing_marker",
       "_tgt": "test_verify_governance_consumer_testverifygovernanceconsumer_shim",
       "source": "test_verify_governance_consumer_testverifygovernanceconsumer_shim",
       "target": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_when_shim_missing_marker",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
+      "source_location": "L205",
+      "weight": 0.8,
+      "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_when_profile_is_unknown",
+      "_tgt": "test_verify_governance_consumer_testverifygovernanceconsumer_read_record",
+      "source": "test_verify_governance_consumer_testverifygovernanceconsumer_read_record",
+      "target": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_when_profile_is_unknown",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
+      "source_location": "L222",
+      "weight": 0.8,
+      "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_when_profile_is_missing",
+      "_tgt": "test_verify_governance_consumer_testverifygovernanceconsumer_read_record",
+      "source": "test_verify_governance_consumer_testverifygovernanceconsumer_read_record",
+      "target": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_when_profile_is_missing",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
+      "source_location": "L305",
+      "weight": 0.8,
+      "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_for_managed_hook_checksum_drift",
+      "_tgt": "test_verify_governance_consumer_testverifygovernanceconsumer_read_record",
+      "source": "test_verify_governance_consumer_testverifygovernanceconsumer_read_record",
+      "target": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_for_managed_hook_checksum_drift",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
+      "source_location": "L326",
+      "weight": 0.8,
+      "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_for_managed_hook_missing_marker",
+      "_tgt": "test_verify_governance_consumer_testverifygovernanceconsumer_read_record",
+      "source": "test_verify_governance_consumer_testverifygovernanceconsumer_read_record",
+      "target": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_for_managed_hook_missing_marker",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
+      "source_location": "L338",
+      "weight": 0.8,
+      "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_for_invalid_override_metadata_and_reports_observed_override",
+      "_tgt": "test_verify_governance_consumer_testverifygovernanceconsumer_read_record",
+      "source": "test_verify_governance_consumer_testverifygovernanceconsumer_read_record",
+      "target": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_for_invalid_override_metadata_and_reports_observed_override",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
+      "source_location": "L352",
+      "weight": 0.8,
+      "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_override_empty_owner",
+      "_tgt": "test_verify_governance_consumer_testverifygovernanceconsumer_read_record",
+      "source": "test_verify_governance_consumer_testverifygovernanceconsumer_read_record",
+      "target": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_override_empty_owner",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
+      "source_location": "L367",
+      "weight": 0.8,
+      "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_override_non_string_reason",
+      "_tgt": "test_verify_governance_consumer_testverifygovernanceconsumer_read_record",
+      "source": "test_verify_governance_consumer_testverifygovernanceconsumer_read_record",
+      "target": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_override_non_string_reason",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
+      "source_location": "L382",
+      "weight": 0.8,
+      "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_override_empty_expires_at",
+      "_tgt": "test_verify_governance_consumer_testverifygovernanceconsumer_read_record",
+      "source": "test_verify_governance_consumer_testverifygovernanceconsumer_read_record",
+      "target": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_override_empty_expires_at",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
+      "source_location": "L401",
+      "weight": 0.8,
+      "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_override_weakens_healthcareplatform_hipaa",
+      "_tgt": "test_verify_governance_consumer_testverifygovernanceconsumer_read_record",
+      "source": "test_verify_governance_consumer_testverifygovernanceconsumer_read_record",
+      "target": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_override_weakens_healthcareplatform_hipaa",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
+      "source_location": "L415",
+      "weight": 0.8,
+      "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_override_disables_seek_plan_mode",
+      "_tgt": "test_verify_governance_consumer_testverifygovernanceconsumer_read_record",
+      "source": "test_verify_governance_consumer_testverifygovernanceconsumer_read_record",
+      "target": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_override_disables_seek_plan_mode",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
+      "source_location": "L429",
+      "weight": 0.8,
+      "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_override_routes_pii_away_from_lam",
+      "_tgt": "test_verify_governance_consumer_testverifygovernanceconsumer_read_record",
+      "source": "test_verify_governance_consumer_testverifygovernanceconsumer_read_record",
+      "target": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_override_routes_pii_away_from_lam",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
+      "source_location": "L443",
+      "weight": 0.8,
+      "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_override_core_fork_without_exception",
+      "_tgt": "test_verify_governance_consumer_testverifygovernanceconsumer_read_record",
+      "source": "test_verify_governance_consumer_testverifygovernanceconsumer_read_record",
+      "target": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_override_core_fork_without_exception",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
+      "source_location": "L457",
+      "weight": 0.8,
+      "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_override_disables_ci_required_gate",
+      "_tgt": "test_verify_governance_consumer_testverifygovernanceconsumer_read_record",
+      "source": "test_verify_governance_consumer_testverifygovernanceconsumer_read_record",
+      "target": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_override_disables_ci_required_gate",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
+      "source_location": "L471",
+      "weight": 0.8,
+      "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_override_dry_run_as_live_evidence",
+      "_tgt": "test_verify_governance_consumer_testverifygovernanceconsumer_read_record",
+      "source": "test_verify_governance_consumer_testverifygovernanceconsumer_read_record",
+      "target": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_override_dry_run_as_live_evidence",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
+      "source_location": "L487",
+      "weight": 0.8,
+      "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_when_healthcareplatform_v2_profile_weakens_constraints",
+      "_tgt": "test_verify_governance_consumer_testverifygovernanceconsumer_read_record",
+      "source": "test_verify_governance_consumer_testverifygovernanceconsumer_read_record",
+      "target": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_when_healthcareplatform_v2_profile_weakens_constraints",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
+      "source_location": "L515",
+      "weight": 0.8,
+      "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_passes_for_valid_v2_managed_consumer",
+      "_tgt": "test_verify_governance_consumer_testverifygovernanceconsumer_read_record",
+      "source": "test_verify_governance_consumer_testverifygovernanceconsumer_read_record",
+      "target": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_passes_for_valid_v2_managed_consumer",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
+      "source_location": "L207",
+      "weight": 0.8,
+      "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_when_profile_is_unknown",
+      "_tgt": "test_verify_governance_consumer_testverifygovernanceconsumer_write_record",
+      "source": "test_verify_governance_consumer_testverifygovernanceconsumer_write_record",
+      "target": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_when_profile_is_unknown",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
+      "source_location": "L224",
+      "weight": 0.8,
+      "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_when_profile_is_missing",
+      "_tgt": "test_verify_governance_consumer_testverifygovernanceconsumer_write_record",
+      "source": "test_verify_governance_consumer_testverifygovernanceconsumer_write_record",
+      "target": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_when_profile_is_missing",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
+      "source_location": "L313",
+      "weight": 0.8,
+      "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_for_managed_hook_checksum_drift",
+      "_tgt": "test_verify_governance_consumer_testverifygovernanceconsumer_write_record",
+      "source": "test_verify_governance_consumer_testverifygovernanceconsumer_write_record",
+      "target": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_for_managed_hook_checksum_drift",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
+      "source_location": "L328",
+      "weight": 0.8,
+      "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_for_managed_hook_missing_marker",
+      "_tgt": "test_verify_governance_consumer_testverifygovernanceconsumer_write_record",
+      "source": "test_verify_governance_consumer_testverifygovernanceconsumer_write_record",
+      "target": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_for_managed_hook_missing_marker",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
+      "source_location": "L340",
+      "weight": 0.8,
+      "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_for_invalid_override_metadata_and_reports_observed_override",
+      "_tgt": "test_verify_governance_consumer_testverifygovernanceconsumer_write_record",
+      "source": "test_verify_governance_consumer_testverifygovernanceconsumer_write_record",
+      "target": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_for_invalid_override_metadata_and_reports_observed_override",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
+      "source_location": "L356",
+      "weight": 0.8,
+      "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_override_empty_owner",
+      "_tgt": "test_verify_governance_consumer_testverifygovernanceconsumer_write_record",
+      "source": "test_verify_governance_consumer_testverifygovernanceconsumer_write_record",
+      "target": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_override_empty_owner",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
+      "source_location": "L371",
+      "weight": 0.8,
+      "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_override_non_string_reason",
+      "_tgt": "test_verify_governance_consumer_testverifygovernanceconsumer_write_record",
+      "source": "test_verify_governance_consumer_testverifygovernanceconsumer_write_record",
+      "target": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_override_non_string_reason",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
+      "source_location": "L390",
+      "weight": 0.8,
+      "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_override_empty_expires_at",
+      "_tgt": "test_verify_governance_consumer_testverifygovernanceconsumer_write_record",
+      "source": "test_verify_governance_consumer_testverifygovernanceconsumer_write_record",
+      "target": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_override_empty_expires_at",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
+      "source_location": "L403",
+      "weight": 0.8,
+      "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_override_weakens_healthcareplatform_hipaa",
+      "_tgt": "test_verify_governance_consumer_testverifygovernanceconsumer_write_record",
+      "source": "test_verify_governance_consumer_testverifygovernanceconsumer_write_record",
+      "target": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_override_weakens_healthcareplatform_hipaa",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
+      "source_location": "L417",
+      "weight": 0.8,
+      "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_override_disables_seek_plan_mode",
+      "_tgt": "test_verify_governance_consumer_testverifygovernanceconsumer_write_record",
+      "source": "test_verify_governance_consumer_testverifygovernanceconsumer_write_record",
+      "target": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_override_disables_seek_plan_mode",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
+      "source_location": "L431",
+      "weight": 0.8,
+      "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_override_routes_pii_away_from_lam",
+      "_tgt": "test_verify_governance_consumer_testverifygovernanceconsumer_write_record",
+      "source": "test_verify_governance_consumer_testverifygovernanceconsumer_write_record",
+      "target": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_override_routes_pii_away_from_lam",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
+      "source_location": "L445",
+      "weight": 0.8,
+      "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_override_core_fork_without_exception",
+      "_tgt": "test_verify_governance_consumer_testverifygovernanceconsumer_write_record",
+      "source": "test_verify_governance_consumer_testverifygovernanceconsumer_write_record",
+      "target": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_override_core_fork_without_exception",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
+      "source_location": "L459",
+      "weight": 0.8,
+      "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_override_disables_ci_required_gate",
+      "_tgt": "test_verify_governance_consumer_testverifygovernanceconsumer_write_record",
+      "source": "test_verify_governance_consumer_testverifygovernanceconsumer_write_record",
+      "target": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_override_disables_ci_required_gate",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
+      "source_location": "L473",
+      "weight": 0.8,
+      "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_override_dry_run_as_live_evidence",
+      "_tgt": "test_verify_governance_consumer_testverifygovernanceconsumer_write_record",
+      "source": "test_verify_governance_consumer_testverifygovernanceconsumer_write_record",
+      "target": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_override_dry_run_as_live_evidence",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
+      "source_location": "L490",
+      "weight": 0.8,
+      "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_when_healthcareplatform_v2_profile_weakens_constraints",
+      "_tgt": "test_verify_governance_consumer_testverifygovernanceconsumer_write_record",
+      "source": "test_verify_governance_consumer_testverifygovernanceconsumer_write_record",
+      "target": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_when_healthcareplatform_v2_profile_weakens_constraints",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
+      "source_location": "L533",
+      "weight": 0.8,
+      "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_passes_for_valid_v2_managed_consumer",
+      "_tgt": "test_verify_governance_consumer_testverifygovernanceconsumer_write_record",
+      "source": "test_verify_governance_consumer_testverifygovernanceconsumer_write_record",
+      "target": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_passes_for_valid_v2_managed_consumer",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
+      "source_location": "L353",
+      "weight": 0.8,
+      "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_override_empty_owner",
+      "_tgt": "test_verify_governance_consumer_testverifygovernanceconsumer_valid_override",
+      "source": "test_verify_governance_consumer_testverifygovernanceconsumer_valid_override",
+      "target": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_override_empty_owner",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
+      "source_location": "L368",
+      "weight": 0.8,
+      "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_override_non_string_reason",
+      "_tgt": "test_verify_governance_consumer_testverifygovernanceconsumer_valid_override",
+      "source": "test_verify_governance_consumer_testverifygovernanceconsumer_valid_override",
+      "target": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_override_non_string_reason",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
+      "source_location": "L402",
+      "weight": 0.8,
+      "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_override_weakens_healthcareplatform_hipaa",
+      "_tgt": "test_verify_governance_consumer_testverifygovernanceconsumer_valid_override",
+      "source": "test_verify_governance_consumer_testverifygovernanceconsumer_valid_override",
+      "target": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_override_weakens_healthcareplatform_hipaa",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
+      "source_location": "L416",
+      "weight": 0.8,
+      "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_override_disables_seek_plan_mode",
+      "_tgt": "test_verify_governance_consumer_testverifygovernanceconsumer_valid_override",
+      "source": "test_verify_governance_consumer_testverifygovernanceconsumer_valid_override",
+      "target": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_override_disables_seek_plan_mode",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
+      "source_location": "L430",
+      "weight": 0.8,
+      "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_override_routes_pii_away_from_lam",
+      "_tgt": "test_verify_governance_consumer_testverifygovernanceconsumer_valid_override",
+      "source": "test_verify_governance_consumer_testverifygovernanceconsumer_valid_override",
+      "target": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_override_routes_pii_away_from_lam",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
+      "source_location": "L444",
+      "weight": 0.8,
+      "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_override_core_fork_without_exception",
+      "_tgt": "test_verify_governance_consumer_testverifygovernanceconsumer_valid_override",
+      "source": "test_verify_governance_consumer_testverifygovernanceconsumer_valid_override",
+      "target": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_override_core_fork_without_exception",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
+      "source_location": "L458",
+      "weight": 0.8,
+      "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_override_disables_ci_required_gate",
+      "_tgt": "test_verify_governance_consumer_testverifygovernanceconsumer_valid_override",
+      "source": "test_verify_governance_consumer_testverifygovernanceconsumer_valid_override",
+      "target": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_override_disables_ci_required_gate",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
+      "source_location": "L472",
+      "weight": 0.8,
+      "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_override_dry_run_as_live_evidence",
+      "_tgt": "test_verify_governance_consumer_testverifygovernanceconsumer_valid_override",
+      "source": "test_verify_governance_consumer_testverifygovernanceconsumer_valid_override",
+      "target": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_override_dry_run_as_live_evidence",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
+      "source_location": "L484",
+      "weight": 0.8,
+      "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_when_healthcareplatform_v2_profile_weakens_constraints",
+      "_tgt": "test_verify_governance_consumer_testverifygovernanceconsumer_next_package_version",
+      "source": "test_verify_governance_consumer_testverifygovernanceconsumer_next_package_version",
+      "target": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_when_healthcareplatform_v2_profile_weakens_constraints",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
+      "source_location": "L510",
+      "weight": 0.8,
+      "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_passes_for_valid_v2_managed_consumer",
+      "_tgt": "test_verify_governance_consumer_testverifygovernanceconsumer_next_package_version",
+      "source": "test_verify_governance_consumer_testverifygovernanceconsumer_next_package_version",
+      "target": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_passes_for_valid_v2_managed_consumer",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
+      "source_location": "L486",
+      "weight": 0.8,
+      "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_when_healthcareplatform_v2_profile_weakens_constraints",
+      "_tgt": "test_verify_governance_consumer_testverifygovernanceconsumer_required_constraints",
+      "source": "test_verify_governance_consumer_testverifygovernanceconsumer_required_constraints",
+      "target": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_when_healthcareplatform_v2_profile_weakens_constraints",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
+      "source_location": "L517",
+      "weight": 0.8,
+      "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_passes_for_valid_v2_managed_consumer",
+      "_tgt": "test_verify_governance_consumer_testverifygovernanceconsumer_required_constraints",
+      "source": "test_verify_governance_consumer_testverifygovernanceconsumer_required_constraints",
+      "target": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_passes_for_valid_v2_managed_consumer",
       "confidence_score": 0.5
     },
     {
@@ -36881,7 +39497,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/overlord/verify_governance_consumer.py",
-      "source_location": "L22",
+      "source_location": "L76",
       "weight": 1.0,
       "_src": "verify_governance_consumer",
       "_tgt": "verify_governance_consumer_consumerverifyerror",
@@ -36893,7 +39509,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/overlord/verify_governance_consumer.py",
-      "source_location": "L27",
+      "source_location": "L81",
       "weight": 1.0,
       "_src": "verify_governance_consumer",
       "_tgt": "verify_governance_consumer_consumerrecord",
@@ -36905,7 +39521,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/overlord/verify_governance_consumer.py",
-      "source_location": "L32",
+      "source_location": "L86",
       "weight": 1.0,
       "_src": "verify_governance_consumer",
       "_tgt": "verify_governance_consumer_fail",
@@ -36917,7 +39533,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/overlord/verify_governance_consumer.py",
-      "source_location": "L36",
+      "source_location": "L90",
       "weight": 1.0,
       "_src": "verify_governance_consumer",
       "_tgt": "verify_governance_consumer_run_git",
@@ -36929,7 +39545,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/overlord/verify_governance_consumer.py",
-      "source_location": "L40",
+      "source_location": "L94",
       "weight": 1.0,
       "_src": "verify_governance_consumer",
       "_tgt": "verify_governance_consumer_git_root",
@@ -36941,7 +39557,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/overlord/verify_governance_consumer.py",
-      "source_location": "L47",
+      "source_location": "L101",
       "weight": 1.0,
       "_src": "verify_governance_consumer",
       "_tgt": "verify_governance_consumer_load_json",
@@ -36953,7 +39569,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/overlord/verify_governance_consumer.py",
-      "source_location": "L59",
+      "source_location": "L113",
       "weight": 1.0,
       "_src": "verify_governance_consumer",
       "_tgt": "verify_governance_consumer_consumer_record_relpath",
@@ -36965,7 +39581,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/overlord/verify_governance_consumer.py",
-      "source_location": "L68",
+      "source_location": "L122",
       "weight": 1.0,
       "_src": "verify_governance_consumer",
       "_tgt": "verify_governance_consumer_required_record_fields",
@@ -36977,7 +39593,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/overlord/verify_governance_consumer.py",
-      "source_location": "L89",
+      "source_location": "L143",
       "weight": 1.0,
       "_src": "verify_governance_consumer",
       "_tgt": "verify_governance_consumer_initial_package_version",
@@ -36989,7 +39605,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/overlord/verify_governance_consumer.py",
-      "source_location": "L98",
+      "source_location": "L152",
       "weight": 1.0,
       "_src": "verify_governance_consumer",
       "_tgt": "verify_governance_consumer_profile_desired_state",
@@ -37001,7 +39617,91 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/overlord/verify_governance_consumer.py",
-      "source_location": "L106",
+      "source_location": "L160",
+      "weight": 1.0,
+      "_src": "verify_governance_consumer",
+      "_tgt": "verify_governance_consumer_profile_contract",
+      "source": "verify_governance_consumer",
+      "target": "verify_governance_consumer_profile_contract",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/overlord/verify_governance_consumer.py",
+      "source_location": "L165",
+      "weight": 1.0,
+      "_src": "verify_governance_consumer",
+      "_tgt": "verify_governance_consumer_manifest_profiles",
+      "source": "verify_governance_consumer",
+      "target": "verify_governance_consumer_manifest_profiles",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/overlord/verify_governance_consumer.py",
+      "source_location": "L170",
+      "weight": 1.0,
+      "_src": "verify_governance_consumer",
+      "_tgt": "verify_governance_consumer_known_profiles",
+      "source": "verify_governance_consumer",
+      "target": "verify_governance_consumer_known_profiles",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/overlord/verify_governance_consumer.py",
+      "source_location": "L178",
+      "weight": 1.0,
+      "_src": "verify_governance_consumer",
+      "_tgt": "verify_governance_consumer_next_package_version",
+      "source": "verify_governance_consumer",
+      "target": "verify_governance_consumer_next_package_version",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/overlord/verify_governance_consumer.py",
+      "source_location": "L187",
+      "weight": 1.0,
+      "_src": "verify_governance_consumer",
+      "_tgt": "verify_governance_consumer_is_v2_record",
+      "source": "verify_governance_consumer",
+      "target": "verify_governance_consumer_is_v2_record",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/overlord/verify_governance_consumer.py",
+      "source_location": "L197",
+      "weight": 1.0,
+      "_src": "verify_governance_consumer",
+      "_tgt": "verify_governance_consumer_profile_required_constraints",
+      "source": "verify_governance_consumer",
+      "target": "verify_governance_consumer_profile_required_constraints",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/overlord/verify_governance_consumer.py",
+      "source_location": "L207",
+      "weight": 1.0,
+      "_src": "verify_governance_consumer",
+      "_tgt": "verify_governance_consumer_record_constraints",
+      "source": "verify_governance_consumer",
+      "target": "verify_governance_consumer_record_constraints",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/overlord/verify_governance_consumer.py",
+      "source_location": "L219",
       "weight": 1.0,
       "_src": "verify_governance_consumer",
       "_tgt": "verify_governance_consumer_expected_managed_paths",
@@ -37013,7 +39713,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/overlord/verify_governance_consumer.py",
-      "source_location": "L113",
+      "source_location": "L226",
       "weight": 1.0,
       "_src": "verify_governance_consumer",
       "_tgt": "verify_governance_consumer_managed_paths",
@@ -37025,7 +39725,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/overlord/verify_governance_consumer.py",
-      "source_location": "L124",
+      "source_location": "L237",
       "weight": 1.0,
       "_src": "verify_governance_consumer",
       "_tgt": "verify_governance_consumer_managed_file_type",
@@ -37037,7 +39737,79 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/overlord/verify_governance_consumer.py",
-      "source_location": "L134",
+      "source_location": "L247",
+      "weight": 1.0,
+      "_src": "verify_governance_consumer",
+      "_tgt": "verify_governance_consumer_managed_file_entry",
+      "source": "verify_governance_consumer",
+      "target": "verify_governance_consumer_managed_file_entry",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/overlord/verify_governance_consumer.py",
+      "source_location": "L257",
+      "weight": 1.0,
+      "_src": "verify_governance_consumer",
+      "_tgt": "verify_governance_consumer_managed_markers",
+      "source": "verify_governance_consumer",
+      "target": "verify_governance_consumer_managed_markers",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/overlord/verify_governance_consumer.py",
+      "source_location": "L266",
+      "weight": 1.0,
+      "_src": "verify_governance_consumer",
+      "_tgt": "verify_governance_consumer_expected_checksum",
+      "source": "verify_governance_consumer",
+      "target": "verify_governance_consumer_expected_checksum",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/overlord/verify_governance_consumer.py",
+      "source_location": "L274",
+      "weight": 1.0,
+      "_src": "verify_governance_consumer",
+      "_tgt": "verify_governance_consumer_non_empty_string",
+      "source": "verify_governance_consumer",
+      "target": "verify_governance_consumer_non_empty_string",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/overlord/verify_governance_consumer.py",
+      "source_location": "L278",
+      "weight": 1.0,
+      "_src": "verify_governance_consumer",
+      "_tgt": "verify_governance_consumer_override_text",
+      "source": "verify_governance_consumer",
+      "target": "verify_governance_consumer_override_text",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/overlord/verify_governance_consumer.py",
+      "source_location": "L282",
+      "weight": 1.0,
+      "_src": "verify_governance_consumer",
+      "_tgt": "verify_governance_consumer_forbidden_override_failures",
+      "source": "verify_governance_consumer",
+      "target": "verify_governance_consumer_forbidden_override_failures",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/overlord/verify_governance_consumer.py",
+      "source_location": "L295",
       "weight": 1.0,
       "_src": "verify_governance_consumer",
       "_tgt": "verify_governance_consumer_is_relative_to",
@@ -37049,7 +39821,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/overlord/verify_governance_consumer.py",
-      "source_location": "L142",
+      "source_location": "L303",
       "weight": 1.0,
       "_src": "verify_governance_consumer",
       "_tgt": "verify_governance_consumer_load_consumer_record",
@@ -37061,7 +39833,31 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/overlord/verify_governance_consumer.py",
-      "source_location": "L151",
+      "source_location": "L312",
+      "weight": 1.0,
+      "_src": "verify_governance_consumer",
+      "_tgt": "verify_governance_consumer_override_records",
+      "source": "verify_governance_consumer",
+      "target": "verify_governance_consumer_override_records",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/overlord/verify_governance_consumer.py",
+      "source_location": "L343",
+      "weight": 1.0,
+      "_src": "verify_governance_consumer",
+      "_tgt": "verify_governance_consumer_workflow_ref_failures",
+      "source": "verify_governance_consumer",
+      "target": "verify_governance_consumer_workflow_ref_failures",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/overlord/verify_governance_consumer.py",
+      "source_location": "L363",
       "weight": 1.0,
       "_src": "verify_governance_consumer",
       "_tgt": "verify_governance_consumer_validate_record",
@@ -37073,7 +39869,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/overlord/verify_governance_consumer.py",
-      "source_location": "L229",
+      "source_location": "L470",
       "weight": 1.0,
       "_src": "verify_governance_consumer",
       "_tgt": "verify_governance_consumer_verify",
@@ -37085,7 +39881,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/overlord/verify_governance_consumer.py",
-      "source_location": "L264",
+      "source_location": "L506",
       "weight": 1.0,
       "_src": "verify_governance_consumer",
       "_tgt": "verify_governance_consumer_print_json",
@@ -37097,7 +39893,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/overlord/verify_governance_consumer.py",
-      "source_location": "L269",
+      "source_location": "L511",
       "weight": 1.0,
       "_src": "verify_governance_consumer",
       "_tgt": "verify_governance_consumer_build_parser",
@@ -37109,7 +39905,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/overlord/verify_governance_consumer.py",
-      "source_location": "L283",
+      "source_location": "L525",
       "weight": 1.0,
       "_src": "verify_governance_consumer",
       "_tgt": "verify_governance_consumer_main",
@@ -37121,7 +39917,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/overlord/verify_governance_consumer.py",
-      "source_location": "L33",
+      "source_location": "L87",
       "weight": 0.8,
       "_src": "verify_governance_consumer_fail",
       "_tgt": "verify_governance_consumer_consumerverifyerror",
@@ -37133,7 +39929,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/overlord/verify_governance_consumer.py",
-      "source_location": "L148",
+      "source_location": "L309",
       "weight": 0.8,
       "_src": "verify_governance_consumer_load_consumer_record",
       "_tgt": "verify_governance_consumer_consumerrecord",
@@ -37145,7 +39941,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/overlord/verify_governance_consumer.py",
-      "source_location": "L43",
+      "source_location": "L97",
       "weight": 0.8,
       "_src": "verify_governance_consumer_git_root",
       "_tgt": "verify_governance_consumer_fail",
@@ -37157,7 +39953,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/overlord/verify_governance_consumer.py",
-      "source_location": "L51",
+      "source_location": "L105",
       "weight": 0.8,
       "_src": "verify_governance_consumer_load_json",
       "_tgt": "verify_governance_consumer_fail",
@@ -37169,7 +39965,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/overlord/verify_governance_consumer.py",
-      "source_location": "L145",
+      "source_location": "L306",
       "weight": 0.8,
       "_src": "verify_governance_consumer_load_consumer_record",
       "_tgt": "verify_governance_consumer_fail",
@@ -37181,7 +39977,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/overlord/verify_governance_consumer.py",
-      "source_location": "L41",
+      "source_location": "L95",
       "weight": 0.8,
       "_src": "verify_governance_consumer_git_root",
       "_tgt": "verify_governance_consumer_run_git",
@@ -37193,7 +39989,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/overlord/verify_governance_consumer.py",
-      "source_location": "L233",
+      "source_location": "L474",
       "weight": 0.8,
       "_src": "verify_governance_consumer_verify",
       "_tgt": "verify_governance_consumer_git_root",
@@ -37205,7 +40001,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/overlord/verify_governance_consumer.py",
-      "source_location": "L148",
+      "source_location": "L309",
       "weight": 0.8,
       "_src": "verify_governance_consumer_load_consumer_record",
       "_tgt": "verify_governance_consumer_load_json",
@@ -37217,7 +40013,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/overlord/verify_governance_consumer.py",
-      "source_location": "L235",
+      "source_location": "L476",
       "weight": 0.8,
       "_src": "verify_governance_consumer_verify",
       "_tgt": "verify_governance_consumer_load_json",
@@ -37229,7 +40025,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/overlord/verify_governance_consumer.py",
-      "source_location": "L237",
+      "source_location": "L478",
       "weight": 0.8,
       "_src": "verify_governance_consumer_verify",
       "_tgt": "verify_governance_consumer_consumer_record_relpath",
@@ -37241,7 +40037,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/overlord/verify_governance_consumer.py",
-      "source_location": "L166",
+      "source_location": "L378",
       "weight": 0.8,
       "_src": "verify_governance_consumer_validate_record",
       "_tgt": "verify_governance_consumer_required_record_fields",
@@ -37253,7 +40049,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/overlord/verify_governance_consumer.py",
-      "source_location": "L183",
+      "source_location": "L398",
       "weight": 0.8,
       "_src": "verify_governance_consumer_validate_record",
       "_tgt": "verify_governance_consumer_initial_package_version",
@@ -37265,7 +40061,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/overlord/verify_governance_consumer.py",
-      "source_location": "L200",
+      "source_location": "L415",
       "weight": 0.8,
       "_src": "verify_governance_consumer_validate_record",
       "_tgt": "verify_governance_consumer_profile_desired_state",
@@ -37277,7 +40073,103 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/overlord/verify_governance_consumer.py",
-      "source_location": "L201",
+      "source_location": "L166",
+      "weight": 0.8,
+      "_src": "verify_governance_consumer_manifest_profiles",
+      "_tgt": "verify_governance_consumer_profile_contract",
+      "source": "verify_governance_consumer_profile_contract",
+      "target": "verify_governance_consumer_manifest_profiles",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/overlord/verify_governance_consumer.py",
+      "source_location": "L171",
+      "weight": 0.8,
+      "_src": "verify_governance_consumer_known_profiles",
+      "_tgt": "verify_governance_consumer_manifest_profiles",
+      "source": "verify_governance_consumer_manifest_profiles",
+      "target": "verify_governance_consumer_known_profiles",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/overlord/verify_governance_consumer.py",
+      "source_location": "L198",
+      "weight": 0.8,
+      "_src": "verify_governance_consumer_profile_required_constraints",
+      "_tgt": "verify_governance_consumer_manifest_profiles",
+      "source": "verify_governance_consumer_manifest_profiles",
+      "target": "verify_governance_consumer_profile_required_constraints",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/overlord/verify_governance_consumer.py",
+      "source_location": "L393",
+      "weight": 0.8,
+      "_src": "verify_governance_consumer_validate_record",
+      "_tgt": "verify_governance_consumer_known_profiles",
+      "source": "verify_governance_consumer_known_profiles",
+      "target": "verify_governance_consumer_validate_record",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/overlord/verify_governance_consumer.py",
+      "source_location": "L189",
+      "weight": 0.8,
+      "_src": "verify_governance_consumer_is_v2_record",
+      "_tgt": "verify_governance_consumer_next_package_version",
+      "source": "verify_governance_consumer_next_package_version",
+      "target": "verify_governance_consumer_is_v2_record",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/overlord/verify_governance_consumer.py",
+      "source_location": "L446",
+      "weight": 0.8,
+      "_src": "verify_governance_consumer_validate_record",
+      "_tgt": "verify_governance_consumer_is_v2_record",
+      "source": "verify_governance_consumer_is_v2_record",
+      "target": "verify_governance_consumer_validate_record",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/overlord/verify_governance_consumer.py",
+      "source_location": "L447",
+      "weight": 0.8,
+      "_src": "verify_governance_consumer_validate_record",
+      "_tgt": "verify_governance_consumer_profile_required_constraints",
+      "source": "verify_governance_consumer_profile_required_constraints",
+      "target": "verify_governance_consumer_validate_record",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/overlord/verify_governance_consumer.py",
+      "source_location": "L449",
+      "weight": 0.8,
+      "_src": "verify_governance_consumer_validate_record",
+      "_tgt": "verify_governance_consumer_record_constraints",
+      "source": "verify_governance_consumer_record_constraints",
+      "target": "verify_governance_consumer_validate_record",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/overlord/verify_governance_consumer.py",
+      "source_location": "L416",
       "weight": 0.8,
       "_src": "verify_governance_consumer_validate_record",
       "_tgt": "verify_governance_consumer_expected_managed_paths",
@@ -37289,7 +40181,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/overlord/verify_governance_consumer.py",
-      "source_location": "L202",
+      "source_location": "L417",
       "weight": 0.8,
       "_src": "verify_governance_consumer_validate_record",
       "_tgt": "verify_governance_consumer_managed_paths",
@@ -37301,7 +40193,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/overlord/verify_governance_consumer.py",
-      "source_location": "L215",
+      "source_location": "L430",
       "weight": 0.8,
       "_src": "verify_governance_consumer_validate_record",
       "_tgt": "verify_governance_consumer_managed_file_type",
@@ -37313,7 +40205,79 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/overlord/verify_governance_consumer.py",
-      "source_location": "L144",
+      "source_location": "L440",
+      "weight": 0.8,
+      "_src": "verify_governance_consumer_validate_record",
+      "_tgt": "verify_governance_consumer_managed_file_entry",
+      "source": "verify_governance_consumer_managed_file_entry",
+      "target": "verify_governance_consumer_validate_record",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/overlord/verify_governance_consumer.py",
+      "source_location": "L438",
+      "weight": 0.8,
+      "_src": "verify_governance_consumer_validate_record",
+      "_tgt": "verify_governance_consumer_managed_markers",
+      "source": "verify_governance_consumer_managed_markers",
+      "target": "verify_governance_consumer_validate_record",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/overlord/verify_governance_consumer.py",
+      "source_location": "L440",
+      "weight": 0.8,
+      "_src": "verify_governance_consumer_validate_record",
+      "_tgt": "verify_governance_consumer_expected_checksum",
+      "source": "verify_governance_consumer_expected_checksum",
+      "target": "verify_governance_consumer_validate_record",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/overlord/verify_governance_consumer.py",
+      "source_location": "L330",
+      "weight": 0.8,
+      "_src": "verify_governance_consumer_override_records",
+      "_tgt": "verify_governance_consumer_non_empty_string",
+      "source": "verify_governance_consumer_non_empty_string",
+      "target": "verify_governance_consumer_override_records",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/overlord/verify_governance_consumer.py",
+      "source_location": "L285",
+      "weight": 0.8,
+      "_src": "verify_governance_consumer_forbidden_override_failures",
+      "_tgt": "verify_governance_consumer_override_text",
+      "source": "verify_governance_consumer_override_text",
+      "target": "verify_governance_consumer_forbidden_override_failures",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/overlord/verify_governance_consumer.py",
+      "source_location": "L460",
+      "weight": 0.8,
+      "_src": "verify_governance_consumer_validate_record",
+      "_tgt": "verify_governance_consumer_forbidden_override_failures",
+      "source": "verify_governance_consumer_forbidden_override_failures",
+      "target": "verify_governance_consumer_validate_record",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/overlord/verify_governance_consumer.py",
+      "source_location": "L305",
       "weight": 0.8,
       "_src": "verify_governance_consumer_load_consumer_record",
       "_tgt": "verify_governance_consumer_is_relative_to",
@@ -37325,7 +40289,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/overlord/verify_governance_consumer.py",
-      "source_location": "L209",
+      "source_location": "L424",
       "weight": 0.8,
       "_src": "verify_governance_consumer_validate_record",
       "_tgt": "verify_governance_consumer_is_relative_to",
@@ -37337,7 +40301,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/overlord/verify_governance_consumer.py",
-      "source_location": "L238",
+      "source_location": "L479",
       "weight": 0.8,
       "_src": "verify_governance_consumer_verify",
       "_tgt": "verify_governance_consumer_load_consumer_record",
@@ -37349,7 +40313,31 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/overlord/verify_governance_consumer.py",
-      "source_location": "L239",
+      "source_location": "L458",
+      "weight": 0.8,
+      "_src": "verify_governance_consumer_validate_record",
+      "_tgt": "verify_governance_consumer_override_records",
+      "source": "verify_governance_consumer_override_records",
+      "target": "verify_governance_consumer_validate_record",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/overlord/verify_governance_consumer.py",
+      "source_location": "L461",
+      "weight": 0.8,
+      "_src": "verify_governance_consumer_validate_record",
+      "_tgt": "verify_governance_consumer_workflow_ref_failures",
+      "source": "verify_governance_consumer_workflow_ref_failures",
+      "target": "verify_governance_consumer_validate_record",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/overlord/verify_governance_consumer.py",
+      "source_location": "L480",
       "weight": 0.8,
       "_src": "verify_governance_consumer_verify",
       "_tgt": "verify_governance_consumer_validate_record",
@@ -37361,7 +40349,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/overlord/verify_governance_consumer.py",
-      "source_location": "L287",
+      "source_location": "L529",
       "weight": 0.8,
       "_src": "verify_governance_consumer_main",
       "_tgt": "verify_governance_consumer_verify",
@@ -37373,7 +40361,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/overlord/verify_governance_consumer.py",
-      "source_location": "L288",
+      "source_location": "L530",
       "weight": 0.8,
       "_src": "verify_governance_consumer_main",
       "_tgt": "verify_governance_consumer_print_json",
@@ -37385,7 +40373,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/overlord/verify_governance_consumer.py",
-      "source_location": "L284",
+      "source_location": "L526",
       "weight": 0.8,
       "_src": "verify_governance_consumer_main",
       "_tgt": "verify_governance_consumer_build_parser",

--- a/raw/execution-scopes/2026-04-21-issue-474-verifier-hardening-implementation.json
+++ b/raw/execution-scopes/2026-04-21-issue-474-verifier-hardening-implementation.json
@@ -1,0 +1,62 @@
+{
+  "expected_execution_root": ".",
+  "expected_branch": "issue-474-verifier-hardening",
+  "execution_mode": "implementation_ready",
+  "allowed_write_paths": [
+    "OVERLORD_BACKLOG.md",
+    "docs/PROGRESS.md",
+    "docs/plans/issue-474-verifier-hardening-pdcar.md",
+    "docs/plans/issue-474-structured-agent-cycle-plan.json",
+    "graphify-out/",
+    "raw/execution-scopes/2026-04-21-issue-474-verifier-hardening-implementation.json",
+    "raw/handoffs/2026-04-21-issue-474-plan-to-implementation.json",
+    "raw/validation/2026-04-21-issue-474-verifier-hardening.md",
+    "scripts/overlord/verify_governance_consumer.py",
+    "scripts/overlord/test_verify_governance_consumer.py"
+  ],
+  "forbidden_roots": [
+    "/Users/bennibarger/Developer/HLDPRO/ai-integration-services",
+    "/Users/bennibarger/Developer/HLDPRO/HealthcarePlatform",
+    "/Users/bennibarger/Developer/HLDPRO/local-ai-machine",
+    "/Users/bennibarger/Developer/HLDPRO/knocktracker",
+    "/Users/bennibarger/Developer/HLDPRO/ASC-Evaluator",
+    "/Users/bennibarger/Developer/HLDPRO/seek-and-ponder",
+    "/Users/bennibarger/Developer/HLDPRO/Stampede"
+  ],
+  "active_parallel_roots": [
+    {
+      "path": "/Users/bennibarger/Developer/HLDPRO/ai-integration-services",
+      "reason": "Pre-existing sibling checkout; not part of issue #474."
+    },
+    {
+      "path": "/Users/bennibarger/Developer/HLDPRO/knocktracker",
+      "reason": "Pre-existing sibling checkout; not part of issue #474."
+    },
+    {
+      "path": "/Users/bennibarger/Developer/HLDPRO/seek-and-ponder",
+      "reason": "Pre-existing sibling checkout; not part of issue #474."
+    },
+    {
+      "path": "/Users/bennibarger/Developer/HLDPRO/Stampede",
+      "reason": "Pre-existing sibling checkout; not part of issue #474."
+    }
+  ],
+  "lane_claim": {
+    "issue_number": 474,
+    "claim_ref": "https://github.com/NIBARGERB-HLDPRO/hldpro-governance/issues/474",
+    "claimed_by": "codex",
+    "claimed_at": "2026-04-21T13:20:00-05:00"
+  },
+  "handoff_evidence": {
+    "status": "accepted",
+    "planner_model": "codex-orchestrator",
+    "implementer_model": "gpt-5.4-codex-bounded-implementation",
+    "accepted_at": "2026-04-21T13:20:00-05:00",
+    "evidence_paths": [
+      "docs/plans/issue-474-structured-agent-cycle-plan.json",
+      "raw/handoffs/2026-04-21-issue-474-plan-to-implementation.json"
+    ],
+    "active_exception_ref": null,
+    "active_exception_expires_at": null
+  }
+}

--- a/raw/handoffs/2026-04-21-issue-474-plan-to-implementation.json
+++ b/raw/handoffs/2026-04-21-issue-474-plan-to-implementation.json
@@ -1,0 +1,66 @@
+{
+  "schema_version": "v1",
+  "handoff_id": "issue-474-plan-to-implementation",
+  "issue_number": 474,
+  "parent_epic_number": 434,
+  "lifecycle_state": "implementation_ready",
+  "from_role": "codex-orchestrator",
+  "to_role": "bounded-implementation-worker",
+  "structured_plan_ref": "docs/plans/issue-474-structured-agent-cycle-plan.json",
+  "execution_scope_ref": "raw/execution-scopes/2026-04-21-issue-474-verifier-hardening-implementation.json",
+  "packet_ref": null,
+  "package_manifest_ref": null,
+  "acceptance_criteria": [
+    {
+      "id": "AC1",
+      "statement": "Verifier rejects reusable governance workflow refs that are tags, short SHAs, mutable refs, or valid SHAs that differ from the consumer governance_ref.",
+      "verification_refs": [
+        "scripts/overlord/test_verify_governance_consumer.py"
+      ]
+    },
+    {
+      "id": "AC2",
+      "statement": "Verifier requires override metadata values to be non-empty strings while preserving observed_overrides output.",
+      "verification_refs": [
+        "scripts/overlord/verify_governance_consumer.py",
+        "scripts/overlord/test_verify_governance_consumer.py"
+      ]
+    },
+    {
+      "id": "AC3",
+      "statement": "Verifier fails forbidden override classes for protected governance constraints.",
+      "verification_refs": [
+        "scripts/overlord/test_verify_governance_consumer.py"
+      ]
+    }
+  ],
+  "validation_commands": [
+    "python3 scripts/overlord/test_verify_governance_consumer.py",
+    "python3 -m unittest scripts.overlord.test_deploy_governance_tooling scripts.overlord.test_verify_governance_consumer",
+    "python3 -m py_compile scripts/overlord/verify_governance_consumer.py scripts/overlord/test_verify_governance_consumer.py",
+    "python3 -m json.tool docs/plans/issue-474-structured-agent-cycle-plan.json",
+    "python3 -m json.tool raw/execution-scopes/2026-04-21-issue-474-verifier-hardening-implementation.json",
+    "python3 -m json.tool raw/handoffs/2026-04-21-issue-474-plan-to-implementation.json",
+    "python3 scripts/overlord/validate_handoff_package.py --root . raw/handoffs/2026-04-21-issue-474-plan-to-implementation.json",
+    "python3 scripts/overlord/validate_structured_agent_cycle_plan.py --root . --branch-name issue-474-verifier-hardening --changed-files-file /tmp/issue-474-changed-files.txt --enforce-governance-surface --enforce-planner-boundary-scope",
+    "python3 scripts/overlord/assert_execution_scope.py --scope raw/execution-scopes/2026-04-21-issue-474-verifier-hardening-implementation.json --changed-files-file /tmp/issue-474-changed-files.txt --require-lane-claim",
+    "tools/local-ci-gate/bin/hldpro-local-ci run --profile hldpro-governance --json"
+  ],
+  "review_artifact_refs": [],
+  "gate_artifact_refs": [],
+  "artifact_refs": [
+    "docs/plans/issue-474-verifier-hardening-pdcar.md",
+    "docs/plans/issue-474-structured-agent-cycle-plan.json",
+    "raw/execution-scopes/2026-04-21-issue-474-verifier-hardening-implementation.json",
+    "scripts/overlord/verify_governance_consumer.py",
+    "scripts/overlord/test_verify_governance_consumer.py"
+  ],
+  "audit_refs": [
+    "raw/validation/2026-04-21-issue-474-verifier-hardening.md"
+  ],
+  "closeout_ref": null,
+  "blocked_on": [],
+  "handoff_decision": "accepted",
+  "created_at": "2026-04-21T13:20:00-05:00",
+  "notes": "Bounded follow-up to merge useful duplicate issue #454 verifier hardening into the already-merged v0.2 verifier implementation."
+}

--- a/raw/validation/2026-04-21-issue-474-verifier-hardening.md
+++ b/raw/validation/2026-04-21-issue-474-verifier-hardening.md
@@ -1,0 +1,25 @@
+# Issue 474 Validation: SSOT Consumer Verifier Hardening
+
+## Scope
+
+Issue #474 ports useful verifier hardening from duplicate branch `issue-454-ssot-verifier` into the merged issue #454 v0.2 verifier implementation.
+
+## Branch Comparison
+
+- Base kept: `origin/main` at PR #473 / issue #454 because it includes v0.2 profile constraints, `repo_profile`, `local_overrides`, managed-file checksums, and the `observed_overrides` output contract.
+- Duplicate deltas ported: stricter reusable workflow SHA checks, override value validation, forbidden override class checks, and focused regression tests.
+- Duplicate deltas skipped: narrower record shape, `observed_local_overrides` output, and alternate helper rewrites that would regress the merged v0.2 contract.
+
+## Validation Log
+
+- PASS: `python3 scripts/overlord/test_verify_governance_consumer.py` - 27 tests.
+- PASS: `python3 -m unittest scripts.overlord.test_deploy_governance_tooling scripts.overlord.test_verify_governance_consumer` - 39 tests.
+- PASS: `python3 -m py_compile scripts/overlord/verify_governance_consumer.py scripts/overlord/test_verify_governance_consumer.py`.
+- PASS: `python3 -m json.tool docs/plans/issue-474-structured-agent-cycle-plan.json`.
+- PASS: `python3 -m json.tool raw/execution-scopes/2026-04-21-issue-474-verifier-hardening-implementation.json`.
+- PASS: `python3 -m json.tool raw/handoffs/2026-04-21-issue-474-plan-to-implementation.json`.
+- PASS: `python3 scripts/overlord/validate_handoff_package.py --root . raw/handoffs/2026-04-21-issue-474-plan-to-implementation.json`.
+- PASS: `python3 scripts/overlord/validate_structured_agent_cycle_plan.py --root . --branch-name issue-474-verifier-hardening --changed-files-file /tmp/issue-474-changed-files.txt --enforce-governance-surface --enforce-planner-boundary-scope`.
+- PASS with declared sibling-root warnings: `python3 scripts/overlord/assert_execution_scope.py --scope raw/execution-scopes/2026-04-21-issue-474-verifier-hardening-implementation.json --changed-files-file /tmp/issue-474-changed-files.txt --require-lane-claim`.
+- PASS: `git diff --check`.
+- PASS: `tools/local-ci-gate/bin/hldpro-local-ci run --profile hldpro-governance --json`.

--- a/scripts/overlord/test_verify_governance_consumer.py
+++ b/scripts/overlord/test_verify_governance_consumer.py
@@ -99,6 +99,14 @@ class TestVerifyGovernanceConsumer(unittest.TestCase):
     def _write_record(self, record: dict) -> None:
         self._record().write_text(json.dumps(record, indent=2) + "\n", encoding="utf-8")
 
+    def _valid_override(self, reason: str = "temporary governance exception") -> dict:
+        return {
+            "issue": "#474",
+            "reason": reason,
+            "owner": "governance",
+            "review_cadence": "quarterly",
+        }
+
     def _next_package_version(self) -> str:
         manifest = json.loads((REPO_ROOT / "docs" / "governance-tooling-package.json").read_text(encoding="utf-8"))
         return manifest["versioning"]["next_contract_version"]
@@ -237,6 +245,58 @@ class TestVerifyGovernanceConsumer(unittest.TestCase):
         payload = json.loads(stdout)
         self.assertIn("reusable workflow ref must be pinned", "\n".join(payload["failures"]))
 
+    def test_verify_fails_workflow_ref_is_tag(self) -> None:
+        self._deploy()
+        workflow = self.product / ".github" / "workflows" / "governance.yml"
+        workflow.parent.mkdir(parents=True)
+        workflow.write_text(
+            "jobs:\n  check:\n    uses: NIBARGERB-HLDPRO/hldpro-governance/.github/workflows/governance-check.yml@v1.0.0\n",
+            encoding="utf-8",
+        )
+
+        code, stdout, stderr = self._invoke(*self._base_args())
+
+        self.assertEqual(code, 1, stderr)
+        payload = json.loads(stdout)
+        failures_text = "\n".join(payload["failures"])
+        self.assertIn("reusable workflow ref must be pinned", failures_text)
+        self.assertIn("@v1.0.0", failures_text)
+
+    def test_verify_fails_workflow_ref_is_short_sha(self) -> None:
+        self._deploy()
+        workflow = self.product / ".github" / "workflows" / "governance.yml"
+        workflow.parent.mkdir(parents=True)
+        workflow.write_text(
+            "jobs:\n  check:\n    uses: NIBARGERB-HLDPRO/hldpro-governance/.github/workflows/governance-check.yml@abc1234\n",
+            encoding="utf-8",
+        )
+
+        code, stdout, stderr = self._invoke(*self._base_args())
+
+        self.assertEqual(code, 1, stderr)
+        payload = json.loads(stdout)
+        failures_text = "\n".join(payload["failures"])
+        self.assertIn("reusable workflow ref must be pinned", failures_text)
+        self.assertIn("@abc1234", failures_text)
+
+    def test_verify_fails_workflow_ref_sha_mismatch(self) -> None:
+        self._deploy()
+        workflow = self.product / ".github" / "workflows" / "governance.yml"
+        workflow.parent.mkdir(parents=True)
+        wrong_sha = "b" * 40
+        workflow.write_text(
+            f"jobs:\n  check:\n    uses: NIBARGERB-HLDPRO/hldpro-governance/.github/workflows/governance-check.yml@{wrong_sha}\n",
+            encoding="utf-8",
+        )
+
+        code, stdout, stderr = self._invoke(*self._base_args())
+
+        self.assertEqual(code, 1, stderr)
+        payload = json.loads(stdout)
+        failures_text = "\n".join(payload["failures"])
+        self.assertIn("reusable workflow ref SHA mismatch", failures_text)
+        self.assertIn(wrong_sha, failures_text)
+
     def test_verify_fails_for_managed_hook_checksum_drift(self) -> None:
         self._deploy()
         hook = self.product / ".claude" / "hooks" / "pre-tool-use.sh"
@@ -286,6 +346,139 @@ class TestVerifyGovernanceConsumer(unittest.TestCase):
         self.assertEqual(payload["observed_overrides"], [{"issue": "#454", "reason": "fixture"}])
         self.assertIn("missing required override metadata: owner", "\n".join(payload["failures"]))
         self.assertIn("review_cadence or expires_at", "\n".join(payload["failures"]))
+
+    def test_verify_fails_override_empty_owner(self) -> None:
+        self._deploy()
+        record = self._read_record()
+        override = self._valid_override()
+        override["owner"] = ""
+        record["overrides"] = [override]
+        self._write_record(record)
+
+        code, stdout, stderr = self._invoke(*self._base_args())
+
+        self.assertEqual(code, 1, stderr)
+        payload = json.loads(stdout)
+        failures_text = "\n".join(payload["failures"])
+        self.assertIn("non-empty string: owner", failures_text)
+
+    def test_verify_fails_override_non_string_reason(self) -> None:
+        self._deploy()
+        record = self._read_record()
+        override = self._valid_override()
+        override["reason"] = 42
+        record["overrides"] = [override]
+        self._write_record(record)
+
+        code, stdout, stderr = self._invoke(*self._base_args())
+
+        self.assertEqual(code, 1, stderr)
+        payload = json.loads(stdout)
+        failures_text = "\n".join(payload["failures"])
+        self.assertIn("non-empty string: reason", failures_text)
+
+    def test_verify_fails_override_empty_expires_at(self) -> None:
+        self._deploy()
+        record = self._read_record()
+        override = {
+            "issue": "#474",
+            "reason": "temporary governance exception",
+            "owner": "governance",
+            "expires_at": "",
+        }
+        record["overrides"] = [override]
+        self._write_record(record)
+
+        code, stdout, stderr = self._invoke(*self._base_args())
+
+        self.assertEqual(code, 1, stderr)
+        payload = json.loads(stdout)
+        failures_text = "\n".join(payload["failures"])
+        self.assertIn("review_cadence or expires_at", failures_text)
+
+    def test_verify_fails_override_weakens_healthcareplatform_hipaa(self) -> None:
+        self._deploy()
+        record = self._read_record()
+        record["overrides"] = [self._valid_override("disable HIPAA checks for development")]
+        self._write_record(record)
+
+        code, stdout, stderr = self._invoke(*self._base_args())
+
+        self.assertEqual(code, 1, stderr)
+        payload = json.loads(stdout)
+        failures_text = "\n".join(payload["failures"])
+        self.assertIn("forbidden override", failures_text)
+        self.assertIn("HealthcarePlatform", failures_text)
+
+    def test_verify_fails_override_disables_seek_plan_mode(self) -> None:
+        self._deploy()
+        record = self._read_record()
+        record["overrides"] = [self._valid_override("disable plan-mode enforcement for quick deploy")]
+        self._write_record(record)
+
+        code, stdout, stderr = self._invoke(*self._base_args())
+
+        self.assertEqual(code, 1, stderr)
+        payload = json.loads(stdout)
+        failures_text = "\n".join(payload["failures"])
+        self.assertIn("forbidden override", failures_text)
+        self.assertIn("plan-mode", failures_text)
+
+    def test_verify_fails_override_routes_pii_away_from_lam(self) -> None:
+        self._deploy()
+        record = self._read_record()
+        record["overrides"] = [self._valid_override("route PII to cloud storage for analytics")]
+        self._write_record(record)
+
+        code, stdout, stderr = self._invoke(*self._base_args())
+
+        self.assertEqual(code, 1, stderr)
+        payload = json.loads(stdout)
+        failures_text = "\n".join(payload["failures"])
+        self.assertIn("forbidden override", failures_text)
+        self.assertIn("LAM", failures_text)
+
+    def test_verify_fails_override_core_fork_without_exception(self) -> None:
+        self._deploy()
+        record = self._read_record()
+        record["overrides"] = [self._valid_override("fork core package to add local patches")]
+        self._write_record(record)
+
+        code, stdout, stderr = self._invoke(*self._base_args())
+
+        self.assertEqual(code, 1, stderr)
+        payload = json.loads(stdout)
+        failures_text = "\n".join(payload["failures"])
+        self.assertIn("forbidden override", failures_text)
+        self.assertIn("core fork", failures_text)
+
+    def test_verify_fails_override_disables_ci_required_gate(self) -> None:
+        self._deploy()
+        record = self._read_record()
+        record["overrides"] = [self._valid_override("disable required-gate for hotfix deploy")]
+        self._write_record(record)
+
+        code, stdout, stderr = self._invoke(*self._base_args())
+
+        self.assertEqual(code, 1, stderr)
+        payload = json.loads(stdout)
+        failures_text = "\n".join(payload["failures"])
+        self.assertIn("forbidden override", failures_text)
+        self.assertIn("CI-required gates", failures_text)
+
+    def test_verify_fails_override_dry_run_as_live_evidence(self) -> None:
+        self._deploy()
+        record = self._read_record()
+        record["overrides"] = [self._valid_override("treat dry-run results as live enforcement evidence")]
+        self._write_record(record)
+
+        code, stdout, stderr = self._invoke(*self._base_args())
+
+        self.assertEqual(code, 1, stderr)
+        payload = json.loads(stdout)
+        failures_text = "\n".join(payload["failures"])
+        self.assertIn("forbidden override", failures_text)
+        self.assertIn("dry-run", failures_text)
 
     def test_verify_fails_when_healthcareplatform_v2_profile_weakens_constraints(self) -> None:
         next_version = self._next_package_version()

--- a/scripts/overlord/verify_governance_consumer.py
+++ b/scripts/overlord/verify_governance_consumer.py
@@ -21,6 +21,56 @@ MANAGED_LOCAL_CI_MARKER = "# hldpro-governance local-ci gate managed"
 GOVERNANCE_WORKFLOW_REF_RE = re.compile(
     r"NIBARGERB-HLDPRO/hldpro-governance/(?:\.github/workflows/)?[^\s'\"#]+@(?P<ref>[^\s'\"#]+)"
 )
+FORBIDDEN_OVERRIDE_CHECKS: list[tuple[re.Pattern[str], str]] = [
+    (
+        re.compile(
+            r"\b(weaken|disable|skip|bypass|remove|relax|ignore)\b[^.]*\b(hipaa|phi|pii|lane)\b"
+            r"|\b(hipaa|phi|pii|lane)\b[^.]*\b(weaken|disable|skip|bypass|remove|relax|ignore)\b",
+            re.IGNORECASE,
+        ),
+        "forbidden override: weakens HealthcarePlatform HIPAA/PHI/PII/lane constraints",
+    ),
+    (
+        re.compile(
+            r"\b(disable|skip|bypass|remove|relax|suppress)\b[^.]*\bplan.?mode\b"
+            r"|\bplan.?mode\b[^.]*\b(disable|skip|bypass|remove|relax|suppress)\b",
+            re.IGNORECASE,
+        ),
+        "forbidden override: disables Seek plan-mode enforcement",
+    ),
+    (
+        re.compile(
+            r"\bpii\b[^.]*\b(cloud|remote|external|route|send|forward|upload)\b"
+            r"|\b(cloud|remote|external|route|send|forward|upload)\b[^.]*\bpii\b",
+            re.IGNORECASE,
+        ),
+        "forbidden override: routes PII away from LAM/local-only constraints",
+    ),
+    (
+        re.compile(
+            r"\b(fork|patch|vendor|copy|duplicate)\b[^.]*\bcore\b"
+            r"|\bcore\b[^.]*\b(fork|patch|vendor|copy|duplicate)\b",
+            re.IGNORECASE,
+        ),
+        "forbidden override: package core fork without issue exception",
+    ),
+    (
+        re.compile(
+            r"\b(disable|skip|bypass|remove|suppress)\b[^.]*\b(ci.?gate|required.?gate|ci.?check|required.?check)\b"
+            r"|\b(ci.?gate|required.?gate|ci.?check|required.?check)\b[^.]*\b(disable|skip|bypass|remove|suppress)\b",
+            re.IGNORECASE,
+        ),
+        "forbidden override: disables CI-required gates",
+    ),
+    (
+        re.compile(
+            r"\bdry.?run\b[^.]*\b(enforce|live|production|active|evidence)\b"
+            r"|\b(enforce|live|production|active|evidence)\b[^.]*\bdry.?run\b",
+            re.IGNORECASE,
+        ),
+        "forbidden override: treats dry-run as live enforcement evidence",
+    ),
+]
 
 
 class ConsumerVerifyError(RuntimeError):
@@ -221,6 +271,27 @@ def _expected_checksum(entry: dict[str, Any]) -> str:
     return ""
 
 
+def _non_empty_string(value: Any) -> bool:
+    return isinstance(value, str) and bool(value.strip())
+
+
+def _override_text(override: dict[str, Any]) -> str:
+    return " ".join(value for value in override.values() if isinstance(value, str))
+
+
+def _forbidden_override_failures(overrides: list[dict[str, Any]]) -> list[str]:
+    failures: list[str] = []
+    for index, override in enumerate(overrides):
+        text = _override_text(override)
+        if not text:
+            continue
+        for pattern, message in FORBIDDEN_OVERRIDE_CHECKS:
+            if pattern.search(text):
+                failures.append(f"override[{index}] {message}: {text!r}")
+                break
+    return failures
+
+
 def _is_relative_to(path: Path, root: Path) -> bool:
     try:
         path.resolve().relative_to(root.resolve())
@@ -254,17 +325,26 @@ def _override_records(payload: dict[str, Any]) -> tuple[list[dict[str, Any]], li
                 continue
             overrides.append(item)
             for required in ("issue", "reason", "owner"):
-                if not item.get(required):
+                if required not in item:
                     failures.append(f"{field}[{index}] missing required override metadata: {required}")
-            if not item.get("review_cadence") and not item.get("expires_at"):
+                elif not _non_empty_string(item[required]):
+                    failures.append(f"{field}[{index}] override metadata must be a non-empty string: {required}")
+            has_valid_cadence = _non_empty_string(item.get("review_cadence"))
+            has_valid_expiry = _non_empty_string(item.get("expires_at"))
+            if "review_cadence" not in item and "expires_at" not in item:
                 failures.append(f"{field}[{index}] missing required override metadata: review_cadence or expires_at")
+            elif not has_valid_cadence and not has_valid_expiry:
+                failures.append(
+                    f"{field}[{index}] override metadata must include non-empty string review_cadence or expires_at"
+                )
     return overrides, failures
 
 
-def _workflow_ref_failures(target_repo: Path) -> list[str]:
+def _workflow_ref_failures(target_repo: Path, governance_ref: str | None) -> list[str]:
     workflow_root = target_repo / ".github" / "workflows"
     if not workflow_root.exists():
         return []
+    valid_governance_ref = governance_ref if governance_ref and SHA_RE.fullmatch(governance_ref) else None
     failures: list[str] = []
     for path in sorted(workflow_root.glob("*.y*ml")):
         relpath = path.relative_to(target_repo).as_posix()
@@ -273,6 +353,10 @@ def _workflow_ref_failures(target_repo: Path) -> list[str]:
             ref = match.group("ref").rstrip("/")
             if not SHA_RE.fullmatch(ref):
                 failures.append(f"reusable workflow ref must be pinned to an exact governance SHA: {relpath} uses @{ref}")
+            elif valid_governance_ref and ref != valid_governance_ref:
+                failures.append(
+                    f"reusable workflow ref SHA mismatch: {relpath} uses @{ref}, expected @{valid_governance_ref}"
+                )
     return failures
 
 
@@ -373,7 +457,8 @@ def _validate_record(
 
     observed_overrides, override_failures = _override_records(payload)
     failures.extend(override_failures)
-    failures.extend(_workflow_ref_failures(target_repo))
+    failures.extend(_forbidden_override_failures(observed_overrides))
+    failures.extend(_workflow_ref_failures(target_repo, governance_ref if isinstance(governance_ref, str) else None))
 
     central = desired_state.get("centrally_applied_surfaces")
     if isinstance(central, list) and central:


### PR DESCRIPTION
## Summary

- Keeps the merged issue #454 v0.2 verifier as the base and ports only the useful duplicate-branch hardening deltas.
- Adds exact reusable workflow SHA mismatch checks against the consumer `governance_ref`.
- Tightens override metadata validation and blocks forbidden override classes for protected governance constraints.
- Records issue #474 plan, execution scope, handoff, validation, backlog/progress mirrors, and refreshed graphify artifacts.

## Validation

- PASS `python3 scripts/overlord/test_verify_governance_consumer.py` (27 tests)
- PASS `python3 -m unittest scripts.overlord.test_deploy_governance_tooling scripts.overlord.test_verify_governance_consumer` (39 tests)
- PASS `python3 -m py_compile scripts/overlord/verify_governance_consumer.py scripts/overlord/test_verify_governance_consumer.py`
- PASS `python3 scripts/overlord/validate_handoff_package.py --root . raw/handoffs/2026-04-21-issue-474-plan-to-implementation.json`
- PASS `python3 scripts/overlord/validate_structured_agent_cycle_plan.py --root . --branch-name issue-474-verifier-hardening --changed-files-file /tmp/issue-474-changed-files.txt --enforce-governance-surface --enforce-planner-boundary-scope`
- PASS `python3 scripts/overlord/assert_execution_scope.py --scope raw/execution-scopes/2026-04-21-issue-474-verifier-hardening-implementation.json --changed-files-file /tmp/issue-474-changed-files.txt --require-lane-claim`
- PASS `git diff --check`
- PASS `tools/local-ci-gate/bin/hldpro-local-ci run --profile hldpro-governance --json`

Closes #474.
