### PR TITLE
[codex] Define secret provisioning UX standards

### DIFF
--- a/STANDARDS.md
+++ b/STANDARDS.md
@@ -149,6 +149,17 @@ These files must be consistent at the contract level. They do **not** need to be
 - Subagent approval system for cross-boundary (frontend↔backend) operations
 - Detailed project tracking lives in `backend/docs/PROJECT_STATUS.md` (supplements root `docs/PROGRESS.md`)
 
+### Secret Provisioning UX
+- Missing-secret and deploy-preflight diagnostics must list required variable names only. They must not print secret values, partial values, token prefixes, raw phone numbers, signed URLs, Authorization headers, generated env file contents, or screenshots containing credentials.
+- Operator guidance must route credential setup through approved provisioning surfaces:
+  - `hldpro-governance/.env.shared` as the gitignored local SSOT for operator-managed local credentials
+  - `scripts/bootstrap-repo-env.sh` generated repo-local env files, which remain ignored generated artifacts
+  - provider dashboards or vaults for provider-owned secret rotation
+  - GitHub Actions secrets or vars for CI-only credentials
+- Tooling, runbooks, issue bodies, PR descriptions, validation artifacts, and CI logs must not instruct operators to paste credential values into inline shell commands. This includes shell export assignments for secret variables, `launchctl setenv` with secret values, and pipelines that send literal values into `gh secret set`.
+- Missing-secret messages should use the canonical pattern documented in `docs/ENV_REGISTRY.md`: report the missing variable names, identify the approved provisioning surface, and ask the operator to rerun the appropriate bootstrap or provider/CI configuration step.
+- Evidence for secret provisioning must be value-free. Valid evidence includes variable names, command exit status, redacted dry-run output, file paths to ignored/generated env targets, provider surface names, GitHub secret names, and issue links.
+
 ## Security Standards (Tiered)
 
 Each repo has a security tier that determines which security artifacts the overlord agents verify.

--- a/docs/ENV_REGISTRY.md
+++ b/docs/ENV_REGISTRY.md
@@ -1,6 +1,6 @@
 # HLDPRO — Environment Variable Registry
 
-**Version:** 2026-04-16
+**Version:** 2026-04-21
 **Owner:** Operator (nibarger.ben@gmail.com)
 **SSOT file:** `hldpro-governance/.env.shared` (gitignored — never commit)
 **Bootstrap:** `bash scripts/bootstrap-repo-env.sh <repo> [target-path]`
@@ -29,6 +29,51 @@ bash ~/Developer/HLDPRO/hldpro-governance/scripts/bootstrap-repo-env.sh seek-loc
 # Seed Stampede market-data env
 bash ~/Developer/HLDPRO/hldpro-governance/scripts/bootstrap-repo-env.sh stampede
 ```
+
+---
+
+## Secret Provisioning UX Contract
+
+Missing-secret diagnostics and deploy preflights must be actionable without asking the operator to paste secret values into a shell, issue, chat, PR, log, or validation artifact.
+
+### Approved provisioning surfaces
+
+| Surface | Use | Evidence allowed |
+|---|---|---|
+| `hldpro-governance/.env.shared` | Local operator-managed credential SSOT. This file is gitignored and must never be committed. | Variable names, target repo key names, and redacted dry-run output only. |
+| `scripts/bootstrap-repo-env.sh` generated files | Repo-local `.env.local` or equivalent generated artifacts for local execution. | Target file path, command exit status, and redacted preview output. |
+| Provider dashboard or vault | Provider-owned rotation and account-scoped secret creation. | Provider name, secret name, scope description, and rotation timestamp. |
+| GitHub Actions secrets or vars | CI-only credentials and deploy approvals. | Secret or variable names and repository/org scope; never values. |
+
+### Diagnostic wording
+
+Use name-only messages:
+
+```text
+Missing required secret variables: CLOUDFLARE_API_TOKEN, CLOUDFLARE_ACCOUNT_ID.
+Provision them through hldpro-governance/.env.shared plus bootstrap for local runs, or through GitHub Actions secrets for CI.
+Values are intentionally not accepted in this prompt or printed in logs.
+```
+
+Use blocked-state messages when the approved surface is unavailable:
+
+```text
+Blocked: required secret variables are absent: CLOUDFLARE_API_TOKEN, CLOUDFLARE_ACCOUNT_ID.
+No deploy was attempted. Configure the approved provisioning surface, then rerun the preflight.
+```
+
+Use ready-state messages without values:
+
+```text
+Ready: required secret variables are present by name and values remain redacted.
+```
+
+### Prohibited guidance
+
+- Do not provide inline secret-setting commands for credential variables.
+- Do not ask operators to paste provider tokens, raw phone numbers, signed URLs, Authorization headers, JWTs, or generated env file contents into terminal commands.
+- Do not record secret values or screenshots containing secret values as validation evidence.
+- Do not source `.env.shared` in a runbook as an execution pattern. Use the bootstrap script or provider/CI secret surfaces instead.
 
 ---
 

--- a/raw/validation/2026-04-21-issue-509-secret-provisioning-ux-standards.md
+++ b/raw/validation/2026-04-21-issue-509-secret-provisioning-ux-standards.md
@@ -39,3 +39,22 @@ Observed results:
 - `scripts/overlord/assert_execution_scope.py --require-lane-claim` passed with warnings for pre-existing dirty sibling roots declared as active parallel roots.
 - `tools/local-ci-gate/bin/hldpro-local-ci --profile hldpro-governance --report-dir cache/local-ci-gate/reports --json` passed.
 - `git diff --check` passed.
+
+## Implementation Validation
+
+The implementation PR changed `STANDARDS.md` and `docs/ENV_REGISTRY.md` only. Local validation passed:
+
+```bash
+python3 scripts/overlord/assert_execution_scope.py --scope raw/execution-scopes/2026-04-21-issue-509-secret-provisioning-ux-standards-implementation.json --require-lane-claim
+python3 scripts/overlord/validate_structured_agent_cycle_plan.py --root .
+tools/local-ci-gate/bin/hldpro-local-ci --profile hldpro-governance --report-dir cache/local-ci-gate/reports --json
+git diff --check
+```
+
+Observed results:
+
+- Execution scope validation passed with active-parallel-root warnings for pre-existing dirty sibling checkouts.
+- Structured plan validation passed.
+- Local CI Gate passed with changed files `STANDARDS.md` and `docs/ENV_REGISTRY.md`.
+- Local CI Gate included and passed `bootstrap-env-contract` and `registry-surface-reconciliation`.
+- Diff hygiene passed.


### PR DESCRIPTION
## Summary

- Adds the Secret Provisioning UX rule to STANDARDS.md before Security Standards.
- Adds the Secret Provisioning UX Contract to docs/ENV_REGISTRY.md using existing .env.shared/bootstrap/provider/GitHub secret surfaces.
- Records implementation validation evidence for issue #509.

## Validation

- `python3 scripts/overlord/assert_execution_scope.py --scope raw/execution-scopes/2026-04-21-issue-509-secret-provisioning-ux-standards-implementation.json --require-lane-claim`
- `python3 scripts/overlord/validate_structured_agent_cycle_plan.py --root .`
- `tools/local-ci-gate/bin/hldpro-local-ci --profile hldpro-governance --report-dir cache/local-ci-gate/reports --json`
- `git diff --check`

Closes #509.
Part of #507.
