### PR TITLE
[codex] Use cross-repo token for sweep artifact PRs

### DIFF
--- a/.github/workflows/overlord-sweep.yml
+++ b/.github/workflows/overlord-sweep.yml
@@ -622,7 +622,7 @@ jobs:
       - name: Commit updated graph
         id: persist_baseline
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GH_CROSS_REPO_TOKEN || secrets.GITHUB_TOKEN }}
         run: |
           set +e
           git config user.name "overlord-bot"
@@ -689,7 +689,7 @@ jobs:
       # ── Create or update GitHub Issue ──
       - name: Create or update overlord report issue
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GH_CROSS_REPO_TOKEN || secrets.GITHUB_TOKEN }}
         run: |
           DATE=$(date -u +%Y-%m-%d)
 

--- a/raw/execution-scopes/2026-04-21-issue-487-overlord-sweep-artifact-pr-implementation.json
+++ b/raw/execution-scopes/2026-04-21-issue-487-overlord-sweep-artifact-pr-implementation.json
@@ -1,6 +1,6 @@
 {
   "expected_execution_root": "{repo_root}",
-  "expected_branch": "issue-487-overlord-sweep-artifact-pr",
+  "expected_branch": "issue-487-overlord-sweep-artifact-pr-token",
   "allowed_write_paths": [
     ".github/workflows/overlord-sweep.yml",
     "docs/plans/issue-487-overlord-sweep-artifact-pr-pdcar.md",

--- a/raw/validation/2026-04-21-issue-487-overlord-sweep-artifact-pr.md
+++ b/raw/validation/2026-04-21-issue-487-overlord-sweep-artifact-pr.md
@@ -14,4 +14,5 @@ Issue: #487
 
 ## Remote Evidence
 
-Pending PR merge and follow-up manual Overlord Sweep dispatch.
+- Run `24739685759` after PR #488: branch push reached `automation/overlord-sweep-2026-04-21-24739685759`, but PR creation failed because the default `GITHUB_TOKEN` is not permitted to create pull requests in this repository.
+- Follow-up patch switches persistence and report issue `GH_TOKEN` to `${{ secrets.GH_CROSS_REPO_TOKEN || secrets.GITHUB_TOKEN }}` to match the existing cross-repo sweep token pattern.


### PR DESCRIPTION
## Summary

- Uses `GH_CROSS_REPO_TOKEN` fallback for Overlord Sweep generated-artifact PR creation and report issue updates.
- Keeps the PR-based artifact persistence path from #488, but avoids the default `GITHUB_TOKEN` pull-request creation restriction observed in run `24739685759`.

## Acceptance Criteria Status

- [x] Branch push path worked in run `24739685759`.
- [x] PR creation now uses `${{ secrets.GH_CROSS_REPO_TOKEN || secrets.GITHUB_TOKEN }}`.
- [x] Local governance gates pass.
- [ ] Post-merge manual sweep creates the generated artifact PR instead of failing `createPullRequest`.

## Validation

- `python3 scripts/overlord/validate_structured_agent_cycle_plan.py --root . --branch-name issue-487-overlord-sweep-artifact-pr-token --changed-files-file /tmp/issue-487-token-changed-files.txt --enforce-governance-surface`
- `python3 scripts/overlord/assert_execution_scope.py --scope raw/execution-scopes/2026-04-21-issue-487-overlord-sweep-artifact-pr-implementation.json --changed-files-file /tmp/issue-487-token-changed-files.txt --require-lane-claim`
- `tools/local-ci-gate/bin/hldpro-local-ci run --profile hldpro-governance --json`
- `git diff --check`

## Blockers and Dependencies

- Follow-up proof requires merge, then manual dispatch of `Overlord Sweep — Weekly Cross-Repo Audit` on `main`.

Refs #487
