### PR TITLE
[codex] Use runner Python for Overlord Sweep graph update

### DIFF
--- a/.github/workflows/overlord-sweep.yml
+++ b/.github/workflows/overlord-sweep.yml
@@ -597,12 +597,12 @@ jobs:
       # ── Update knowledge graph ──
       - name: Update knowledge graph
         run: |
-          python3.11 -m pip install graphifyy -q
+          python3 -m pip install graphifyy -q
           python3 scripts/knowledge_base/graphify_targets.py list --scheduled --format tsv > /tmp/graphify-targets.tsv
           while IFS=$'\t' read -r repo_slug display_name source_path output_path wiki_path; do
             if [ -d "$source_path" ]; then
               echo "Refreshing graphify artifacts for ${display_name}"
-              python3.11 scripts/knowledge_base/build_graph.py \
+              python3 scripts/knowledge_base/build_graph.py \
                 --source "$source_path" \
                 --output "$output_path" \
                 --wiki-dir "$wiki_path" \

--- a/docs/plans/issue-485-overlord-sweep-python-runtime-pdcar.md
+++ b/docs/plans/issue-485-overlord-sweep-python-runtime-pdcar.md
@@ -1,0 +1,31 @@
+# Issue 485 PDCAR: Overlord Sweep Python Runtime
+
+Issue: NIBARGERB-HLDPRO/hldpro-governance#485  
+Date: 2026-04-21
+
+## Plan
+
+Manual sweep run `24739125036` proved the self-learning report step now runs, then failed later in `Update knowledge graph` because the workflow called `python3.11` and the GitHub-hosted runner did not expose that binary.
+
+Expected implementation:
+
+- Replace the hardcoded `python3.11` calls in `.github/workflows/overlord-sweep.yml` with `python3`.
+- Keep graphify installation and graph building in the same step.
+- Validate the workflow change through local governance gates.
+- Re-run the manual sweep after merge.
+
+## Do
+
+Patch the workflow runtime command only, then run workflow/local-governance checks and publish a focused PR.
+
+## Check
+
+Acceptance criteria:
+
+- The workflow no longer depends on a missing `python3.11` binary.
+- Local CI and workflow coverage checks pass.
+- The next manual Overlord Sweep reaches graph update with an available Python runtime.
+
+## Act
+
+If the sweep fails later, record the concrete downstream blocker in an issue and continue the loop without reclassifying the already-proven self-learning report step as failed.

--- a/docs/plans/issue-485-overlord-sweep-python-runtime-structured-agent-cycle-plan.json
+++ b/docs/plans/issue-485-overlord-sweep-python-runtime-structured-agent-cycle-plan.json
@@ -1,0 +1,91 @@
+{
+  "session_id": "session-20260421-issue-485-overlord-sweep-python-runtime",
+  "issue_number": 485,
+  "objective": "Remove the GitHub-hosted runner dependency on a missing python3.11 binary from the Overlord Sweep graph update step.",
+  "tier": 2,
+  "scope_boundary": [
+    "Modify only the Overlord Sweep workflow Python runtime invocation and issue-backed planning, scope, and validation evidence.",
+    "Preserve the existing graphify install/build behavior except for the interpreter executable.",
+    "Use issue #485 as the governing issue for the post-self-learning sweep blocker."
+  ],
+  "out_of_scope": [
+    "Changing graphify graph generation behavior.",
+    "Changing self-learning report generation.",
+    "Changing downstream repositories."
+  ],
+  "research_summary": "Run 24739125036 checked out all governed repos and successfully completed Validate codex and agent model pins, Memory integrity audit, Build self-learning knowledge report, and Build effectiveness baseline snapshot. The later Update knowledge graph step failed immediately with python3.11: command not found.",
+  "research_artifacts": [
+    "https://github.com/NIBARGERB-HLDPRO/hldpro-governance/issues/485",
+    "https://github.com/NIBARGERB-HLDPRO/hldpro-governance/actions/runs/24739125036",
+    ".github/workflows/overlord-sweep.yml"
+  ],
+  "sprints": [
+    {
+      "name": "Workflow Python runtime fix",
+      "goal": "Use the runner-provided Python runtime for graphify installation and graph generation.",
+      "tasks": [
+        "Replace python3.11 with python3 in the Overlord Sweep graph update step.",
+        "Validate the workflow change with local governance gates.",
+        "Publish, merge, and re-run the manual sweep."
+      ],
+      "acceptance_criteria": [
+        "No python3.11 invocation remains in the Overlord Sweep workflow.",
+        "Local CI gate passes.",
+        "Manual sweep reaches the graph update step without python3.11 command-not-found."
+      ],
+      "file_paths": [
+        ".github/workflows/overlord-sweep.yml",
+        "docs/plans/issue-485-overlord-sweep-python-runtime-pdcar.md",
+        "docs/plans/issue-485-overlord-sweep-python-runtime-structured-agent-cycle-plan.json",
+        "raw/execution-scopes/2026-04-21-issue-485-overlord-sweep-python-runtime-implementation.json",
+        "raw/validation/2026-04-21-issue-485-overlord-sweep-python-runtime.md"
+      ]
+    }
+  ],
+  "specialist_reviews": [
+    {
+      "reviewer": "codex-orchestrator-log-inspection",
+      "role": "workflow failure triage",
+      "focus": "Inspect Overlord Sweep run 24739125036 and identify the post-self-learning failure source.",
+      "status": "accepted",
+      "summary": "The run failed immediately in Update knowledge graph because python3.11 was not found on the GitHub-hosted runner; replacing the workflow invocation with python3 is the bounded runtime fix.",
+      "evidence": [
+        "https://github.com/NIBARGERB-HLDPRO/hldpro-governance/actions/runs/24739125036"
+      ]
+    }
+  ],
+  "alternate_model_review": {
+    "required": false,
+    "reviewer": "not-required-for-workflow-runtime-bugfix",
+    "model_family": "none",
+    "status": "not_requested",
+    "summary": "This is a deterministic workflow runtime fix with no architecture or policy change.",
+    "evidence": [
+      "https://github.com/NIBARGERB-HLDPRO/hldpro-governance/issues/485"
+    ]
+  },
+  "execution_handoff": {
+    "session_agent": "Codex",
+    "execution_mode": "implementation_ready",
+    "approved_scope_summary": "Issue #485 may update the Overlord Sweep workflow interpreter invocation and required governance evidence.",
+    "next_execution_step": "Merge the workflow runtime fix and re-run Overlord Sweep on main.",
+    "blocked_on": [],
+    "execution_scope_ref": "raw/execution-scopes/2026-04-21-issue-485-overlord-sweep-python-runtime-implementation.json",
+    "handoff_package_ref": null,
+    "validation_artifact_refs": [
+      "raw/validation/2026-04-21-issue-485-overlord-sweep-python-runtime.md"
+    ],
+    "closeout_ref": null
+  },
+  "material_deviation_rules": [
+    "If python3 lacks graphify-compatible version support on the runner, replace the step with explicit setup-python instead of broadening the workflow.",
+    "If graphify itself fails after the interpreter fix, record the new failure separately before claiming full sweep completion."
+  ],
+  "approved": true,
+  "approved_by": [
+    "operator directive",
+    "GitHub issue #485",
+    "Codex orchestrator"
+  ],
+  "approved_at": "2026-04-21T18:25:00Z"
+}

--- a/raw/execution-scopes/2026-04-21-issue-485-overlord-sweep-python-runtime-implementation.json
+++ b/raw/execution-scopes/2026-04-21-issue-485-overlord-sweep-python-runtime-implementation.json
@@ -1,0 +1,39 @@
+{
+  "expected_execution_root": "{repo_root}",
+  "expected_branch": "issue-485-overlord-sweep-python-runtime",
+  "allowed_write_paths": [
+    ".github/workflows/overlord-sweep.yml",
+    "docs/plans/issue-485-overlord-sweep-python-runtime-pdcar.md",
+    "docs/plans/issue-485-overlord-sweep-python-runtime-structured-agent-cycle-plan.json",
+    "raw/execution-scopes/2026-04-21-issue-485-overlord-sweep-python-runtime-implementation.json",
+    "raw/validation/2026-04-21-issue-485-overlord-sweep-python-runtime.md"
+  ],
+  "forbidden_roots": [
+    "/Users/bennibarger/Developer/HLDPRO/hldpro-governance"
+  ],
+  "active_parallel_roots": [
+    {
+      "path": "/Users/bennibarger/Developer/HLDPRO/hldpro-governance",
+      "reason": "Primary checkout is a separate active worktree and must not be modified by issue #485."
+    }
+  ],
+  "execution_mode": "implementation_ready",
+  "lane_claim": {
+    "issue_number": 485,
+    "claim_ref": "https://github.com/NIBARGERB-HLDPRO/hldpro-governance/issues/485",
+    "claimed_by": "session-agent-codex-gpt-5.4",
+    "claimed_at": "2026-04-21T18:25:00Z"
+  },
+  "handoff_evidence": {
+    "status": "accepted",
+    "planner_model": "operator-directive",
+    "implementer_model": "gpt-5.4",
+    "accepted_at": "2026-04-21T18:25:00Z",
+    "evidence_paths": [
+      "docs/plans/issue-485-overlord-sweep-python-runtime-structured-agent-cycle-plan.json",
+      "https://github.com/NIBARGERB-HLDPRO/hldpro-governance/issues/485"
+    ],
+    "active_exception_ref": null,
+    "active_exception_expires_at": null
+  }
+}

--- a/raw/validation/2026-04-21-issue-485-overlord-sweep-python-runtime.md
+++ b/raw/validation/2026-04-21-issue-485-overlord-sweep-python-runtime.md
@@ -1,0 +1,18 @@
+# Issue 485 Validation: Overlord Sweep Python Runtime
+
+Date: 2026-04-21  
+Issue: #485
+
+## Local Evidence
+
+| Check | Result |
+|---|---|
+| `rg -n "python3\\.11" .github/workflows/overlord-sweep.yml` | PASS; no matches |
+| `python3 scripts/overlord/validate_structured_agent_cycle_plan.py --root . --branch-name issue-485-overlord-sweep-python-runtime --changed-files-file /tmp/issue-485-changed-files.txt --enforce-governance-surface` | PASS |
+| `python3 scripts/overlord/assert_execution_scope.py --scope raw/execution-scopes/2026-04-21-issue-485-overlord-sweep-python-runtime-implementation.json --changed-files-file /tmp/issue-485-changed-files.txt --require-lane-claim` | PASS |
+| `tools/local-ci-gate/bin/hldpro-local-ci run --profile hldpro-governance --json` | PASS |
+| `git diff --check` | PASS |
+
+## Remote Evidence
+
+Pending PR merge and follow-up manual Overlord Sweep dispatch.


### PR DESCRIPTION
## Summary

- Replaces the hardcoded `python3.11` calls in the Overlord Sweep graph update step with `python3`, matching the runtime available on GitHub-hosted runners.
- Adds issue #485 plan, execution scope, and validation evidence for the post-self-learning sweep blocker.

## Acceptance Criteria Status

- [x] `overlord-sweep.yml` no longer invokes `python3.11`.
- [x] Local governance surface planning and execution scope validation pass.
- [x] Local CI gate passes.
- [ ] Post-merge manual Overlord Sweep completes the graph update step.

## Validation

- `rg -n "python3\\.11" .github/workflows/overlord-sweep.yml` returned no matches.
- `python3 scripts/overlord/validate_structured_agent_cycle_plan.py --root . --branch-name issue-485-overlord-sweep-python-runtime --changed-files-file /tmp/issue-485-changed-files.txt --enforce-governance-surface`
- `python3 scripts/overlord/assert_execution_scope.py --scope raw/execution-scopes/2026-04-21-issue-485-overlord-sweep-python-runtime-implementation.json --changed-files-file /tmp/issue-485-changed-files.txt --require-lane-claim`
- `tools/local-ci-gate/bin/hldpro-local-ci run --profile hldpro-governance --json`
- `git diff --check`

## Blockers and Dependencies

- Follow-up proof requires merge, then manual dispatch of `Overlord Sweep — Weekly Cross-Repo Audit` on `main`.

Fixes #485
