### PR TITLE
[codex] Add provisioning evidence safety validator

### DIFF
--- a/docs/FEATURE_REGISTRY.md
+++ b/docs/FEATURE_REGISTRY.md
@@ -55,6 +55,7 @@
 | GOV-028 | REMOTE_MCP_BRIDGE_GOVERNANCE | Remote MCP Bridge standards, thin client contract, audit verifier, Stage D proof runner, recurring health monitor, payload-safe alerts, and operator runbook | IN_PROGRESS | REQUIRED |
 | GOV-029 | PAGES_DEPLOY_GATE | Pages Deploy Gate (governance-owned, issue #469) | COMPLETE | OPS_READY |
 | GOV-030 | PAGES_DEPLOYMENT_PARITY | Cloudflare Pages deployment freshness and domain parity verifier | COMPLETE | OPS_READY |
+| GOV-031 | SECRET_PROVISIONING_EVIDENCE | No-secret provisioning evidence validator and Local CI Gate check | COMPLETE | REQUIRED |
 
 ---
 
@@ -76,6 +77,8 @@
 | GOV-002 | `graphify-governance-contract.yml` is the governance repo’s local graphify contract gate: it validates the manifest-defined target set, helper scripts, and generated `wiki/index.md` synchronization before graph contract changes merge. |
 | GOV-006 | Current rollout adds `docs/FEATURE_REGISTRY.md` as a governed artifact and blocks stale code-only changes when the registry is not updated. |
 | GOV-029 | `scripts/pages-deploy/pages_deploy_gate.py` provides a reusable Cloudflare Pages Direct Upload gate for governed consumers. It validates consumer config, preflights `node`/`wrangler`, checks required env names without printing values, requires `PAGES_DEPLOY_APPROVED=1` for live deploys, runs optional pre-deploy hooks before build/upload, rejects stale or oversized artifacts, invokes Wrangler with `CI=true` and `--non-interactive`, and emits redacted deployment evidence. |
+| GOV-031 | `scripts/overlord/validate_provisioning_evidence.py` scans provisioning evidence for token-like strings, JWT fragments, Authorization headers, signed URLs, raw phone numbers, and generated env file contents while reporting only file paths and matched classes. |
+| GOV-031 | The `hldpro-governance` Local CI Gate profile runs `provisioning-evidence-safety` when standards, env registry, runbooks, validation artifacts, Pages deploy tooling, or Remote MCP tooling change. |
 
 ### AGENT_AUDIT
 

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -43,6 +43,7 @@
 | Item | Issue | Date | Notes |
 |------|-------|------|-------|
 | Governance SSOT consumer adoption report and epic closeout | #459 #452 | 2026-04-21 | Added the org-level consumer adoption report, wired it into overlord-sweep and Local CI, recorded the v0.2 adoption snapshot, and opened downstream residual workflow-pin issues HealthcarePlatform#1462 and ASC-Evaluator#13. |
+| Secret provisioning evidence validator | #510 | 2026-04-21 | Added `scripts/overlord/validate_provisioning_evidence.py`, focused leakage-class tests, and `hldpro-governance` Local CI Gate wiring for no-secret provisioning evidence checks. |
 | Governance SSOT consumer verifier edge-case hardening | #474 | 2026-04-21 | Ported duplicate issue #454 verifier QA deltas into the merged v0.2 verifier: workflow-ref mismatch checks, strict override metadata validation, forbidden override class checks, and focused tests. |
 | Pages Deploy Gate | #469 | 2026-04-21 | DONE. Adds the governance-owned Cloudflare Pages Direct Upload deploy gate, 15 mocked pytest cases, deploy and rollback runbooks, two-phase deploy approval, build freshness, Pages limit checks, secret redaction, and evidence output for governed Pages consumers. |
 | Cloudflare Pages deployment freshness and domain parity verifier | #470 | 2026-04-21 | Adds `scripts/pages-deploy/pages_deploy_verifier.py` with stale-checkout guard, cache-busting requests, retry/backoff, redirect-chain recording, stable deployment-id checks, nonblocking inactive/CNAME reporting, and mocked pytest coverage. |

--- a/docs/SERVICE_REGISTRY.md
+++ b/docs/SERVICE_REGISTRY.md
@@ -43,6 +43,7 @@
 | validate_structured_agent_cycle_plan.py | `scripts/overlord/validate_structured_agent_cycle_plan.py` | Validates structured plan JSON against org schema |
 | assert_execution_scope.py | `scripts/overlord/assert_execution_scope.py` | Asserts issue work runs from the declared root/branch, enforces planning-only `allowed_write_paths`, requires accepted pinned-agent handoff evidence for non-planning diffs, and can require `lane_claim` issue ownership |
 | check_execution_environment.py | `scripts/overlord/check_execution_environment.py` | Session-start execution-scope preflight for root, branch, write paths, sibling roots, and optional lane-claim enforcement |
+| validate_provisioning_evidence.py | `scripts/overlord/validate_provisioning_evidence.py` | Scans provisioning evidence for secret-like values while reporting only file paths and matched classes |
 | validate_governed_repos.py | `scripts/overlord/validate_governed_repos.py` | Validates `docs/governed_repos.json` and reconciles it with graphify targets |
 | governed_repos.py | `scripts/overlord/governed_repos.py` | Shared adapter for executable governed repo registry consumers |
 | codex_ingestion.py | `scripts/overlord/codex_ingestion.py` | Codex review ingestion: generate, qualify, promote; Codex QA remains distinct from Worker authority |

--- a/docs/runbooks/local-ci-gate-toolkit.md
+++ b/docs/runbooks/local-ci-gate-toolkit.md
@@ -53,6 +53,7 @@ It runs or plans:
 - Governance-surface planning gate when governance paths changed.
 - Planner-boundary execution-scope assertion when planner-boundary paths changed.
 - `git diff --check`.
+- Secret provisioning evidence safety checks when standards, env registry, runbooks, validation artifacts, Pages deploy tooling, or Remote MCP tooling change.
 - Focused Local CI Gate tests when `tools/local-ci-gate/` changed.
 
 The runner continues through all checks it can run and exits non-zero only for blocker failures. Advisory failures are reported but do not block by default.

--- a/raw/validation/2026-04-21-issue-510-provisioning-evidence-validator.md
+++ b/raw/validation/2026-04-21-issue-510-provisioning-evidence-validator.md
@@ -35,3 +35,25 @@ Observed results:
 - `scripts/overlord/validate_structured_agent_cycle_plan.py --root .` passed.
 - `tools/local-ci-gate/bin/hldpro-local-ci --profile hldpro-governance --report-dir cache/local-ci-gate/reports --json` passed.
 - `git diff --check` passed.
+
+## Implementation Validation
+
+The implementation extends the existing Local CI Gate and Overlord script surfaces. It does not add a new runner or standalone deploy/security workflow.
+
+```bash
+python3 scripts/overlord/test_validate_provisioning_evidence.py
+python3 -m unittest discover tools/local-ci-gate/tests
+python3 scripts/overlord/assert_execution_scope.py --scope raw/execution-scopes/2026-04-21-issue-510-provisioning-evidence-validator-implementation.json --require-lane-claim
+python3 scripts/overlord/validate_structured_agent_cycle_plan.py --root .
+tools/local-ci-gate/bin/hldpro-local-ci --profile hldpro-governance --report-dir cache/local-ci-gate/reports --json
+git diff --check
+```
+
+Observed results:
+
+- `scripts/overlord/test_validate_provisioning_evidence.py` passed: 8 tests.
+- `python3 -m unittest discover tools/local-ci-gate/tests` passed: 21 tests.
+- `assert_execution_scope.py` passed with declared active-parallel-root warnings only.
+- `validate_structured_agent_cycle_plan.py --root .` passed: 132 structured plan files.
+- Local CI Gate passed with verdict `pass`; blocker `provisioning-evidence-safety` ran and passed.
+- `git diff --check` passed.

--- a/scripts/overlord/test_validate_provisioning_evidence.py
+++ b/scripts/overlord/test_validate_provisioning_evidence.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+import contextlib
+import io
+import tempfile
+import unittest
+from pathlib import Path
+
+import validate_provisioning_evidence as validator
+
+
+class ValidateProvisioningEvidenceTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmp = tempfile.TemporaryDirectory()
+        self.root = Path(self.tmp.name)
+
+    def tearDown(self) -> None:
+        self.tmp.cleanup()
+
+    def write_file(self, rel_path: str, content: str) -> Path:
+        path = self.root / rel_path
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content, encoding="utf-8")
+        return path
+
+    def run_validator(self, *args: str) -> tuple[int, str]:
+        out = io.StringIO()
+        with contextlib.redirect_stdout(out):
+            rc = validator.main(["--root", str(self.root), *args])
+        return rc, out.getvalue()
+
+    def test_safe_name_only_missing_secret_output_passes(self) -> None:
+        self.write_file(
+            "raw/validation/safe.md",
+            "Missing required secret variables: CLOUDFLARE_API_TOKEN, CLOUDFLARE_ACCOUNT_ID.\n"
+            "Provision them through hldpro-governance/.env.shared plus bootstrap.\n"
+            "Values are intentionally not accepted here.\n",
+        )
+
+        rc, output = self.run_validator("raw/validation/safe.md")
+
+        self.assertEqual(rc, 0)
+        self.assertIn("PASS provisioning evidence scan", output)
+
+    def test_token_like_string_fails_without_echoing_value(self) -> None:
+        token = "sk" + "_live_" + "abcdefghijklmnopqrstuvwxyz123456"
+        self.write_file("raw/validation/leak.md", f"Token: {token}\n")
+
+        rc, output = self.run_validator("raw/validation/leak.md")
+
+        self.assertEqual(rc, 1)
+        self.assertIn("token-like-string", output)
+        self.assertNotIn(token, output)
+
+    def test_jwt_fragment_fails(self) -> None:
+        self.write_file(
+            "raw/validation/jwt.md",
+            "JWT: eyJhbGciOiJIUzI1NiJ9.abcdefghijklmnopqrstuvwxyz123456.abcdefghijklmnopqrstuvwxyz123456\n",
+        )
+
+        rc, output = self.run_validator("raw/validation/jwt.md")
+
+        self.assertEqual(rc, 1)
+        self.assertIn("jwt-fragment", output)
+
+    def test_authorization_header_fails(self) -> None:
+        self.write_file("raw/validation/header.md", "Authorization: Bearer abcdefghijklmnop1234567890\n")
+
+        rc, output = self.run_validator("raw/validation/header.md")
+
+        self.assertEqual(rc, 1)
+        self.assertIn("authorization-header", output)
+        self.assertNotIn("abcdefghijklmnop1234567890", output)
+
+    def test_signed_url_fails(self) -> None:
+        self.write_file("raw/validation/url.md", "https://example.com/path?X-Amz-Signature=abcdef1234567890\n")
+
+        rc, output = self.run_validator("raw/validation/url.md")
+
+        self.assertEqual(rc, 1)
+        self.assertIn("signed-url", output)
+        self.assertNotIn("abcdef1234567890", output)
+
+    def test_raw_phone_number_fails(self) -> None:
+        self.write_file("raw/validation/phone.md", "Test phone: +18175550123\n")
+
+        rc, output = self.run_validator("raw/validation/phone.md")
+
+        self.assertEqual(rc, 1)
+        self.assertIn("raw-phone-number", output)
+        self.assertNotIn("+18175550123", output)
+
+    def test_generated_env_file_content_fails(self) -> None:
+        self.write_file(".env.local", "CLOUDFLARE_API_TOKEN=token-value-that-should-not-appear\n")
+
+        rc, output = self.run_validator(".env.local")
+
+        self.assertEqual(rc, 1)
+        self.assertIn("generated-env-file-content", output)
+        self.assertNotIn("token-value-that-should-not-appear", output)
+
+    def test_changed_files_file_limits_scan(self) -> None:
+        changed = self.write_file("changed-files.txt", "raw/validation/leak.md\n")
+        self.write_file("raw/validation/leak.md", "Authorization: Bearer abcdefghijklmnop1234567890\n")
+        ignored_token = "sk" + "_live_" + "abcdefghijklmnopqrstuvwxyz123456"
+        self.write_file("raw/validation/ignored.md", f"Token: {ignored_token}\n")
+
+        rc, output = self.run_validator("--changed-files-file", str(changed))
+
+        self.assertEqual(rc, 1)
+        self.assertIn("raw/validation/leak.md:1", output)
+        self.assertNotIn("raw/validation/ignored.md", output)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/overlord/validate_provisioning_evidence.py
+++ b/scripts/overlord/validate_provisioning_evidence.py
@@ -1,0 +1,182 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+
+DEFAULT_SCAN_PATHS = (
+    "STANDARDS.md",
+    "docs/ENV_REGISTRY.md",
+    "docs/EXTERNAL_SERVICES_RUNBOOK.md",
+    "docs/runbooks/",
+    "raw/validation/",
+    "scripts/pages-deploy/",
+    "scripts/remote-mcp/",
+)
+
+FIXTURE_ONLY_PATHS = {
+    "scripts/overlord/test_validate_provisioning_evidence.py",
+}
+
+SAFE_SUFFIXES = {
+    ".md",
+    ".txt",
+    ".json",
+    ".jsonl",
+    ".yml",
+    ".yaml",
+    ".sh",
+    ".py",
+}
+
+
+@dataclass(frozen=True)
+class Finding:
+    path: str
+    line: int
+    category: str
+
+
+@dataclass(frozen=True)
+class Rule:
+    category: str
+    pattern: re.Pattern[str]
+
+
+RULES = (
+    Rule(
+        "authorization-header",
+        re.compile(r"\bAuthorization\s*:\s*(?:Bearer|Basic|sso-key)\s+(?!\$|\$\{)[^\s`'\"<>]+", re.IGNORECASE),
+    ),
+    Rule(
+        "jwt-fragment",
+        re.compile(r"\beyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{12,}\.[A-Za-z0-9_-]{12,}\b"),
+    ),
+    Rule(
+        "token-like-string",
+        re.compile(
+            r"\b(?:sk_live|sk_test|sk-ant|ghp|github_pat|xox[baprs]|SG|pk_live|rk_live|AKIA|ASIA)"
+            r"[-_A-Za-z0-9]{12,}\b"
+        ),
+    ),
+    Rule(
+        "signed-url",
+        re.compile(
+            r"https?://[^\s`'\"<>]+[?&](?:X-Amz-Signature|X-Goog-Signature|Signature|sig|signature|access_token|token)=",
+            re.IGNORECASE,
+        ),
+    ),
+    Rule(
+        "raw-phone-number",
+        re.compile(r"(?<![A-Za-z0-9_])\+[1-9]\d{10,14}(?![A-Za-z0-9_])"),
+    ),
+)
+
+ENV_ASSIGNMENT_RE = re.compile(r"^\s*(?:export\s+)?[A-Z][A-Z0-9_]{2,}\s*=\s*(?!$|<redacted>|REDACTED|\$\{?)[^\s#]+")
+
+
+def _normalize_repo_path(path: str) -> str:
+    while path.startswith("./"):
+        path = path[2:]
+    return path
+
+
+def _read_changed_files(path: Path) -> list[str]:
+    raw = path.read_text(encoding="utf-8")
+    entries = raw.split("\0") if "\0" in raw else raw.splitlines()
+    return [_normalize_repo_path(entry.strip()) for entry in entries if entry.strip()]
+
+
+def _is_env_file(path: str) -> bool:
+    name = Path(path).name
+    return name == ".env" or name.startswith(".env.") or name.endswith(".env") or ".env." in name
+
+
+def _is_scan_candidate(path: Path, rel_path: str) -> bool:
+    if rel_path in FIXTURE_ONLY_PATHS:
+        return False
+    if not path.is_file():
+        return False
+    if _is_env_file(rel_path):
+        return True
+    return path.suffix in SAFE_SUFFIXES
+
+
+def _expand_scan_paths(root: Path, requested: list[str]) -> list[Path]:
+    paths: list[Path] = []
+    for raw in requested:
+        rel = _normalize_repo_path(raw)
+        candidate = root / rel
+        if candidate.is_dir():
+            paths.extend(child for child in candidate.rglob("*") if child.is_file())
+        elif candidate.exists():
+            paths.append(candidate)
+    return sorted(set(paths))
+
+
+def _default_paths(root: Path) -> list[str]:
+    return [path for path in DEFAULT_SCAN_PATHS if (root / path).exists()]
+
+
+def scan_file(root: Path, path: Path) -> list[Finding]:
+    try:
+        rel_path = path.relative_to(root).as_posix()
+    except ValueError:
+        rel_path = path.as_posix()
+
+    if not _is_scan_candidate(path, rel_path):
+        return []
+
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except UnicodeDecodeError:
+        return []
+
+    findings: list[Finding] = []
+    env_file = _is_env_file(rel_path)
+    for line_number, line in enumerate(lines, start=1):
+        if env_file and ENV_ASSIGNMENT_RE.search(line):
+            findings.append(Finding(rel_path, line_number, "generated-env-file-content"))
+        for rule in RULES:
+            if rule.pattern.search(line):
+                findings.append(Finding(rel_path, line_number, rule.category))
+    return findings
+
+
+def scan_paths(root: Path, requested: list[str]) -> list[Finding]:
+    findings: list[Finding] = []
+    for path in _expand_scan_paths(root, requested):
+        findings.extend(scan_file(root, path))
+    return findings
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Validate provisioning evidence does not contain secret-like values.")
+    parser.add_argument("paths", nargs="*", help="Repo-relative files or directories to scan.")
+    parser.add_argument("--root", default=".", help="Repo root.")
+    parser.add_argument("--changed-files-file", type=Path, help="Optional newline or NUL-delimited changed files list.")
+    args = parser.parse_args(argv)
+
+    root = Path(args.root).resolve()
+    requested = [_normalize_repo_path(path) for path in args.paths]
+    if args.changed_files_file:
+        requested.extend(_read_changed_files(args.changed_files_file))
+    if not requested:
+        requested = _default_paths(root)
+
+    findings = scan_paths(root, requested)
+    if findings:
+        for finding in findings:
+            print(f"FAIL {finding.path}:{finding.line}: provisioning evidence contains {finding.category}")
+        return 1
+
+    print(f"PASS provisioning evidence scan: {len(_expand_scan_paths(root, requested))} file(s)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/local-ci-gate/profiles/hldpro-governance.yml
+++ b/tools/local-ci-gate/profiles/hldpro-governance.yml
@@ -121,6 +121,28 @@ profile:
         - python3
         - scripts/test_bootstrap_repo_env_contract.py
 
+    - id: provisioning-evidence-safety
+      title: Secret provisioning evidence safety
+      severity: blocker
+      scope: changed
+      paths:
+        - STANDARDS.md
+        - docs/ENV_REGISTRY.md
+        - docs/EXTERNAL_SERVICES_RUNBOOK.md
+        - docs/runbooks/
+        - raw/validation/
+        - scripts/pages-deploy/
+        - scripts/remote-mcp/
+        - scripts/overlord/validate_provisioning_evidence.py
+        - scripts/overlord/test_validate_provisioning_evidence.py
+      command:
+        - python3
+        - scripts/overlord/validate_provisioning_evidence.py
+        - --root
+        - .
+        - --changed-files-file
+        - "{changed_files_file}"
+
     - id: workflow-local-coverage
       title: GitHub workflow local-first coverage inventory
       severity: blocker

--- a/tools/local-ci-gate/tests/test_local_ci_gate.py
+++ b/tools/local-ci-gate/tests/test_local_ci_gate.py
@@ -346,6 +346,34 @@ profile:
 
         self.assertEqual(statuses["handoff-package-integrity"], "skipped")
 
+    def test_governance_profile_runs_provisioning_evidence_validator_for_runbooks(self) -> None:
+        profile = gate.load_profile(PROFILES_DIR / "hldpro-governance.yml")
+        changed = gate.resolve_changed_files(
+            self.root,
+            explicit_files=["docs/runbooks/pages-deploy-gate.md"],
+            include_untracked=False,
+        )
+
+        report = gate.run_checks(self.root, profile, changed, dry_run=True, report_dir=self.root / "reports")
+        provisioning = next(result for result in report.results if result.check.id == "provisioning-evidence-safety")
+
+        self.assertEqual(provisioning.status, "planned")
+        self.assertIn("scripts/overlord/validate_provisioning_evidence.py", provisioning.command)
+        self.assertIn("--changed-files-file", provisioning.command)
+
+    def test_governance_profile_skips_provisioning_evidence_validator_for_unrelated_paths(self) -> None:
+        profile = gate.load_profile(PROFILES_DIR / "hldpro-governance.yml")
+        changed = gate.resolve_changed_files(
+            self.root,
+            explicit_files=["docs/plans/issue-999-example.md"],
+            include_untracked=False,
+        )
+
+        report = gate.run_checks(self.root, profile, changed, dry_run=True, report_dir=self.root / "reports")
+        statuses = {result.check.id: result.status for result in report.results}
+
+        self.assertEqual(statuses["provisioning-evidence-safety"], "skipped")
+
     def test_execution_scope_resolution_prefers_active_issue_implementation_scope(self) -> None:
         scope_dir = self.root / "raw" / "execution-scopes"
         scope_dir.mkdir(parents=True)


### PR DESCRIPTION
## Summary
- Adds `scripts/overlord/validate_provisioning_evidence.py` for no-secret provisioning evidence scans.
- Wires the validator into the existing `hldpro-governance` Local CI Gate profile as `provisioning-evidence-safety`.
- Adds focused validator and Local CI Gate routing tests, plus registry/runbook/progress updates.

## Validation
- `python3 scripts/overlord/test_validate_provisioning_evidence.py`
- `python3 -m unittest discover tools/local-ci-gate/tests`
- `python3 scripts/overlord/assert_execution_scope.py --scope raw/execution-scopes/2026-04-21-issue-510-provisioning-evidence-validator-implementation.json --require-lane-claim`
- `python3 scripts/overlord/validate_structured_agent_cycle_plan.py --root .`
- `tools/local-ci-gate/bin/hldpro-local-ci --profile hldpro-governance --report-dir cache/local-ci-gate/reports --json`
- `git diff --check`

Closes #510.
Part of #507.