### PR TITLE
[codex] Add runbook secret scrub scope

### DIFF
--- a/docs/plans/issue-512-runbook-secret-scrub-structured-agent-cycle-plan.json
+++ b/docs/plans/issue-512-runbook-secret-scrub-structured-agent-cycle-plan.json
@@ -1,0 +1,113 @@
+{
+  "session_id": "session-20260421-issue-512-runbook-secret-scrub",
+  "issue_number": 512,
+  "objective": "Scrub governance runbooks that normalize inline secret exports, direct .env.shared shell sourcing, value-bearing examples, or unsafe GitHub secret examples.",
+  "tier": 2,
+  "scope_boundary": [
+    "Issue #512 owns governance runbook/documentation remediation only.",
+    "Extend existing docs and FAIL_FAST guidance; do not create a new validator or runner.",
+    "Use scripts/overlord/validate_provisioning_evidence.py from issue #510 as the verification surface."
+  ],
+  "out_of_scope": [
+    "Secret rotation unless a real leak is confirmed and separately approved.",
+    "Downstream product repo edits.",
+    "Pages deploy gate code changes; issue #511 owns that and is closed.",
+    "No-secret evidence validator changes; issue #510 owns that and is closed.",
+    "Committing .env.shared, generated .env files, provider tokens, raw phone numbers, signed URLs, Authorization headers, JWTs, or credential screenshots."
+  ],
+  "research_summary": "The runbook scrub should update docs/EXTERNAL_SERVICES_RUNBOOK.md, docs/runbooks/remote-mcp-bridge.md, and docs/FAIL_FAST_LOG.md using the canonical Secret Provisioning UX language from STANDARDS.md and docs/ENV_REGISTRY.md. Existing #510 validation should verify the remediated docs.",
+  "research_artifacts": [
+    "https://github.com/NIBARGERB-HLDPRO/hldpro-governance/issues/512",
+    "STANDARDS.md",
+    "docs/ENV_REGISTRY.md",
+    "docs/EXTERNAL_SERVICES_RUNBOOK.md",
+    "docs/runbooks/remote-mcp-bridge.md",
+    "scripts/overlord/validate_provisioning_evidence.py"
+  ],
+  "sprints": [
+    {
+      "name": "Sprint 4 - Governance runbook scrub",
+      "goal": "Remove unsafe inline secret provisioning guidance from governance runbooks.",
+      "tasks": [
+        "Replace inline export and launchctl secret examples with name-only approved provisioning guidance.",
+        "Replace any gh secret set examples that include literal values with variable-name-only/file/stdin-safe wording.",
+        "Remove token-like prefixes and value-bearing examples from docs/EXTERNAL_SERVICES_RUNBOOK.md.",
+        "Add a FAIL_FAST_LOG entry for the bad pattern and remediation.",
+        "Run the no-secret provisioning evidence validator on the remediated docs."
+      ],
+      "acceptance_criteria": [
+        "docs/EXTERNAL_SERVICES_RUNBOOK.md contains no token-like prefixes or value-bearing secret examples.",
+        "docs/runbooks/remote-mcp-bridge.md uses .env.shared/bootstrap/provider-vault/GitHub Actions secret guidance instead of inline secret export examples.",
+        "Any gh secret set wording is name-only and never includes literal values.",
+        "docs/FAIL_FAST_LOG.md records the pattern and remediation.",
+        "Local CI Gate passes, including provisioning-evidence-safety."
+      ],
+      "file_paths": [
+        "docs/EXTERNAL_SERVICES_RUNBOOK.md",
+        "docs/runbooks/remote-mcp-bridge.md",
+        "docs/FAIL_FAST_LOG.md",
+        "docs/PROGRESS.md",
+        "docs/plans/issue-512-runbook-secret-scrub-structured-agent-cycle-plan.json",
+        "raw/execution-scopes/2026-04-21-issue-512-runbook-secret-scrub-implementation.json",
+        "raw/validation/2026-04-21-issue-512-runbook-secret-scrub.md"
+      ]
+    }
+  ],
+  "specialist_reviews": [
+    {
+      "reviewer": "Franklin",
+      "role": "Runbook scrub explorer",
+      "focus": "Find existing runbook locations that normalize inline secret provisioning guidance.",
+      "status": "accepted",
+      "summary": "Recommended scrubbing docs/EXTERNAL_SERVICES_RUNBOOK.md and docs/runbooks/remote-mcp-bridge.md, then verifying with the #510 validator.",
+      "evidence": [
+        "docs/EXTERNAL_SERVICES_RUNBOOK.md",
+        "docs/runbooks/remote-mcp-bridge.md"
+      ]
+    }
+  ],
+  "alternate_model_review": {
+    "required": false,
+    "reviewer": "not requested for docs-only runbook remediation",
+    "model_family": "n/a",
+    "status": "not_requested",
+    "summary": "This lane is a bounded docs scrub under the approved Secret Provisioning UX epic and uses the existing validator.",
+    "evidence": [
+      "docs/plans/issue-507-secret-provisioning-ux-structured-agent-cycle-plan.json"
+    ]
+  },
+  "execution_handoff": {
+    "session_agent": "codex-gpt-5",
+    "execution_mode": "implementation_ready",
+    "approved_scope_summary": "Issue #512 may update the targeted governance runbooks, FAIL_FAST_LOG, progress, and validation artifacts.",
+    "next_execution_step": "Merge this implementation scope as a planning-only PR, then implement the runbook scrub on the same issue branch name.",
+    "blocked_on": [],
+    "handoff_package_ref": null,
+    "execution_scope_ref": "raw/execution-scopes/2026-04-21-issue-512-runbook-secret-scrub-implementation.json",
+    "packet_ref": null,
+    "package_manifest_ref": null,
+    "validation_artifact_refs": [
+      "raw/validation/2026-04-21-issue-512-runbook-secret-scrub.md"
+    ],
+    "review_artifact_refs": [],
+    "gate_artifact_refs": [],
+    "closeout_ref": null,
+    "next_role": "codex-orchestrator",
+    "qa_gate_required": true,
+    "handoff_acceptance_criteria": [
+      "Structured plan validates.",
+      "Execution scope validates with lane claim.",
+      "Local CI gate passes before merge."
+    ]
+  },
+  "material_deviation_rules": [
+    "If a real committed secret is found, stop and create a separate incident/rotation issue without quoting the value.",
+    "If downstream repo docs need edits, route to #513 and owning repo issues instead of mutating them here.",
+    "If validator semantics need changes, open a follow-up issue rather than expanding this docs-only lane."
+  ],
+  "approved": true,
+  "approved_by": [
+    "codex-gpt-5"
+  ],
+  "approved_at": "2026-04-21T00:00:00Z"
+}

--- a/raw/execution-scopes/2026-04-21-issue-512-runbook-secret-scrub-implementation.json
+++ b/raw/execution-scopes/2026-04-21-issue-512-runbook-secret-scrub-implementation.json
@@ -1,0 +1,64 @@
+{
+  "$schema": "../../docs/schemas/execution-scope.schema.json",
+  "expected_execution_root": ".",
+  "expected_branch": "issue-512-runbook-secret-scrub-20260421",
+  "execution_mode": "implementation_ready",
+  "allowed_write_paths": [
+    "docs/EXTERNAL_SERVICES_RUNBOOK.md",
+    "docs/runbooks/remote-mcp-bridge.md",
+    "docs/FAIL_FAST_LOG.md",
+    "docs/PROGRESS.md",
+    "docs/plans/issue-512-runbook-secret-scrub-structured-agent-cycle-plan.json",
+    "raw/execution-scopes/2026-04-21-issue-512-runbook-secret-scrub-implementation.json",
+    "raw/validation/2026-04-21-issue-512-runbook-secret-scrub.md"
+  ],
+  "forbidden_roots": [
+    "/Users/bennibarger/Developer/HLDPRO/HealthcarePlatform",
+    "/Users/bennibarger/Developer/HLDPRO/ai-integration-services",
+    "/Users/bennibarger/Developer/HLDPRO/local-ai-machine",
+    "/Users/bennibarger/Developer/HLDPRO/knocktracker",
+    "/Users/bennibarger/Developer/HLDPRO/ASC-Evaluator",
+    "/Users/bennibarger/Developer/HLDPRO/seek-and-ponder",
+    "/Users/bennibarger/Developer/HLDPRO/Stampede"
+  ],
+  "active_parallel_roots": [
+    {
+      "path": "/Users/bennibarger/Developer/HLDPRO/HealthcarePlatform",
+      "reason": "Pre-existing dirty sibling checkout; not part of issue #512."
+    },
+    {
+      "path": "/Users/bennibarger/Developer/HLDPRO/ai-integration-services",
+      "reason": "Pre-existing dirty sibling checkout; not part of issue #512."
+    },
+    {
+      "path": "/Users/bennibarger/Developer/HLDPRO/knocktracker",
+      "reason": "Pre-existing dirty sibling checkout; not part of issue #512."
+    },
+    {
+      "path": "/Users/bennibarger/Developer/HLDPRO/seek-and-ponder",
+      "reason": "Pre-existing dirty sibling checkout; not part of issue #512."
+    },
+    {
+      "path": "/Users/bennibarger/Developer/HLDPRO/Stampede",
+      "reason": "Pre-existing dirty sibling checkout; not part of issue #512."
+    }
+  ],
+  "lane_claim": {
+    "issue_number": 512,
+    "claim_ref": "https://github.com/NIBARGERB-HLDPRO/hldpro-governance/issues/512",
+    "claimed_by": "codex-gpt-5",
+    "claimed_at": "2026-04-21T00:00:00Z"
+  },
+  "handoff_evidence": {
+    "status": "accepted",
+    "planner_model": "operator-brief",
+    "implementer_model": "codex-gpt-5",
+    "accepted_at": "2026-04-21T00:00:00Z",
+    "evidence_paths": [
+      "docs/plans/issue-507-secret-provisioning-ux-structured-agent-cycle-plan.json",
+      "https://github.com/NIBARGERB-HLDPRO/hldpro-governance/issues/512"
+    ],
+    "active_exception_ref": null,
+    "active_exception_expires_at": null
+  }
+}

--- a/raw/validation/2026-04-21-issue-512-runbook-secret-scrub.md
+++ b/raw/validation/2026-04-21-issue-512-runbook-secret-scrub.md
@@ -1,0 +1,39 @@
+# Validation: Issue #512 Runbook Secret Scrub
+
+Date: 2026-04-21
+Repo: `hldpro-governance`
+Branch: `issue-512-runbook-secret-scrub-20260421`
+Issue: #512
+Epic: #507
+
+## Scope
+
+This lane extends existing governance documentation only:
+
+- `docs/EXTERNAL_SERVICES_RUNBOOK.md`
+- `docs/runbooks/remote-mcp-bridge.md`
+- `docs/FAIL_FAST_LOG.md`
+- Supporting GOV progress, execution-scope, plan, and validation artifacts
+
+No new validator, deploy gate, secret rotation, downstream repo mutation, or credential value handling is authorized.
+
+## Scope-Only Validation
+
+Run before merging the preparatory scope-only PR:
+
+```bash
+python3 -m json.tool docs/plans/issue-512-runbook-secret-scrub-structured-agent-cycle-plan.json >/dev/null
+python3 -m json.tool raw/execution-scopes/2026-04-21-issue-512-runbook-secret-scrub-implementation.json >/dev/null
+python3 scripts/overlord/validate_structured_agent_cycle_plan.py --root .
+python3 scripts/overlord/assert_execution_scope.py --scope raw/execution-scopes/2026-04-21-issue-512-runbook-secret-scrub-implementation.json --require-lane-claim
+tools/local-ci-gate/bin/hldpro-local-ci --profile hldpro-governance --report-dir cache/local-ci-gate/reports --json
+git diff --check
+```
+
+Observed results:
+
+- JSON syntax validation passed for the structured plan and execution scope.
+- `scripts/overlord/validate_structured_agent_cycle_plan.py --root .` passed.
+- `assert_execution_scope.py` passed with declared active-parallel-root warnings only.
+- Local CI Gate passed with verdict `pass`; blocker `provisioning-evidence-safety` ran and passed.
+- `git diff --check` passed.


### PR DESCRIPTION
## Summary
- Adds the issue #512 structured plan, execution scope, and validation artifact.
- Constrains implementation to existing governance runbooks, FAIL_FAST_LOG, progress, and validation artifacts.
- Uses the existing #510 provisioning evidence validator; no new tool or downstream repo mutation.

## Validation
- `python3 -m json.tool docs/plans/issue-512-runbook-secret-scrub-structured-agent-cycle-plan.json >/dev/null`
- `python3 -m json.tool raw/execution-scopes/2026-04-21-issue-512-runbook-secret-scrub-implementation.json >/dev/null`
- `python3 scripts/overlord/validate_structured_agent_cycle_plan.py --root .`
- `python3 scripts/overlord/assert_execution_scope.py --scope raw/execution-scopes/2026-04-21-issue-512-runbook-secret-scrub-implementation.json --require-lane-claim`
- `tools/local-ci-gate/bin/hldpro-local-ci --profile hldpro-governance --report-dir cache/local-ci-gate/reports --json`
- `git diff --check`

Part of #512.
Part of #507.