### PR TITLE
[Issue #583] Hard-gate SoM packet and consumer wiring

### DIFF
--- a/.github/workflows/governance-check.yml
+++ b/.github/workflows/governance-check.yml
@@ -135,6 +135,13 @@ jobs:
             --repo "${GITHUB_REPOSITORY}" \
             --progress-path docs/PROGRESS.md
 
+      - name: Verify governed consumer contract
+        if: github.repository != 'NIBARGERB-HLDPRO/hldpro-governance' && hashFiles('.hldpro/governance-tooling.json') != ''
+        run: |
+          python3 .governance/scripts/overlord/verify_governance_consumer.py \
+            --governance-root .governance \
+            --target-repo .
+
       - name: Validate structured agent cycle plans
         run: |
           set -euo pipefail
@@ -264,6 +271,7 @@ jobs:
           set -euo pipefail
 
           REPO_NAME="${GITHUB_REPOSITORY##*/}"
+          BRANCH_NAME="${GITHUB_HEAD_REF:-${GITHUB_REF_NAME}}"
 
           if [ "$REPO_NAME" = "hldpro-governance" ]; then
             HANDOFF_VALIDATOR="scripts/overlord/validate_handoff_package.py"
@@ -279,13 +287,17 @@ jobs:
           # Any plan update can change handoff refs or ACs, so docs/plans/ intentionally triggers this cheap validator.
           HANDOFF_REGEX='^(docs/plans/|docs/schemas/(package-handoff\.schema\.json|examples/package-handoff/)|raw/(closeouts|cross-review|execution-scopes|handoffs|packets|validation)/|scripts/overlord/(validate_handoff_package|test_validate_handoff_package)\.py$)'
           HANDOFF_CHANGES="$(grep -E "$HANDOFF_REGEX" /tmp/governance-changed-files.txt || true)"
-          if [ -z "$HANDOFF_CHANGES" ]; then
+          if [ -z "$HANDOFF_CHANGES" ] && ! echo "$BRANCH_NAME" | grep -Eq '(^|/)issue-[0-9]+'; then
             echo "✓ No handoff package paths changed; handoff integrity validation skipped"
             exit 0
           fi
 
-          echo "Handoff-relevant changes:"
-          echo "$HANDOFF_CHANGES"
+          if [ -n "$HANDOFF_CHANGES" ]; then
+            echo "Handoff-relevant changes:"
+            echo "$HANDOFF_CHANGES"
+          else
+            echo "Issue branch detected; running handoff validation even without direct handoff-path changes"
+          fi
           python3 "$HANDOFF_VALIDATOR" --root .
 
       - name: Enforce Stage 6 closeout evidence

--- a/STANDARDS.md
+++ b/STANDARDS.md
@@ -43,9 +43,12 @@
   - `alternate_model_review`
   - `execution_handoff`
   - `material_deviation_rules`
+- Active issue-lane plans must also capture machine-checkable reviewer identity and handoff/review evidence fields sufficient for validators to reject self-review and evidence-free promotion.
 - Issue-driven execution branches (`issue-*`) and risk-fix branches (`riskfix/*`) must have at least one valid `*structured-agent-cycle-plan.json` file before execution is governance-ready. Note: `riskfix/<slug>-YYYYMMDD` (with date suffix) is the **required** implementation branch pattern for `local-ai-machine`, enforced by `edge_breaker_mcp_contract.yml`. Other repos accept `riskfix/*` as an optional prefix alongside standard `feat/fix/chore/docs` conventions but do not require it.
 - Reusable governance CI validates structured plans through `scripts/overlord/validate_structured_agent_cycle_plan.py`.
 - Cross-model review results from `scripts/codex-review.sh claude` belong in `alternate_model_review`.
+- `alternate_model_review.required=false` is not a free-text bypass. New active issue-lane plans may omit alternate-family review only with a validator-legal bounded exemption.
+- Once a plan records accepted specialist or alternate-family review, `execution_handoff.review_artifact_refs` must be populated with `raw/cross-review/...` evidence before promotion continues.
 
 ### Planner Write-Boundary (Tier 1)
 - Tier 1 planner sessions may create planning, review, and handoff artifacts only.
@@ -528,6 +531,13 @@ Required lifecycle links:
 - GitHub issue number and optional parent epic number.
 - Source role and destination role.
 - Structured plan reference.
+- Lifecycle-state transitions are hard-gated:
+  - `planned` / `planning_only` may defer populated review refs only until the
+    required review actually happens.
+  - Promotion to `implementation_ready` requires accepted review evidence and
+    populated review refs.
+  - Continuing handoffs from `implementation_ready` onward require populated
+    handoff and gate evidence where the lifecycle validator expects it.
 - Execution-scope reference for implementation-ready or later states.
 - Packet reference for dispatch/validation-ready or later states.
 - Acceptance criteria with verification references.

--- a/docs/EXTERNAL_SERVICES_RUNBOOK.md
+++ b/docs/EXTERNAL_SERVICES_RUNBOOK.md
@@ -110,6 +110,11 @@ bash scripts/model-fallback-log.sh \
 
 **Purpose:** Planner (`claude-opus-4-6`), planning fallback and primary Worker (`claude-sonnet-4-6`), and completion/gate verifier (`claude-haiku-4-5-20251001` where allowed). Also serves as cross-model reviewer invoked FROM codex via the operator-facing wrapper `scripts/codex-review.sh claude`.
 
+Cross-model review artifacts returned through `scripts/codex-review.sh claude`
+are not optional narrative notes. On active governed issue lanes they are the
+machine-checkable `raw/cross-review/...` evidence that must populate plan and
+handoff review refs before promotion from planning to implementation.
+
 ### Auth
 - `CLAUDE_CODE_OAUTH_TOKEN` in the repo's bootstrap-generated env surface (governance: `.env.local`)
 - Issued via `claude setup-token` (operator Max subscription)

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -10,6 +10,7 @@
 
 | Plan | Issue | Status | Priority | Est. Hours | Deliverables | Notes |
 |------|-------|--------|----------|------------|--------------|-------|
+| Hard-gate issue-level SoM enforcement against self-review and missing handoff evidence | #583 | IN PROGRESS | HIGH | 4-6 | Schema/validator/CI hard gates, replay proof against Stampede #184, alternate-family review evidence | Source-governance fix after third revisit of false-complete session-wiring claims; downstream Stampede repair is separate issue #197 |
 | Downstream thin session-contract adapter rollout epic | #579 | IN PROGRESS | HIGH | 6-10 | Governance epic, downstream child issue map, thin-adapter rollout across LAM/AIS/Seek/KT/Stampede/HP/ASC | Opened from approved plan #575 after governance-source SSOT reconciliation #576 merged |
 | Session waterfall runbook enforcement at session start | #573 | IN PROGRESS | HIGH | 4-6 | CODEX session contract, bootstrap sentinel, validator/package/CI enforcement, issue evidence | Governance-first slice only; downstream repo adoption remains follow-up work |
 | Consumer-pulled governance adoption rollout | #403 | DONE | MEDIUM | 4-6 | Knocktracker pilot merged through downstream PRs #178 and #179; governance PR #406 records evidence | Uses knocktracker #177 as the first repo-side consumer-pull pilot |

--- a/docs/codex-reviews/2026-04-29-claude.md
+++ b/docs/codex-reviews/2026-04-29-claude.md
@@ -1,25 +1,95 @@
-**Findings**
+All five artifacts read. Conducting the alternate-family review now.
 
-No blocking issues identified in the proposed change summary.
+---
 
-1. **Low — `bypassPermissions` default mode**: Acceptable for a governed review-path agent that operates under dispatcher supervision, but the STANDARDS.md update should document the rationale (review agents read-only by default, no destructive tool access) so future auditors don't flag it as a security gap.
+# Alternate-Family Review — Issue #583 Planning Packet
 
-2. **Low — `max-turns 8` default**: Reasonable for a bounded packet review. Confirm this ceiling is sufficient for larger review packets (e.g., multi-file diffs with 10+ files). If not, the contract should specify how the caller requests a higher ceiling.
+**Reviewer:** Claude (Anthropic family, alternate to GPT-5.4 planner)
+**Date:** 2026-04-29
+**Scope:** Planning packet acceptance-criteria hardness and loophole analysis
+**Verdict:** Conditional accept — two blocking findings, four non-blocking gaps
 
-3. **Info — `silence-timeout 300`**: 5 minutes is generous for a no-tools review. Unlikely to be hit in practice, but confirms the contract won't prematurely kill a slow model response.
+---
 
-4. **Info — dry-run reporting**: Good governance hygiene. Ensure the dry-run output format is specified in the contract (e.g., JSON vs. markdown), so downstream consumers (closeout hooks, backlog-promoter) can parse it deterministically.
+## Findings
 
-**Open Questions**
+### BLOCKING
 
-- Does the contract specify what happens when the reviewer *needs* tool access (e.g., to verify a file exists)? The "unless explicitly enabled" clause should define the opt-in mechanism.
-- Is `claude-opus-4-6` the correct pin for the *reviewer* role? STANDARDS.md §Society of Minds routes long-form PRs to `gpt-5.4 @ medium` and code PRs to `Sonnet-4-6`. Clarify whether this contract is for the Claude-family alternate reviewer or whether it supersedes the SoM routing table.
+**B1. The handoff itself exhibits the failure mode it aims to prevent.**
 
-**Validation Gaps**
+`raw/handoffs/2026-04-29-issue-583-hard-gated-som-enforcement.json` carries:
+- `review_artifact_refs: []`
+- `gate_artifact_refs: []`
+- `packet_ref: null`
+- `package_manifest_ref: null`
 
-- No actual diff or file content was included in the packet — this review validates the *design intent* only, not the implementation.
-- STANDARDS.md and EXTERNAL_SERVICES_RUNBOOK.md update content not provided for cross-check.
+The `lifecycle_state` is `planned` and `execution_mode` is `planning_only`, so empty refs are arguably correct *at this stage*. But the packet does not define the **lifecycle-gated rule** that makes this legal now and illegal later. Without that rule, the validator has no basis to distinguish "legitimately empty because planning" from "empty because someone skipped the review" — which is exactly the issue-184 shape. The implementation sprint must specify which `lifecycle_state` transitions require non-empty refs, and the validator must enforce that transition rule, not just a static check.
 
-**Summary**
+**Resolution required:** Add an explicit lifecycle-state transition matrix to AC3 (or a new AC) defining which ref fields must be populated at each state boundary (`planned` → `implementation_ready` → `in_progress` → `complete`). The structured-plan validator and handoff validator must both enforce these transition gates.
 
-The proposed review-path contract is sound. No blocking defects. The no-tools packet-review path successfully returns a concise markdown result with Findings and Summary, validating the contract's feasibility. Residual risk is limited to the model-pin ambiguity (Finding #2 in Open Questions) and the absence of actual implementation artifacts to verify against.
+---
+
+**B2. Cross-review artifact path is not writable in the current execution scope.**
+
+The handoff's `blocked_on` correctly lists:
+```
+raw/cross-review/2026-04-29-issue-583-hard-gated-som-enforcement.md
+```
+
+But the execution scope at `raw/execution-scopes/...planning.json` does not include this path in `allowed_write_paths`. The planning sprint cannot complete its own gate — the cross-review artifact that unblocks implementation cannot be written without a scope violation or a scope amendment.
+
+**Resolution required:** Either add the cross-review path to `allowed_write_paths` in the planning execution scope, or define a scope-promotion step that adds it before the review is captured.
+
+---
+
+### NON-BLOCKING (must be addressed before implementation-ready promotion)
+
+**N1. "Bounded legal exemption" for AC2 is undefined.**
+
+AC2 states alternate_model_review may be bypassed "only with a bounded legal exemption that the validator recognizes." Neither the PDCAR nor the structured plan specifies what constitutes a legal exemption — no field name, no schema shape, no expiry mechanism. If the implementation introduces a permissive exemption field (e.g., `exemption_reason: "not needed"`), the gate is worthless.
+
+**Recommendation:** Before implementation, define the minimum exemption schema: at least an `exemption_type` enum, `granted_by` identity, `expires_at` timestamp, and the validator must reject expired or unknown exemption types.
+
+**N2. Reviewer identity metadata is not machine-verifiable in the current packet.**
+
+`specialist_reviews[0].reviewer` = `"Repository-state audit synthesis"` is a description, not a checkable identity. The ACs demand "enough identity metadata to prove reviewer independence," but the packet itself doesn't demonstrate what that metadata looks like. The validator cannot enforce independence if the identity field is free-text.
+
+**Recommendation:** The implementation must add structured `reviewer_model_family` and `reviewer_model_id` fields (or equivalent) so the validator can mechanically compare reviewer identity against author/orchestrator identity.
+
+**N3. AC4 consumer CI scope is ambiguous.**
+
+AC4 claims "Consumer governance CI runs the structured-plan and handoff validators as blocking checks." The PDCAR scope says "keep downstream product-repo repair out of this source-fix lane." These conflict: either this lane wires the validators into consumer CI (which means touching downstream repos), or it only proves the validators *would* block the old shape (replay proof). The implementation team will interpret whichever is more convenient.
+
+**Recommendation:** Rewrite AC4 to distinguish: (a) the source validators are blocking in hldpro-governance CI, and (b) a downstream replay using the Stampede issue-184 shape proves the validators reject it. Defer actual consumer-repo CI wiring to the thin-adapter rollout epic (issue #579) or a new issue, and note that explicitly.
+
+**N4. Same-model self-handoff is not addressed.**
+
+The execution scope records `planner_model: "gpt-5.4"` and `implementer_model: "gpt-5.4"`. The handoff is `from_role: "codex-orchestrator"` to `to_role: "codex-orchestrator"`. The ACs address reviewer independence but not handoff-role independence. If the same model in the same role can plan, implement, and accept its own handoff, the separation-of-concerns principle erodes.
+
+**Recommendation:** Either document why same-model-same-role handoff is acceptable at the planning stage (and add a validator rule for later stages), or require that implementation handoffs involve a different role.
+
+---
+
+## Open Questions
+
+1. Does the validator today distinguish `lifecycle_state` at all, or does it treat every handoff as a flat object? If the latter, implementing B1 requires new validator architecture, not just new rules.
+2. Is there a registry of valid `exemption_type` values planned, or will this be an open enum that any orchestrator can extend?
+
+## Validation Gaps
+
+- No regression test shape is defined yet for the lifecycle-transition gate (B1). The implementation sprint lists "regression tests that reproduce the bad Stampede issue #184 shape" but doesn't mention a test for a packet that is valid at `planned` but invalid when promoted without populating refs.
+- The cross-review artifact that proves this alternate-family review happened has no writable path (B2), so the review evidence *for this packet* cannot be recorded without a scope fix.
+
+## Summary
+
+The packet correctly identifies the issue-184 failure class and proposes the right enforcement surfaces. The acceptance criteria are phrased as hard gates rather than advisory language — that's a real improvement over prior governance packets. However, two blocking gaps remain:
+
+1. **The validator cannot distinguish "legitimately empty during planning" from "bypassed"** without a lifecycle-transition rule — the same ambiguity that let issue-184 through.
+2. **The execution scope cannot write its own unblocking cross-review artifact**, creating a procedural deadlock.
+
+**Before implementation may proceed**, these conditions must be true:
+
+- B1 and B2 are resolved in the planning artifacts (amended handoff, execution scope, and/or new AC)
+- N1 through N4 are acknowledged with either amendments or explicit deferral rationale recorded in the PDCAR Adjust section
+- This review is captured as a cross-review artifact at `raw/cross-review/2026-04-29-issue-583-hard-gated-som-enforcement.md` (after B2 is resolved)
+- The structured plan's `alternate_model_review.status` is updated from `pending` to `accepted_with_conditions` and references this review

--- a/docs/governance-consumer-pull-state.json
+++ b/docs/governance-consumer-pull-state.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "owner_repo": "NIBARGERB-HLDPRO/hldpro-governance",
-  "updated_at": "2026-04-21",
+  "updated_at": "2026-04-29",
   "consumer_record_path": ".hldpro/governance-tooling.json",
   "pinning": {
     "governance_ref": "required_exact_git_sha",
@@ -59,24 +59,135 @@
       }
     },
     "ai-integration-services": {
-      "package_version": "0.2.0-ssot-bootstrap",
+      "package_version": "0.3.0-hard-gated-som",
       "managed_files": [
-        ".hldpro/local-ci.sh",
-        ".hldpro/governance-tooling.json"
+        {
+          "path": ".hldpro/local-ci.sh",
+          "type": "local_ci_shim"
+        },
+        {
+          "path": ".hldpro/governance-tooling.json",
+          "type": "consumer_record"
+        },
+        {
+          "path": "CLAUDE.md",
+          "type": "tracked_session_contract",
+          "required_strings": [
+            "hldpro-governance",
+            "STANDARDS.md"
+          ]
+        },
+        {
+          "path": "CODEX.md",
+          "type": "tracked_session_contract",
+          "required_strings": [
+            "hldpro-governance",
+            "supervisor/orchestrator"
+          ]
+        },
+        {
+          "path": "docs/EXTERNAL_SERVICES_RUNBOOK.md",
+          "type": "tracked_session_contract",
+          "required_strings": [
+            "hldpro-governance",
+            "EXTERNAL_SERVICES_RUNBOOK.md"
+          ]
+        },
+        {
+          "path": "scripts/codex-review.sh",
+          "type": "tracked_session_contract",
+          "required_strings": [
+            "claude"
+          ]
+        }
       ]
     },
     "knocktracker": {
-      "package_version": "0.2.0-ssot-bootstrap",
+      "package_version": "0.3.0-hard-gated-som",
       "managed_files": [
-        ".hldpro/local-ci.sh",
-        ".hldpro/governance-tooling.json"
+        {
+          "path": ".hldpro/local-ci.sh",
+          "type": "local_ci_shim"
+        },
+        {
+          "path": ".hldpro/governance-tooling.json",
+          "type": "consumer_record"
+        },
+        {
+          "path": "CLAUDE.md",
+          "type": "tracked_session_contract",
+          "required_strings": [
+            "hldpro-governance",
+            "STANDARDS.md"
+          ]
+        },
+        {
+          "path": "CODEX.md",
+          "type": "tracked_session_contract",
+          "required_strings": [
+            "hldpro-governance",
+            "supervisor/orchestrator"
+          ]
+        },
+        {
+          "path": "docs/EXTERNAL_SERVICES_RUNBOOK.md",
+          "type": "tracked_session_contract",
+          "required_strings": [
+            "hldpro-governance",
+            "EXTERNAL_SERVICES_RUNBOOK.md"
+          ]
+        },
+        {
+          "path": "scripts/codex-review.sh",
+          "type": "tracked_session_contract",
+          "required_strings": [
+            "claude"
+          ]
+        }
       ]
     },
     "local-ai-machine": {
-      "package_version": "0.2.0-ssot-bootstrap",
+      "package_version": "0.3.0-hard-gated-som",
       "managed_files": [
-        ".hldpro/local-ci.sh",
-        ".hldpro/governance-tooling.json"
+        {
+          "path": ".hldpro/local-ci.sh",
+          "type": "local_ci_shim"
+        },
+        {
+          "path": ".hldpro/governance-tooling.json",
+          "type": "consumer_record"
+        },
+        {
+          "path": "CLAUDE.md",
+          "type": "tracked_session_contract",
+          "required_strings": [
+            "hldpro-governance",
+            "STANDARDS.md"
+          ]
+        },
+        {
+          "path": "CODEX.md",
+          "type": "tracked_session_contract",
+          "required_strings": [
+            "hldpro-governance",
+            "supervisor/orchestrator"
+          ]
+        },
+        {
+          "path": "docs/EXTERNAL_SERVICES_RUNBOOK.md",
+          "type": "tracked_session_contract",
+          "required_strings": [
+            "hldpro-governance",
+            "EXTERNAL_SERVICES_RUNBOOK.md"
+          ]
+        },
+        {
+          "path": "scripts/codex-review.sh",
+          "type": "tracked_session_contract",
+          "required_strings": [
+            "claude"
+          ]
+        }
       ],
       "profile_constraints": [
         "local model runtime routing",
@@ -86,10 +197,47 @@
       ]
     },
     "healthcareplatform": {
-      "package_version": "0.2.0-ssot-bootstrap",
+      "package_version": "0.3.0-hard-gated-som",
       "managed_files": [
-        ".hldpro/local-ci.sh",
-        ".hldpro/governance-tooling.json"
+        {
+          "path": ".hldpro/local-ci.sh",
+          "type": "local_ci_shim"
+        },
+        {
+          "path": ".hldpro/governance-tooling.json",
+          "type": "consumer_record"
+        },
+        {
+          "path": "CLAUDE.md",
+          "type": "tracked_session_contract",
+          "required_strings": [
+            "hldpro-governance",
+            "STANDARDS.md"
+          ]
+        },
+        {
+          "path": "CODEX.md",
+          "type": "tracked_session_contract",
+          "required_strings": [
+            "hldpro-governance",
+            "supervisor/orchestrator"
+          ]
+        },
+        {
+          "path": "docs/EXTERNAL_SERVICES_RUNBOOK.md",
+          "type": "tracked_session_contract",
+          "required_strings": [
+            "hldpro-governance",
+            "EXTERNAL_SERVICES_RUNBOOK.md"
+          ]
+        },
+        {
+          "path": "scripts/codex-review.sh",
+          "type": "tracked_session_contract",
+          "required_strings": [
+            "claude"
+          ]
+        }
       ],
       "profile_constraints": [
         "HIPAA and PHI controls must not be weakened",
@@ -99,10 +247,47 @@
       ]
     },
     "seek-and-ponder": {
-      "package_version": "0.2.0-ssot-bootstrap",
+      "package_version": "0.3.0-hard-gated-som",
       "managed_files": [
-        ".hldpro/local-ci.sh",
-        ".hldpro/governance-tooling.json"
+        {
+          "path": ".hldpro/local-ci.sh",
+          "type": "local_ci_shim"
+        },
+        {
+          "path": ".hldpro/governance-tooling.json",
+          "type": "consumer_record"
+        },
+        {
+          "path": "CLAUDE.md",
+          "type": "tracked_session_contract",
+          "required_strings": [
+            "hldpro-governance",
+            "STANDARDS.md"
+          ]
+        },
+        {
+          "path": "CODEX.md",
+          "type": "tracked_session_contract",
+          "required_strings": [
+            "hldpro-governance",
+            "supervisor/orchestrator"
+          ]
+        },
+        {
+          "path": "docs/EXTERNAL_SERVICES_RUNBOOK.md",
+          "type": "tracked_session_contract",
+          "required_strings": [
+            "hldpro-governance",
+            "EXTERNAL_SERVICES_RUNBOOK.md"
+          ]
+        },
+        {
+          "path": "scripts/codex-review.sh",
+          "type": "tracked_session_contract",
+          "required_strings": [
+            "claude"
+          ]
+        }
       ],
       "profile_constraints": [
         "plan-mode gate before code writes",
@@ -111,10 +296,47 @@
       ]
     },
     "stampede": {
-      "package_version": "0.2.0-ssot-bootstrap",
+      "package_version": "0.3.0-hard-gated-som",
       "managed_files": [
-        ".hldpro/local-ci.sh",
-        ".hldpro/governance-tooling.json"
+        {
+          "path": ".hldpro/local-ci.sh",
+          "type": "local_ci_shim"
+        },
+        {
+          "path": ".hldpro/governance-tooling.json",
+          "type": "consumer_record"
+        },
+        {
+          "path": "CLAUDE.md",
+          "type": "tracked_session_contract",
+          "required_strings": [
+            "hldpro-governance",
+            "STANDARDS.md"
+          ]
+        },
+        {
+          "path": "CODEX.md",
+          "type": "tracked_session_contract",
+          "required_strings": [
+            "hldpro-governance",
+            "supervisor/orchestrator"
+          ]
+        },
+        {
+          "path": "docs/EXTERNAL_SERVICES_RUNBOOK.md",
+          "type": "tracked_session_contract",
+          "required_strings": [
+            "hldpro-governance",
+            "EXTERNAL_SERVICES_RUNBOOK.md"
+          ]
+        },
+        {
+          "path": "scripts/codex-review.sh",
+          "type": "tracked_session_contract",
+          "required_strings": [
+            "claude"
+          ]
+        }
       ],
       "profile_constraints": [
         "trading/product runtime safety",
@@ -122,10 +344,47 @@
       ]
     },
     "asc-evaluator": {
-      "package_version": "0.2.0-ssot-bootstrap",
+      "package_version": "0.3.0-hard-gated-som",
       "managed_files": [
-        ".hldpro/local-ci.sh",
-        ".hldpro/governance-tooling.json"
+        {
+          "path": ".hldpro/local-ci.sh",
+          "type": "local_ci_shim"
+        },
+        {
+          "path": ".hldpro/governance-tooling.json",
+          "type": "consumer_record"
+        },
+        {
+          "path": "CLAUDE.md",
+          "type": "tracked_session_contract",
+          "required_strings": [
+            "hldpro-governance",
+            "STANDARDS.md"
+          ]
+        },
+        {
+          "path": "CODEX.md",
+          "type": "tracked_session_contract",
+          "required_strings": [
+            "hldpro-governance",
+            "supervisor/orchestrator"
+          ]
+        },
+        {
+          "path": "docs/EXTERNAL_SERVICES_RUNBOOK.md",
+          "type": "tracked_session_contract",
+          "required_strings": [
+            "hldpro-governance",
+            "EXTERNAL_SERVICES_RUNBOOK.md"
+          ]
+        },
+        {
+          "path": "scripts/codex-review.sh",
+          "type": "tracked_session_contract",
+          "required_strings": [
+            "claude"
+          ]
+        }
       ],
       "profile_constraints": [
         "knowledge-repo exemption",

--- a/docs/governance-tooling-package.json
+++ b/docs/governance-tooling-package.json
@@ -4,11 +4,11 @@
   "package_owner_repo": "NIBARGERB-HLDPRO/hldpro-governance",
   "contract_issue": 290,
   "parent_epic": 288,
-  "updated_at": "2026-04-19",
+  "updated_at": "2026-04-29",
   "versioning": {
     "initial_version": "0.1.0-contract",
     "initial_release_tag": "governance-tooling-v0.1.0",
-    "next_contract_version": "0.2.0-ssot-bootstrap",
+    "next_contract_version": "0.3.0-hard-gated-som",
     "next_contract_issue": 453,
     "next_contract_parent_epic": 452,
     "release_issue": 332,
@@ -18,7 +18,7 @@
     "compatibility_policy": "A consumer repo must record the governance package git SHA it deploys. Release tags improve readability and rollback communication, but tags do not replace the SHA record."
   },
   "ssot_bootstrap_v2": {
-    "status": "contract_draft",
+    "status": "superseded_by_0_3_0_hard_gated_som",
     "issue": 453,
     "parent_epic": 452,
     "extends": "0.1.0-contract",
@@ -30,8 +30,7 @@
     ],
     "optional_consumer_surfaces": [
       ".hldpro/repo-governance-profile.json",
-      ".claude/settings.json pointer or managed shim",
-      "thin CLAUDE.md or AGENTS.md governance pointer"
+      ".claude/settings.json pointer or managed shim"
     ],
     "non_goals": [
       "Do not make downstream repos blind mirrors of hldpro-governance.",
@@ -173,7 +172,7 @@
       "verification": [
         "python3 scripts/overlord/validate_structured_agent_cycle_plan.py --root ."
       ],
-      "notes": "Governance-surface changes require issue-backed structured planning."
+      "notes": "Governance-surface changes require issue-backed structured planning. Active issue-lane validation enforces reviewer identity metadata, blocks same-model self-review, requires legal alternate-review exemptions only, and requires review refs once accepted review exists or implementation promotion begins."
     },
     {
       "id": "workflow-local-coverage",
@@ -224,7 +223,7 @@
       "verification": [
         "python3 scripts/overlord/verify_governance_consumer.py --target-repo <consumer> --profile <profile> --governance-ref <sha>"
       ],
-      "notes": "Hook behavior may be stricter in consumer repos, but stricter local behavior must be declared with owner, reason, and review cadence. Consumer records may represent managed shell hooks, tracked session-contract files such as CODEX.md, and hook-settings contracts such as `.claude/settings.json` matcher requirements."
+      "notes": "Hook behavior may be stricter in consumer repos, but stricter local behavior must be declared with owner, reason, and review cadence. Consumer records may represent managed shell hooks, tracked session-contract files such as CLAUDE.md, CODEX.md, docs/EXTERNAL_SERVICES_RUNBOOK.md, and scripts/codex-review.sh, plus hook-settings contracts such as `.claude/settings.json` matcher requirements."
     },
     {
       "id": "reusable-workflow-refs",
@@ -309,7 +308,7 @@
         "handoff package validation",
         "closeout and PR evidence gates"
       ],
-      "notes": "Package consumers should be able to point to lifecycle refs without copying lifecycle validation logic."
+      "notes": "Package consumers should be able to point to lifecycle refs without copying lifecycle validation logic. Lifecycle-state transitions are enforced: implementation-ready and later handoffs must carry the required review/gate refs for their state."
     }
   ],
   "artifact_classes": {

--- a/docs/plans/issue-583-hard-gated-som-enforcement-pdcar.md
+++ b/docs/plans/issue-583-hard-gated-som-enforcement-pdcar.md
@@ -1,0 +1,81 @@
+# Issue #583 PDCAR: Hard-Gated Issue-Level SoM Enforcement
+
+Issue: https://github.com/NIBARGERB-HLDPRO/hldpro-governance/issues/583
+Branch: `issue-583-hard-gated-som-enforcement`
+
+## Plan
+
+Hard-gate issue-level Society of Minds enforcement so governed consumer repos
+cannot merge self-reviewed planning packets or packets missing independent
+review and handoff evidence.
+
+This lane exists because the recent thin-adapter rollout improved repo
+entrypoints but did not actually bind the issue-level waterfall. The immediate
+proof is Stampede issue `#184`, where the active planning packet records
+orchestrator self-review, bypasses alternate-family review, and carries no
+governed handoff or review artifact references.
+
+## Do
+
+Implementation scope for issue `#583`:
+
+- harden the structured-plan schema and validator so governed plans record
+  enough identity metadata to prove reviewer independence
+- reject orchestrator self-review for governed plans
+- allow `alternate_model_review.required=false` only when a bounded exemption
+  is recorded and validator-legal
+- require non-empty `review_artifact_refs` for governed plans and require
+  non-null handoff refs for non-draft plans intended to continue through the
+  waterfall
+- wire the plan and handoff validators into the consumer governance CI contract
+- add regression tests that reproduce the bad Stampede issue `#184` shape and
+  prove the hardened rules reject it
+- keep downstream product-repo repair out of this source-fix lane except for
+  validation replay and proof
+
+## Check
+
+Before implementation:
+
+- the issue-backed planning packet validates locally
+- the acceptance criteria are phrased as hard gates, not advisory wording
+- alternate-family review is captured through the governed
+  `scripts/codex-review.sh claude` path before implementation-ready promotion
+
+After implementation:
+
+- a plan with self-review or missing reviewer-family metadata fails the
+  structured-plan validator
+- a plan with `alternate_model_review.required=false` and no legal exemption
+  fails the structured-plan validator
+- lifecycle gates are explicit:
+  - `planned` / `planning_only` may defer populated review and gate refs only
+    while alternate-family review is still pending
+  - promotion to `implementation_ready` requires accepted alternate-family
+    review evidence and non-empty `review_artifact_refs`
+  - continuing governed handoffs from `implementation_ready` onward require
+    non-null handoff evidence and fail closed when missing
+- the structured-plan and handoff validators enforce those lifecycle gates
+- governance CI and the managed consumer-governance contract both run the plan
+  and handoff validators as blocking steps
+- proof includes a downstream replay showing the old Stampede issue `#184`
+  packet shape would now fail under the hardened rules
+
+## Adjust
+
+If the current schema cannot encode reviewer/author independence cleanly,
+introduce the minimum new fields needed and document them in the standards and
+schema examples. Do not add a weaker warning-only path or repo-local exception
+to get the bad packet shape through CI.
+
+If managed consumer workflow rollout cannot happen inside this source-fix lane,
+the implementation must still land the blocking source contract and record a
+downstream replay proof plus a separate issue-backed consumer rollout follow-up.
+Do not blur "source contract fixed" and "all consumers upgraded" into the same
+completion claim.
+
+## Review
+
+This issue must not be called fixed until alternate-family review accepts the
+hard-gated acceptance criteria, the source validators/CI are green, and the
+downstream replay proves the old failure shape is blocked.

--- a/docs/plans/issue-583-hard-gated-som-enforcement-structured-agent-cycle-plan.json
+++ b/docs/plans/issue-583-hard-gated-som-enforcement-structured-agent-cycle-plan.json
@@ -130,7 +130,7 @@
       "raw/cross-review/2026-04-29-issue-583-hard-gated-som-enforcement.md"
     ],
     "gate_artifact_refs": [
-      "cache/local-ci-gate/reports/20260429T155625Z-hldpro-governance-git/local-ci-20260429T155632Z.json"
+      "raw/validation/2026-04-29-issue-583-hard-gated-som-enforcement.md"
     ],
     "closeout_ref": "raw/closeouts/2026-04-29-issue-583-hard-gated-som-enforcement.md",
     "next_role": "codex-orchestrator",

--- a/docs/plans/issue-583-hard-gated-som-enforcement-structured-agent-cycle-plan.json
+++ b/docs/plans/issue-583-hard-gated-som-enforcement-structured-agent-cycle-plan.json
@@ -1,0 +1,154 @@
+{
+  "session_id": "session-20260429-issue-583-hard-gated-som-enforcement",
+  "issue_number": 583,
+  "objective": "Hard-gate issue-level Society of Minds enforcement so governed repos cannot merge self-reviewed packets or packets missing review and handoff evidence.",
+  "plan_author": {
+    "role": "codex-orchestrator",
+    "model_id": "gpt-5.4",
+    "model_family": "openai"
+  },
+  "tier": 1,
+  "scope_boundary": [
+    "Issue-583 work in hldpro-governance only.",
+    "Issue-backed plan, execution scope, handoff, review, validation, and closeout evidence for source-level guardrail hardening.",
+    "Schema, validator, test, standards, runbook, and governance-CI contract updates needed to fail self-review and missing review/handoff evidence.",
+    "Downstream replay proof against Stampede issue #184 without mutating Stampede in this source-fix lane."
+  ],
+  "out_of_scope": [
+    "Direct repair of Stampede issue #184 in this branch.",
+    "Reopening thin-adapter policy decisions from issues #575 and #576.",
+    "Warning-only guardrails that still allow the known bad packet shape to merge.",
+    "Unrelated changes to graphify, Stage 6 closeout, or bootstrap flows unless they are required by the validator or CI contract."
+  ],
+  "research_summary": "A fresh audit of Stampede issue #184 proved the same class of governance drift remains live after the thin-adapter rollout. On the active branch, the issue-184 structured plan records an accepted specialist review by the Codex orchestrator itself, marks alternate-model review as not requested, leaves review_artifact_refs empty, and leaves handoff_package_ref null. After fetching current main, the repo-level thin-adapter surfaces from issue #195 are present, so branch drift explains part of the missing wrapper signal but not the deeper issue: governance validators and consumer CI do not actually enforce reviewer independence, mandatory review evidence, or mandatory handoff evidence for governed issue packets.",
+  "research_artifacts": [
+    "https://github.com/NIBARGERB-HLDPRO/hldpro-governance/issues/583",
+    "https://github.com/NIBARGERB-HLDPRO/Stampede/issues/197",
+    "https://github.com/NIBARGERB-HLDPRO/Stampede/issues/184",
+    "docs/EXTERNAL_SERVICES_RUNBOOK.md",
+    "STANDARDS.md",
+    "scripts/overlord/validate_structured_agent_cycle_plan.py",
+    "scripts/overlord/validate_handoff_package.py",
+    "Stampede docs/plans/issue-184-structured-agent-cycle-plan.json",
+    "Stampede .github/workflows/governance-check.yml"
+  ],
+  "sprints": [
+    {
+      "name": "Planning and alternate-family gate",
+      "goal": "Create the hard-gated packet and get alternate-family acceptance before implementation-ready promotion.",
+      "tasks": [
+        "Create the PDCAR, structured plan, planning execution scope, and planned handoff for issue #583.",
+        "Write hard acceptance criteria that make reviewer independence, alternate-review exemption legality, review evidence, handoff evidence, and lifecycle-gated state transitions blocking conditions.",
+        "Send the packet through the governed scripts/codex-review.sh claude path and record the review artifact."
+      ],
+      "acceptance_criteria": [
+        "The issue-583 packet validates locally and remains planning_only before alternate-family acceptance.",
+        "The acceptance criteria are phrased as blocking gates rather than advisory reminders, including explicit lifecycle-state transition rules for when empty refs are legal versus illegal.",
+        "Alternate-family review is captured through the governed wrapper path before implementation-ready promotion."
+      ],
+      "file_paths": [
+        "docs/plans/issue-583-hard-gated-som-enforcement-pdcar.md",
+        "docs/plans/issue-583-hard-gated-som-enforcement-structured-agent-cycle-plan.json",
+        "raw/execution-scopes/2026-04-29-issue-583-hard-gated-som-enforcement-planning.json",
+        "raw/handoffs/2026-04-29-issue-583-hard-gated-som-enforcement.json",
+        "raw/cross-review/2026-04-29-issue-583-hard-gated-som-enforcement.md",
+        "docs/codex-reviews/2026-04-29-claude.md",
+        "raw/validation/2026-04-29-issue-583-hard-gated-som-enforcement.md"
+      ]
+    },
+    {
+      "name": "Implementation and proof",
+      "goal": "Land the minimal governance-source changes that fail the known bad packet shape closed.",
+      "tasks": [
+        "Patch structured-plan schema/examples and validator for reviewer/author identity metadata, self-review rejection, and legal alternate-review exemptions only.",
+        "Patch handoff schema/examples and validator for lifecycle-gated required handoff/review refs on continuing governed lanes.",
+        "Wire the hardened validators into governance CI and the managed consumer-governance contract surfaces.",
+        "Add regression tests and downstream replay proof using the old Stampede issue-184 shape."
+      ],
+      "acceptance_criteria": [
+        "Self-reviewed governed plans fail deterministically.",
+        "Illegal alternate-review bypasses fail deterministically.",
+        "Lifecycle promotion from planning_only to implementation_ready fails without accepted alternate-family review evidence and non-empty review refs.",
+        "Missing continuing handoff refs fail deterministically from implementation_ready onward.",
+        "Governance CI and the managed consumer-governance contract block the old failure shape."
+      ],
+      "file_paths": [
+        "docs/schemas/structured-agent-cycle-plan.schema.json",
+        "docs/schemas/package-handoff.schema.json",
+        "scripts/overlord/validate_structured_agent_cycle_plan.py",
+        "scripts/overlord/validate_handoff_package.py",
+        "scripts/overlord/test_validate_structured_agent_cycle_plan.py",
+        "scripts/overlord/test_validate_handoff_package.py",
+        ".github/workflows/governance-check.yml",
+        "tools/local-ci-gate/profiles/hldpro-governance.yml",
+        "STANDARDS.md",
+        "docs/EXTERNAL_SERVICES_RUNBOOK.md"
+      ]
+    }
+  ],
+  "specialist_reviews": [
+    {
+      "reviewer": "Repository-state audit synthesis",
+      "reviewer_model_id": "gpt-5.4-mini",
+      "reviewer_model_family": "openai",
+      "role": "problem statement and scope confirmation",
+      "focus": "Confirm the known failure is real, bounded, and source-governance in nature before implementation begins.",
+      "status": "accepted",
+      "summary": "The issue #184 packet and current validator/CI surfaces prove a real governance gap: repo-level adapters are present on main, but issue-level role separation and evidence rules are not hard-gated.",
+      "evidence": [
+        "https://github.com/NIBARGERB-HLDPRO/hldpro-governance/issues/583",
+        "https://github.com/NIBARGERB-HLDPRO/Stampede/issues/184",
+        "https://github.com/NIBARGERB-HLDPRO/Stampede/issues/197"
+      ]
+    }
+  ],
+  "alternate_model_review": {
+    "required": true,
+    "reviewer": "Claude specialist review via scripts/codex-review.sh claude",
+    "model_family": "anthropic",
+    "status": "accepted_with_followup",
+    "summary": "Alternate-family review accepted the direction but required two blocking packet fixes before implementation: define lifecycle-gated ref requirements and authorize the cross-review artifact path in the planning scope. It also requested explicit exemption-shape, structured identity fields, consumer-contract wording, and same-role handoff rationale before implementation-ready promotion.",
+    "evidence": [
+      "docs/codex-reviews/2026-04-29-claude.md",
+      "raw/cross-review/2026-04-29-issue-583-hard-gated-som-enforcement.md"
+    ]
+  },
+  "execution_handoff": {
+    "session_agent": "codex-orchestrator",
+    "execution_mode": "implementation_ready",
+    "approved_scope_summary": "Issue #583 is implementation-ready to harden the governance-source schema, validator, standards, runbook, consumer-verifier, deployer, and CI contract surfaces named in the implementation execution scope, plus the issue-backed proof artifacts for this lane.",
+    "next_execution_step": "Complete the bounded source-fix, rerun focused validator and CI proof including the old Stampede issue-184 replay and the strengthened consumer-verifier path, then record validation and closeout evidence for PR and auto-merge.",
+    "blocked_on": [],
+    "handoff_package_ref": "raw/handoffs/2026-04-29-issue-583-hard-gated-som-enforcement.json",
+    "execution_scope_ref": "raw/execution-scopes/2026-04-29-issue-583-hard-gated-som-enforcement-implementation.json",
+    "packet_ref": null,
+    "package_manifest_ref": null,
+    "validation_artifact_refs": [
+      "raw/validation/2026-04-29-issue-583-hard-gated-som-enforcement.md"
+    ],
+    "review_artifact_refs": [
+      "raw/cross-review/2026-04-29-issue-583-hard-gated-som-enforcement.md"
+    ],
+    "gate_artifact_refs": [
+      "cache/local-ci-gate/reports/20260429T155625Z-hldpro-governance-git/local-ci-20260429T155632Z.json"
+    ],
+    "closeout_ref": "raw/closeouts/2026-04-29-issue-583-hard-gated-som-enforcement.md",
+    "next_role": "codex-orchestrator",
+    "qa_gate_required": true,
+    "handoff_acceptance_criteria": [
+      "The implementation remains inside the schema, validator, standards, runbook, CI, and issue-proof surfaces named in the implementation execution scope.",
+      "Alternate-family review is captured through the governed wrapper path and recorded in raw/cross-review before implementation-ready promotion.",
+      "Validation must prove the old Stampede issue-184 shape now fails under the hardened rules before this issue can be called fixed."
+    ]
+  },
+  "material_deviation_rules": [
+    "Do not call this issue fixed on the strength of adapter presence alone.",
+    "Do not implement warning-only guardrails for the known bad packet shape.",
+    "Do not widen this source-fix lane into direct Stampede product or research work."
+  ],
+  "approved": true,
+  "approved_by": [
+    "Codex orchestrator"
+  ],
+  "approved_at": "2026-04-29T12:10:00Z"
+}

--- a/docs/schemas/structured-agent-cycle-plan.schema.json
+++ b/docs/schemas/structured-agent-cycle-plan.schema.json
@@ -35,6 +35,9 @@
       "type": "string",
       "minLength": 1
     },
+    "plan_author": {
+      "$ref": "#/$defs/identity"
+    },
     "tier": {
       "type": "integer",
       "minimum": 1,
@@ -174,6 +177,14 @@
           "type": "string",
           "minLength": 1
         },
+        "reviewer_model_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "reviewer_model_family": {
+          "type": "string",
+          "minLength": 1
+        },
         "role": {
           "type": "string",
           "minLength": 1
@@ -194,6 +205,9 @@
         "summary": {
           "type": "string",
           "minLength": 1
+        },
+        "exemption": {
+          "$ref": "#/$defs/reviewExemption"
         },
         "evidence": {
           "type": "array",
@@ -250,6 +264,60 @@
             "type": "string",
             "minLength": 1
           }
+        }
+      }
+    },
+    "identity": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "role",
+        "model_id",
+        "model_family"
+      ],
+      "properties": {
+        "role": {
+          "type": "string",
+          "minLength": 1
+        },
+        "model_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "model_family": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "reviewExemption": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "exemption_type",
+        "granted_by",
+        "expires_at",
+        "rationale"
+      ],
+      "properties": {
+        "exemption_type": {
+          "type": "string",
+          "enum": [
+            "historical_grandfathered",
+            "alternate_service_outage"
+          ]
+        },
+        "granted_by": {
+          "type": "string",
+          "minLength": 1
+        },
+        "expires_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "rationale": {
+          "type": "string",
+          "minLength": 1
         }
       }
     },

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,24 +1,24 @@
-# Graph Report - .  (2026-04-28)
+# Graph Report - .  (2026-04-29)
 
 ## Corpus Check
 - 145 files · ~0 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 1991 nodes · 4205 edges · 92 communities detected
-- Extraction: 46% EXTRACTED · 54% INFERRED · 0% AMBIGUOUS · INFERRED: 2285 edges (avg confidence: 0.5)
+- 2021 nodes · 4278 edges · 92 communities detected
+- Extraction: 46% EXTRACTED · 54% INFERRED · 0% AMBIGUOUS · INFERRED: 2330 edges (avg confidence: 0.5)
 - Token cost: 0 input · 0 output
 
 ## God Nodes (most connected - your core abstractions)
-1. `WindowsOllamaSubmitter` - 48 edges
-2. `TestVerifyGovernanceConsumer` - 46 edges
+1. `TestVerifyGovernanceConsumer` - 48 edges
+2. `WindowsOllamaSubmitter` - 48 edges
 3. `PiiDetectionError` - 44 edges
 4. `ModelNotAllowedError` - 44 edges
 5. `EndpointUnreachableError` - 44 edges
-6. `TestAssertExecutionScope` - 35 edges
-7. `RepoFixture` - 31 edges
-8. `_tier1_packet()` - 31 edges
-9. `TestGovernanceSurfacePlanGate` - 28 edges
+6. `TestGovernanceSurfacePlanGate` - 36 edges
+7. `TestAssertExecutionScope` - 35 edges
+8. `RepoFixture` - 31 edges
+9. `_tier1_packet()` - 31 edges
 10. `AuditWriter` - 28 edges
 
 ## Surprising Connections (you probably didn't know these)
@@ -53,87 +53,87 @@ Nodes (46): _expand_home(), governed_repos(), GovernedRepo, load_registry(), rep
 
 ### Community 4 - "Community 4"
 Cohesion: 0.06
-Nodes (24): BaseHTTPRequestHandler, build_parser(), build_payload(), _call_fixture(), _call_live(), Check, _fixture_server(), _FixtureMcpHandler (+16 more)
+Nodes (23): BaseHTTPRequestHandler, build_parser(), build_payload(), _call_fixture(), _call_live(), Check, _fixture_server(), _FixtureMcpHandler (+15 more)
 
 ### Community 5 - "Community 5"
-Cohesion: 0.08
-Nodes (38): build_parser(), build_payload(), _call_fixture(), _call_live(), Check, _fixture_request(), _latest_live_instruction(), main() (+30 more)
+Cohesion: 0.1
+Nodes (43): add_common_args(), apply(), _build_local_ci_plan(), build_plan(), _consumer_record(), _consumer_record_relpath(), _ensure_relative_to(), _fail() (+35 more)
 
 ### Community 6 - "Community 6"
-Cohesion: 0.18
+Cohesion: 0.17
 Nodes (1): TestVerifyGovernanceConsumer
 
 ### Community 7 - "Community 7"
+Cohesion: 0.08
+Nodes (38): build_parser(), build_payload(), _call_fixture(), _call_live(), Check, _fixture_request(), _latest_live_instruction(), main() (+30 more)
+
+### Community 8 - "Community 8"
 Cohesion: 0.06
 Nodes (20): ABC, BaseAggregator, ArtifactWriter, RunManifest, BaseAggregator, BaseModel, SimulationEngine, PersonaLoader (+12 more)
 
-### Community 8 - "Community 8"
+### Community 9 - "Community 9"
+Cohesion: 0.1
+Nodes (42): build_parser(), _consumer_record_relpath(), ConsumerRecord, ConsumerVerifyError, _contains_negated_forbidden_action(), _expected_checksum(), _expected_entry_failures(), _expected_managed_entries() (+34 more)
+
+### Community 10 - "Community 10"
 Cohesion: 0.13
 Nodes (38): append_audit(), atomic_write_json(), _base_packet(), _build_decision_packet(), _build_instruction_packet(), build_request(), _build_response_packet(), _build_resume_packet() (+30 more)
 
-### Community 9 - "Community 9"
-Cohesion: 0.1
-Nodes (34): append_fail_fast_block_entry(), append_fail_fast_candidate(), append_fail_fast_table_entry(), append_progress_candidate(), bounded_text(), build_parser(), build_review_context(), build_schema_file() (+26 more)
-
-### Community 10 - "Community 10"
+### Community 11 - "Community 11"
 Cohesion: 0.2
 Nodes (4): _git(), RepoFixture, TestAssertExecutionScope, _working_directory()
 
-### Community 11 - "Community 11"
-Cohesion: 0.11
-Nodes (29): _json(), TestValidateCloseout, _write(), build_parser(), _extract_repo_refs(), _load_json(), main(), _repo_rel() (+21 more)
-
 ### Community 12 - "Community 12"
-Cohesion: 0.11
-Nodes (39): build_parser(), _consumer_record_relpath(), ConsumerRecord, ConsumerVerifyError, _contains_negated_forbidden_action(), _expected_checksum(), _expected_managed_paths(), _fail() (+31 more)
+Cohesion: 0.1
+Nodes (38): build_parser(), CloseoutDecision, evaluate(), _is_governance_surface(), _is_planning_only(), _issue_number(), main(), _matching_closeouts() (+30 more)
 
 ### Community 13 - "Community 13"
+Cohesion: 0.1
+Nodes (34): append_fail_fast_block_entry(), append_fail_fast_candidate(), append_fail_fast_table_entry(), append_progress_candidate(), bounded_text(), build_parser(), build_review_context(), build_schema_file() (+26 more)
+
+### Community 14 - "Community 14"
 Cohesion: 0.13
 Nodes (37): ArtifactStats, branch_binding_preflight(), _check_pages_limits(), count_files(), deploy(), emit_evidence(), enforce_pages_limits(), extract_deployment_url() (+29 more)
 
-### Community 14 - "Community 14"
+### Community 15 - "Community 15"
 Cohesion: 0.12
 Nodes (20): append_audit(), _audit_path(), ensure_queue(), load_packet(), _load_plan(), QueueDecision, Replay audit events into logical latest states.      `latest_states` includes ac, replay_audit() (+12 more)
 
-### Community 15 - "Community 15"
+### Community 16 - "Community 16"
 Cohesion: 0.12
 Nodes (38): _branch_issue_number(), build_argument_parser(), _build_summary(), _changed_files_from_git(), ChangedFiles, _check_exit_code(), _check_matches_changed_files(), CheckResult (+30 more)
 
-### Community 16 - "Community 16"
+### Community 17 - "Community 17"
 Cohesion: 0.11
 Nodes (34): _branch_issue_number(), _changed_paths(), _changed_paths_from_file(), check_scope(), _current_branch(), ExecutionScope, _format_path(), _git_root() (+26 more)
 
-### Community 17 - "Community 17"
+### Community 18 - "Community 18"
+Cohesion: 0.11
+Nodes (2): _plan(), TestGovernanceSurfacePlanGate
+
+### Community 19 - "Community 19"
 Cohesion: 0.14
 Nodes (28): atomic_write_yaml(), build_report(), _date_from_text(), duplicate_counts(), enrich_packet(), _entry_id(), LearningEntry, LearningMatch (+20 more)
 
-### Community 18 - "Community 18"
+### Community 20 - "Community 20"
 Cohesion: 0.17
 Nodes (31): default_env(), deploy_calls(), FakeCompleted, _make_cf_response(), make_runner(), run_gate(), run_gate_expect_error(), test_branch_binding_preflight_fails_on_mismatch() (+23 more)
 
-### Community 19 - "Community 19"
+### Community 21 - "Community 21"
 Cohesion: 0.13
 Nodes (19): add_common_args(), build_plan(), build_refresh_command(), execute_refresh(), find_target(), git_hook_paths(), HelperError, HookPlan (+11 more)
 
-### Community 20 - "Community 20"
+### Community 22 - "Community 22"
 Cohesion: 0.15
 Nodes (30): _branch(), build_report(), _cname_note(), _deployment_url(), _domain_label(), _domain_result(), _domains(), emit_summary() (+22 more)
 
-### Community 21 - "Community 21"
+### Community 23 - "Community 23"
 Cohesion: 0.1
 Nodes (30): _find_packet_file(), _load_packet(), load_pii_patterns(), _load_schema(), Load and compile PII patterns from pii-patterns.yml., Enforce cross-family independence for tier-1 dual-planner packets.      When pri, Refuse if any consecutive pair in the parent chain shares model_id across differ, Enforce expected handoff sequence with no tier jumps. (+22 more)
 
-### Community 22 - "Community 22"
-Cohesion: 0.13
-Nodes (2): _plan(), TestGovernanceSurfacePlanGate
-
-### Community 23 - "Community 23"
+### Community 24 - "Community 24"
 Cohesion: 0.16
 Nodes (28): aggregate_file_scores(), augment_workflow_doc_candidates(), baseline_results(), build_summary(), build_trace(), emit_usage_events(), estimate_tokens(), evaluate_relevance() (+20 more)
-
-### Community 24 - "Community 24"
-Cohesion: 0.18
-Nodes (24): add_common_args(), apply(), _build_local_ci_plan(), build_plan(), _consumer_record(), _consumer_record_relpath(), _ensure_relative_to(), _fail() (+16 more)
 
 ### Community 25 - "Community 25"
 Cohesion: 0.16
@@ -164,100 +164,100 @@ Cohesion: 0.08
 Nodes (1): TestLocalCiGate
 
 ### Community 32 - "Community 32"
-Cohesion: 0.17
-Nodes (13): build_parser(), CloseoutDecision, evaluate(), _is_governance_surface(), _is_planning_only(), _issue_number(), main(), _matching_closeouts() (+5 more)
-
-### Community 33 - "Community 33"
 Cohesion: 0.27
 Nodes (20): FakeTransport, response(), run_report(), test_cache_busting_headers(), test_cname_mismatch_not_blocking(), test_different_deployment_ids(), test_domain_not_200(), test_expected_title_matches() (+12 more)
 
-### Community 34 - "Community 34"
+### Community 33 - "Community 33"
 Cohesion: 0.15
 Nodes (11): apply_policy(), classifier_match(), _contains_term(), decide(), deterministic_match(), GateDecision, _load_classifier(), load_rules() (+3 more)
 
-### Community 35 - "Community 35"
+### Community 34 - "Community 34"
 Cohesion: 0.19
 Nodes (21): build(), category_for(), describe_file(), esc(), FileInfo, first_comment(), first_heading(), frontmatter_field() (+13 more)
 
-### Community 36 - "Community 36"
+### Community 35 - "Community 35"
 Cohesion: 0.21
 Nodes (12): _actual_workflows(), check_inventory(), _command_file_candidates(), _load_inventory(), main(), _normalize_path(), _validate_coverage(), _validate_required_snippets() (+4 more)
 
+### Community 36 - "Community 36"
+Cohesion: 0.3
+Nodes (1): TestDeployGovernanceTooling
+
 ### Community 37 - "Community 37"
-Cohesion: 0.1
-Nodes (15): Modify first_hash in manifest and verify fails., Test that truncated file (missing last line) breaks manifest., Delete last line and verify detects entry_count mismatch., Test that duplicate line (replay) breaks seq monotonicity., Duplicate a line and verify detects non-monotonic seq., Test that tampering with a line breaks the chain., Tamper with line N and verify fails at line N+1., Test that replacing entry_hmac with wrong value fails verification. (+7 more)
+Cohesion: 0.21
+Nodes (20): _branch_issue_number(), _display_path(), _find_plan_files(), _is_governance_surface(), _is_planning_evidence_surface(), _load_json_safe(), main(), _matching_execution_scopes() (+12 more)
 
 ### Community 38 - "Community 38"
-Cohesion: 0.32
-Nodes (1): TestDeployGovernanceTooling
+Cohesion: 0.1
+Nodes (15): Modify first_hash in manifest and verify fails., Test that truncated file (missing last line) breaks manifest., Delete last line and verify detects entry_count mismatch., Test that duplicate line (replay) breaks seq monotonicity., Duplicate a line and verify detects non-monotonic seq., Test that tampering with a line breaks the chain., Tamper with line N and verify fails at line N+1., Test that replacing entry_hmac with wrong value fails verification. (+7 more)
 
 ### Community 39 - "Community 39"
 Cohesion: 0.14
 Nodes (10): check_github_issue_open(), collect_section_lines(), fail(), issue_column_index(), issue_numbers(), main(), parse_markdown_row(), validate_section() (+2 more)
 
 ### Community 40 - "Community 40"
-Cohesion: 0.27
-Nodes (14): add_common_args(), build_plan(), _common_preview_payload(), DeployError, DeployPlan, _existing_shim_state(), _fail(), _is_relative_to() (+6 more)
-
-### Community 41 - "Community 41"
 Cohesion: 0.37
 Nodes (4): _git(), RepoFixture, _scope(), TestWorkerHandoffRoute
 
-### Community 42 - "Community 42"
+### Community 41 - "Community 41"
 Cohesion: 0.27
 Nodes (1): TestDeployLocalCIGate
 
-### Community 43 - "Community 43"
+### Community 42 - "Community 42"
 Cohesion: 0.28
 Nodes (14): compare_inventory(), _default_branch_name(), _inventory_rows_from_payload(), InventoryDrift, load_inventory_file(), _load_json(), load_live_inventory(), main() (+6 more)
 
-### Community 44 - "Community 44"
+### Community 43 - "Community 43"
 Cohesion: 0.23
 Nodes (14): build_alert(), build_parser(), _contains_sensitive(), _load_payload(), main(), _now(), render_markdown(), _safe_text() (+6 more)
 
-### Community 45 - "Community 45"
+### Community 44 - "Community 44"
 Cohesion: 0.23
 Nodes (12): backlog_issues(), build_summary(), collect_active_issue_refs(), current_repo_slug(), fail(), gh_json(), IssueRef, main() (+4 more)
 
-### Community 46 - "Community 46"
+### Community 45 - "Community 45"
 Cohesion: 0.14
 Nodes (2): FakeResponse, TestRuntimeInventory
 
-### Community 47 - "Community 47"
+### Community 46 - "Community 46"
 Cohesion: 0.23
 Nodes (6): _check_required_checks(), evaluate(), _labels(), main(), eligible_payload(), TestAutomergePolicyCheck
 
-### Community 48 - "Community 48"
-Cohesion: 0.3
-Nodes (14): _branch_issue_number(), _display_path(), _find_plan_files(), _is_governance_surface(), _load_json_safe(), main(), _matching_execution_scopes(), _matching_plan_payloads() (+6 more)
+### Community 47 - "Community 47"
+Cohesion: 0.32
+Nodes (3): _json(), TestValidateCloseout, _write()
 
-### Community 49 - "Community 49"
+### Community 48 - "Community 48"
 Cohesion: 0.27
 Nodes (14): build_report(), codex_backlog_status(), extract_runbook_paths(), extract_som_excerpt(), format_hook_note(), git_branch(), main(), parse_args() (+6 more)
 
-### Community 50 - "Community 50"
+### Community 49 - "Community 49"
 Cohesion: 0.26
 Nodes (2): _run(), TestPlanPreflight
 
-### Community 51 - "Community 51"
+### Community 50 - "Community 50"
 Cohesion: 0.35
 Nodes (3): _payload(), _run_hook(), TestSchemaGuardHook
 
-### Community 52 - "Community 52"
+### Community 51 - "Community 51"
 Cohesion: 0.26
 Nodes (1): GovernedReposValidationTests
 
-### Community 53 - "Community 53"
+### Community 52 - "Community 52"
 Cohesion: 0.19
 Nodes (8): build_governance(), emit_dispatch_packet(), emit_packet(), main(), Emit a dispatch-ready packet that includes a complete governance block., Emit a minimal or dispatch-ready packet YAML file. Returns path to written file., Build a governance block dict for inclusion in a dispatch-ready packet., TestPacketEmitter
 
-### Community 54 - "Community 54"
+### Community 53 - "Community 53"
 Cohesion: 0.28
 Nodes (2): run_hook(), TestBranchSwitchGuard
 
-### Community 55 - "Community 55"
+### Community 54 - "Community 54"
 Cohesion: 0.51
 Nodes (1): TestOrgRepoInventory
+
+### Community 55 - "Community 55"
+Cohesion: 0.33
+Nodes (3): _json(), TestCheckStage6Closeout, _write()
 
 ### Community 56 - "Community 56"
 Cohesion: 0.24
@@ -265,7 +265,7 @@ Nodes (7): TestValidateSessionErrorPatterns, _write_runbook(), _field_key(), _fi
 
 ### Community 57 - "Community 57"
 Cohesion: 0.29
-Nodes (12): check(), main(), Exercise vault discovery from sibling governance worktrees., Exercise vault discovery from HLDPRO/var/worktrees/* governance worktrees., Exercise Seek/Ponder bootstrap aliases without leaking synthetic values., Exercise Stampede bootstrap with production Tradier mapping and redaction., Exercise lam bootstrap with command-like vault values and missing optional keys., run_nested_var_worktree_lam_bootstrap() (+4 more)
+Nodes (12): check(), main(), Exercise worktree invocation while still resolving the canonical governance root, Exercise failure when the canonical governance root is absent., Exercise Seek/Ponder bootstrap aliases without leaking synthetic values., Exercise Stampede bootstrap with production Tradier mapping and redaction., Exercise lam bootstrap with command-like vault values and missing optional keys., run_canonical_root_worktree_lam_bootstrap() (+4 more)
 
 ### Community 58 - "Community 58"
 Cohesion: 0.3
@@ -308,12 +308,12 @@ Cohesion: 0.49
 Nodes (9): check(), fail(), main(), read_text(), repos_for_static_checkout(), validate_docs_surfaces(), validate_runtime_registry_consumers(), validate_static_checkout_workflow() (+1 more)
 
 ### Community 68 - "Community 68"
-Cohesion: 0.61
-Nodes (8): check(), main(), run_command(), test_logger_backwards_compatible(), test_logger_query_trace_fields(), test_measurement_falls_back_from_stale_governance_repo_path(), test_measurement_outputs_query_traces(), test_schema_shape()
+Cohesion: 0.42
+Nodes (8): run_fire(), test_exec_failure_after_successful_preflight_logs_and_signals(), test_preflight_failure_logs_and_exits_fast(), test_preflight_timeout_logs_and_exits_fast(), test_review_template_default_persona_reaches_codex_fire(), test_review_template_propagates_wrapper_failure(), test_success_does_not_write_failure_log(), write_fake_codex()
 
 ### Community 69 - "Community 69"
-Cohesion: 0.5
-Nodes (8): run_fire(), test_exec_failure_after_successful_preflight_logs_and_signals(), test_preflight_failure_logs_and_exits_fast(), test_preflight_timeout_logs_and_exits_fast(), test_review_template_default_persona_reaches_codex_fire(), test_review_template_propagates_wrapper_failure(), test_success_does_not_write_failure_log(), write_fake_codex()
+Cohesion: 0.61
+Nodes (8): check(), main(), run_command(), test_logger_backwards_compatible(), test_logger_query_trace_fields(), test_measurement_falls_back_from_stale_governance_repo_path(), test_measurement_outputs_query_traces(), test_schema_shape()
 
 ### Community 70 - "Community 70"
 Cohesion: 0.46
@@ -418,10 +418,12 @@ Nodes (1): Build a client from well-known environment variables.
 ## Suggested Questions
 _Questions this graph is uniquely positioned to answer:_
 
-- **Why does `ConsumerVerifyError` connect `Community 12` to `Community 4`?**
+- **Why does `ConsumerVerifyError` connect `Community 9` to `Community 5`?**
   _High betweenness centrality (0.015) - this node is a cross-community bridge._
-- **Why does `GateError` connect `Community 15` to `Community 4`?**
-  _High betweenness centrality (0.010) - this node is a cross-community bridge._
+- **Why does `GateError` connect `Community 16` to `Community 5`?**
+  _High betweenness centrality (0.009) - this node is a cross-community bridge._
+- **Why does `SomClientError` connect `Community 4` to `Community 5`?**
+  _High betweenness centrality (0.008) - this node is a cross-community bridge._
 - **Are the 39 inferred relationships involving `WindowsOllamaSubmitter` (e.g. with `main()` and `AuditWriter`) actually correct?**
   _`WindowsOllamaSubmitter` has 39 INFERRED edges - model-reasoned connections that need verification._
 - **Are the 39 inferred relationships involving `PiiDetectionError` (e.g. with `.submit()` and `AuditWriter`) actually correct?**
@@ -430,5 +432,3 @@ _Questions this graph is uniquely positioned to answer:_
   _`ModelNotAllowedError` has 39 INFERRED edges - model-reasoned connections that need verification._
 - **Are the 39 inferred relationships involving `EndpointUnreachableError` (e.g. with `.submit()` and `AuditWriter`) actually correct?**
   _`EndpointUnreachableError` has 39 INFERRED edges - model-reasoned connections that need verification._
-- **What connects `Load persona JSON files. Resolves local-first, shared fallback.`, `Convenience: load shared dir from bundled package personas/.`, `Subprocess-backed provider using codex exec --ephemeral.` to the rest of the system?**
-  _82 weakly-connected nodes found - possible documentation gaps or missing edges._

--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -9,7 +9,7 @@
       "source_file": "scripts/windows-ollama/tests/__init__.py",
       "source_location": "L1",
       "id": "init",
-      "community": 7
+      "community": 8
     },
     {
       "label": "aggregator.py",
@@ -17,7 +17,7 @@
       "source_file": "packages/hldpro-sim/hldprosim/aggregator.py",
       "source_location": "L1",
       "id": "aggregator",
-      "community": 7
+      "community": 8
     },
     {
       "label": "BaseAggregator",
@@ -25,7 +25,7 @@
       "source_file": "packages/hldpro-sim/hldprosim/aggregator.py",
       "source_location": "L8",
       "id": "aggregator_baseaggregator",
-      "community": 7
+      "community": 8
     },
     {
       "label": "ABC",
@@ -33,7 +33,7 @@
       "source_file": "",
       "source_location": "",
       "id": "abc",
-      "community": 7
+      "community": 8
     },
     {
       "label": "aggregate()",
@@ -41,7 +41,7 @@
       "source_file": "packages/hldpro-sim/hldprosim/aggregator.py",
       "source_location": "L10",
       "id": "aggregator_aggregate",
-      "community": 7
+      "community": 8
     },
     {
       "label": "artifacts.py",
@@ -49,7 +49,7 @@
       "source_file": "packages/hldpro-sim/hldprosim/artifacts.py",
       "source_location": "L1",
       "id": "artifacts",
-      "community": 7
+      "community": 8
     },
     {
       "label": "RunManifest",
@@ -57,7 +57,7 @@
       "source_file": "packages/hldpro-sim/hldprosim/artifacts.py",
       "source_location": "L10",
       "id": "artifacts_runmanifest",
-      "community": 7
+      "community": 8
     },
     {
       "label": "_git_commit()",
@@ -65,7 +65,7 @@
       "source_file": "packages/hldpro-sim/hldprosim/artifacts.py",
       "source_location": "L21",
       "id": "artifacts_git_commit",
-      "community": 7
+      "community": 8
     },
     {
       "label": "ArtifactWriter",
@@ -73,7 +73,7 @@
       "source_file": "packages/hldpro-sim/hldprosim/artifacts.py",
       "source_location": "L33",
       "id": "artifacts_artifactwriter",
-      "community": 7
+      "community": 8
     },
     {
       "label": ".__init__()",
@@ -81,7 +81,7 @@
       "source_file": "packages/hldpro-sim/hldprosim/artifacts.py",
       "source_location": "L34",
       "id": "artifacts_artifactwriter_init",
-      "community": 7
+      "community": 8
     },
     {
       "label": ".write()",
@@ -89,7 +89,7 @@
       "source_file": "packages/hldpro-sim/hldprosim/artifacts.py",
       "source_location": "L37",
       "id": "artifacts_artifactwriter_write",
-      "community": 7
+      "community": 8
     },
     {
       "label": "engine.py",
@@ -97,7 +97,7 @@
       "source_file": "packages/hldpro-sim/hldprosim/engine.py",
       "source_location": "L1",
       "id": "engine",
-      "community": 7
+      "community": 8
     },
     {
       "label": "SimulationEngine",
@@ -105,7 +105,7 @@
       "source_file": "packages/hldpro-sim/hldprosim/engine.py",
       "source_location": "L7",
       "id": "engine_simulationengine",
-      "community": 7
+      "community": 8
     },
     {
       "label": ".__init__()",
@@ -113,7 +113,7 @@
       "source_file": "packages/hldpro-sim/hldprosim/engine.py",
       "source_location": "L8",
       "id": "engine_simulationengine_init",
-      "community": 7
+      "community": 8
     },
     {
       "label": ".run()",
@@ -121,7 +121,7 @@
       "source_file": "packages/hldpro-sim/hldprosim/engine.py",
       "source_location": "L20",
       "id": "engine_simulationengine_run",
-      "community": 7
+      "community": 8
     },
     {
       "label": "personas.py",
@@ -129,7 +129,7 @@
       "source_file": "packages/hldpro-sim/hldprosim/personas.py",
       "source_location": "L1",
       "id": "personas",
-      "community": 7
+      "community": 8
     },
     {
       "label": "PersonaLoader",
@@ -137,7 +137,7 @@
       "source_file": "packages/hldpro-sim/hldprosim/personas.py",
       "source_location": "L6",
       "id": "personas_personaloader",
-      "community": 7
+      "community": 8
     },
     {
       "label": ".__init__()",
@@ -145,7 +145,7 @@
       "source_file": "packages/hldpro-sim/hldprosim/personas.py",
       "source_location": "L9",
       "id": "personas_personaloader_init",
-      "community": 7
+      "community": 8
     },
     {
       "label": ".load()",
@@ -153,7 +153,7 @@
       "source_file": "packages/hldpro-sim/hldprosim/personas.py",
       "source_location": "L13",
       "id": "personas_personaloader_load",
-      "community": 7
+      "community": 8
     },
     {
       "label": "from_package()",
@@ -161,7 +161,7 @@
       "source_file": "packages/hldpro-sim/hldprosim/personas.py",
       "source_location": "L23",
       "id": "personas_from_package",
-      "community": 7
+      "community": 8
     },
     {
       "label": "Load persona JSON files. Resolves local-first, shared fallback.",
@@ -169,7 +169,7 @@
       "source_file": "packages/hldpro-sim/hldprosim/personas.py",
       "source_location": "L7",
       "id": "personas_rationale_7",
-      "community": 7
+      "community": 8
     },
     {
       "label": "Convenience: load shared dir from bundled package personas/.",
@@ -185,7 +185,7 @@
       "source_file": "packages/hldpro-sim/hldprosim/providers.py",
       "source_location": "L1",
       "id": "providers",
-      "community": 7
+      "community": 8
     },
     {
       "label": "BaseProvider",
@@ -193,7 +193,7 @@
       "source_file": "packages/hldpro-sim/hldprosim/providers.py",
       "source_location": "L10",
       "id": "providers_baseprovider",
-      "community": 7
+      "community": 8
     },
     {
       "label": "Protocol",
@@ -201,7 +201,7 @@
       "source_file": "",
       "source_location": "",
       "id": "protocol",
-      "community": 7
+      "community": 8
     },
     {
       "label": ".complete()",
@@ -209,7 +209,7 @@
       "source_file": "packages/hldpro-sim/hldprosim/providers.py",
       "source_location": "L11",
       "id": "providers_baseprovider_complete",
-      "community": 7
+      "community": 8
     },
     {
       "label": "CodexCliProvider",
@@ -217,7 +217,7 @@
       "source_file": "packages/hldpro-sim/hldprosim/providers.py",
       "source_location": "L14",
       "id": "providers_codexcliprovider",
-      "community": 7
+      "community": 8
     },
     {
       "label": ".__init__()",
@@ -225,7 +225,7 @@
       "source_file": "packages/hldpro-sim/hldprosim/providers.py",
       "source_location": "L17",
       "id": "providers_codexcliprovider_init",
-      "community": 7
+      "community": 8
     },
     {
       "label": ".complete()",
@@ -233,7 +233,7 @@
       "source_file": "packages/hldpro-sim/hldprosim/providers.py",
       "source_location": "L21",
       "id": "providers_codexcliprovider_complete",
-      "community": 7
+      "community": 8
     },
     {
       "label": "AnthropicApiProvider",
@@ -241,7 +241,7 @@
       "source_file": "packages/hldpro-sim/hldprosim/providers.py",
       "source_location": "L71",
       "id": "providers_anthropicapiprovider",
-      "community": 7
+      "community": 8
     },
     {
       "label": ".complete()",
@@ -249,7 +249,7 @@
       "source_file": "packages/hldpro-sim/hldprosim/providers.py",
       "source_location": "L74",
       "id": "providers_anthropicapiprovider_complete",
-      "community": 7
+      "community": 8
     },
     {
       "label": "Subprocess-backed provider using codex exec --ephemeral.",
@@ -257,7 +257,7 @@
       "source_file": "packages/hldpro-sim/hldprosim/providers.py",
       "source_location": "L15",
       "id": "providers_rationale_15",
-      "community": 7
+      "community": 8
     },
     {
       "label": "Cloud stub \u2014 not implemented until API keys are provisioned.",
@@ -265,7 +265,7 @@
       "source_file": "packages/hldpro-sim/hldprosim/providers.py",
       "source_location": "L72",
       "id": "providers_rationale_72",
-      "community": 7
+      "community": 8
     },
     {
       "label": "runner.py",
@@ -273,7 +273,7 @@
       "source_file": "packages/hldpro-sim/hldprosim/runner.py",
       "source_location": "L1",
       "id": "runner",
-      "community": 7
+      "community": 8
     },
     {
       "label": "Runner",
@@ -281,7 +281,7 @@
       "source_file": "packages/hldpro-sim/hldprosim/runner.py",
       "source_location": "L6",
       "id": "runner_runner",
-      "community": 7
+      "community": 8
     },
     {
       "label": ".__init__()",
@@ -289,7 +289,7 @@
       "source_file": "packages/hldpro-sim/hldprosim/runner.py",
       "source_location": "L7",
       "id": "runner_runner_init",
-      "community": 7
+      "community": 8
     },
     {
       "label": ".run_n()",
@@ -297,7 +297,7 @@
       "source_file": "packages/hldpro-sim/hldprosim/runner.py",
       "source_location": "L10",
       "id": "runner_runner_run_n",
-      "community": 7
+      "community": 8
     },
     {
       "label": "stampede_consumer.py",
@@ -305,7 +305,7 @@
       "source_file": "packages/hldpro-sim/tests/fixtures/stampede_consumer.py",
       "source_location": "L1",
       "id": "stampede_consumer",
-      "community": 7
+      "community": 8
     },
     {
       "label": "NarrativeOutcome",
@@ -313,7 +313,7 @@
       "source_file": "packages/hldpro-sim/tests/fixtures/stampede_consumer.py",
       "source_location": "L8",
       "id": "stampede_consumer_narrativeoutcome",
-      "community": 7
+      "community": 8
     },
     {
       "label": "BaseModel",
@@ -321,7 +321,7 @@
       "source_file": "",
       "source_location": "",
       "id": "basemodel",
-      "community": 7
+      "community": 8
     },
     {
       "label": "NarrativeAggregator",
@@ -329,7 +329,7 @@
       "source_file": "packages/hldpro-sim/tests/fixtures/stampede_consumer.py",
       "source_location": "L17",
       "id": "stampede_consumer_narrativeaggregator",
-      "community": 7
+      "community": 8
     },
     {
       "label": "BaseAggregator",
@@ -337,7 +337,7 @@
       "source_file": "",
       "source_location": "",
       "id": "baseaggregator",
-      "community": 7
+      "community": 8
     },
     {
       "label": ".aggregate()",
@@ -345,7 +345,7 @@
       "source_file": "packages/hldpro-sim/tests/fixtures/stampede_consumer.py",
       "source_location": "L18",
       "id": "stampede_consumer_narrativeaggregator_aggregate",
-      "community": 7
+      "community": 8
     },
     {
       "label": "test_artifacts.py",
@@ -489,7 +489,7 @@
       "source_file": "packages/hldpro-sim/tests/test_stampede_consumer_proof.py",
       "source_location": "L1",
       "id": "test_stampede_consumer_proof",
-      "community": 7
+      "community": 8
     },
     {
       "label": "MockProvider",
@@ -497,7 +497,7 @@
       "source_file": "packages/hldpro-sim/tests/test_stampede_consumer_proof.py",
       "source_location": "L37",
       "id": "test_stampede_consumer_proof_mockprovider",
-      "community": 7
+      "community": 8
     },
     {
       "label": ".complete()",
@@ -505,7 +505,7 @@
       "source_file": "packages/hldpro-sim/tests/test_stampede_consumer_proof.py",
       "source_location": "L38",
       "id": "test_stampede_consumer_proof_mockprovider_complete",
-      "community": 7
+      "community": 8
     },
     {
       "label": "test_stampede_e2e()",
@@ -513,7 +513,7 @@
       "source_file": "packages/hldpro-sim/tests/test_stampede_consumer_proof.py",
       "source_location": "L42",
       "id": "test_stampede_consumer_proof_test_stampede_e2e",
-      "community": 7
+      "community": 8
     },
     {
       "label": "cli_session_supervisor.py",
@@ -705,7 +705,7 @@
       "source_file": "scripts/knowledge_base/graphify_hook_helper.py",
       "source_location": "L1",
       "id": "graphify_hook_helper",
-      "community": 19
+      "community": 21
     },
     {
       "label": "HelperError",
@@ -713,7 +713,7 @@
       "source_file": "scripts/knowledge_base/graphify_hook_helper.py",
       "source_location": "L18",
       "id": "graphify_hook_helper_helpererror",
-      "community": 19
+      "community": 21
     },
     {
       "label": "RuntimeError",
@@ -721,7 +721,7 @@
       "source_file": "",
       "source_location": "",
       "id": "runtimeerror",
-      "community": 4
+      "community": 5
     },
     {
       "label": "HookPlan",
@@ -729,7 +729,7 @@
       "source_file": "scripts/knowledge_base/graphify_hook_helper.py",
       "source_location": "L23",
       "id": "graphify_hook_helper_hookplan",
-      "community": 19
+      "community": 21
     },
     {
       "label": ".to_json()",
@@ -737,7 +737,7 @@
       "source_file": "scripts/knowledge_base/graphify_hook_helper.py",
       "source_location": "L32",
       "id": "graphify_hook_helper_hookplan_to_json",
-      "community": 19
+      "community": 21
     },
     {
       "label": "load_manifest()",
@@ -745,7 +745,7 @@
       "source_file": "scripts/knowledge_base/graphify_hook_helper.py",
       "source_location": "L44",
       "id": "graphify_hook_helper_load_manifest",
-      "community": 19
+      "community": 21
     },
     {
       "label": "target_rows()",
@@ -753,7 +753,7 @@
       "source_file": "scripts/knowledge_base/graphify_hook_helper.py",
       "source_location": "L54",
       "id": "graphify_hook_helper_target_rows",
-      "community": 19
+      "community": 21
     },
     {
       "label": "find_target()",
@@ -761,7 +761,7 @@
       "source_file": "scripts/knowledge_base/graphify_hook_helper.py",
       "source_location": "L61",
       "id": "graphify_hook_helper_find_target",
-      "community": 19
+      "community": 21
     },
     {
       "label": "infer_repo_slug()",
@@ -769,7 +769,7 @@
       "source_file": "scripts/knowledge_base/graphify_hook_helper.py",
       "source_location": "L68",
       "id": "graphify_hook_helper_infer_repo_slug",
-      "community": 19
+      "community": 21
     },
     {
       "label": "resolve_under()",
@@ -777,7 +777,7 @@
       "source_file": "scripts/knowledge_base/graphify_hook_helper.py",
       "source_location": "L80",
       "id": "graphify_hook_helper_resolve_under",
-      "community": 19
+      "community": 21
     },
     {
       "label": "git_hook_paths()",
@@ -785,7 +785,7 @@
       "source_file": "scripts/knowledge_base/graphify_hook_helper.py",
       "source_location": "L89",
       "id": "graphify_hook_helper_git_hook_paths",
-      "community": 19
+      "community": 21
     },
     {
       "label": "build_plan()",
@@ -793,7 +793,7 @@
       "source_file": "scripts/knowledge_base/graphify_hook_helper.py",
       "source_location": "L103",
       "id": "graphify_hook_helper_build_plan",
-      "community": 19
+      "community": 21
     },
     {
       "label": "is_relative_to()",
@@ -801,7 +801,7 @@
       "source_file": "scripts/knowledge_base/graphify_hook_helper.py",
       "source_location": "L122",
       "id": "graphify_hook_helper_is_relative_to",
-      "community": 19
+      "community": 21
     },
     {
       "label": "preflight_safe_output()",
@@ -809,7 +809,7 @@
       "source_file": "scripts/knowledge_base/graphify_hook_helper.py",
       "source_location": "L130",
       "id": "graphify_hook_helper_preflight_safe_output",
-      "community": 19
+      "community": 21
     },
     {
       "label": "build_refresh_command()",
@@ -817,7 +817,7 @@
       "source_file": "scripts/knowledge_base/graphify_hook_helper.py",
       "source_location": "L139",
       "id": "graphify_hook_helper_build_refresh_command",
-      "community": 19
+      "community": 21
     },
     {
       "label": "managed_hook_body()",
@@ -825,7 +825,7 @@
       "source_file": "scripts/knowledge_base/graphify_hook_helper.py",
       "source_location": "L157",
       "id": "graphify_hook_helper_managed_hook_body",
-      "community": 19
+      "community": 21
     },
     {
       "label": "install_hooks()",
@@ -833,7 +833,7 @@
       "source_file": "scripts/knowledge_base/graphify_hook_helper.py",
       "source_location": "L171",
       "id": "graphify_hook_helper_install_hooks",
-      "community": 19
+      "community": 21
     },
     {
       "label": "execute_refresh()",
@@ -841,7 +841,7 @@
       "source_file": "scripts/knowledge_base/graphify_hook_helper.py",
       "source_location": "L187",
       "id": "graphify_hook_helper_execute_refresh",
-      "community": 19
+      "community": 21
     },
     {
       "label": "print_json()",
@@ -849,7 +849,7 @@
       "source_file": "scripts/knowledge_base/graphify_hook_helper.py",
       "source_location": "L192",
       "id": "graphify_hook_helper_print_json",
-      "community": 19
+      "community": 21
     },
     {
       "label": "add_common_args()",
@@ -857,7 +857,7 @@
       "source_file": "scripts/knowledge_base/graphify_hook_helper.py",
       "source_location": "L197",
       "id": "graphify_hook_helper_add_common_args",
-      "community": 19
+      "community": 21
     },
     {
       "label": "main()",
@@ -865,7 +865,7 @@
       "source_file": "scripts/knowledge_base/graphify_hook_helper.py",
       "source_location": "L204",
       "id": "graphify_hook_helper_main",
-      "community": 19
+      "community": 21
     },
     {
       "label": "graphify_targets.py",
@@ -993,7 +993,7 @@
       "source_file": "scripts/knowledge_base/measure_graphify_usage.py",
       "source_location": "L1",
       "id": "measure_graphify_usage",
-      "community": 23
+      "community": 24
     },
     {
       "label": "Scenario",
@@ -1001,7 +1001,7 @@
       "source_file": "scripts/knowledge_base/measure_graphify_usage.py",
       "source_location": "L72",
       "id": "measure_graphify_usage_scenario",
-      "community": 23
+      "community": 24
     },
     {
       "label": "GraphData",
@@ -1009,7 +1009,7 @@
       "source_file": "scripts/knowledge_base/measure_graphify_usage.py",
       "source_location": "L86",
       "id": "measure_graphify_usage_graphdata",
-      "community": 23
+      "community": 24
     },
     {
       "label": "estimate_tokens()",
@@ -1017,7 +1017,7 @@
       "source_file": "scripts/knowledge_base/measure_graphify_usage.py",
       "source_location": "L93",
       "id": "measure_graphify_usage_estimate_tokens",
-      "community": 23
+      "community": 24
     },
     {
       "label": "normalize_tokens()",
@@ -1025,7 +1025,7 @@
       "source_file": "scripts/knowledge_base/measure_graphify_usage.py",
       "source_location": "L97",
       "id": "measure_graphify_usage_normalize_tokens",
-      "community": 23
+      "community": 24
     },
     {
       "label": "parse_args()",
@@ -1033,7 +1033,7 @@
       "source_file": "scripts/knowledge_base/measure_graphify_usage.py",
       "source_location": "L108",
       "id": "measure_graphify_usage_parse_args",
-      "community": 23
+      "community": 24
     },
     {
       "label": "load_scenarios()",
@@ -1041,7 +1041,7 @@
       "source_file": "scripts/knowledge_base/measure_graphify_usage.py",
       "source_location": "L120",
       "id": "measure_graphify_usage_load_scenarios",
-      "community": 23
+      "community": 24
     },
     {
       "label": "resolve_graph_path()",
@@ -1049,7 +1049,7 @@
       "source_file": "scripts/knowledge_base/measure_graphify_usage.py",
       "source_location": "L125",
       "id": "measure_graphify_usage_resolve_graph_path",
-      "community": 23
+      "community": 24
     },
     {
       "label": "resolve_label_path()",
@@ -1057,7 +1057,7 @@
       "source_file": "scripts/knowledge_base/measure_graphify_usage.py",
       "source_location": "L134",
       "id": "measure_graphify_usage_resolve_label_path",
-      "community": 23
+      "community": 24
     },
     {
       "label": "load_graph()",
@@ -1065,7 +1065,7 @@
       "source_file": "scripts/knowledge_base/measure_graphify_usage.py",
       "source_location": "L139",
       "id": "measure_graphify_usage_load_graph",
-      "community": 23
+      "community": 24
     },
     {
       "label": "resolve_repo_root()",
@@ -1073,7 +1073,7 @@
       "source_file": "scripts/knowledge_base/measure_graphify_usage.py",
       "source_location": "L151",
       "id": "measure_graphify_usage_resolve_repo_root",
-      "community": 23
+      "community": 24
     },
     {
       "label": "relativize_source_file()",
@@ -1081,7 +1081,7 @@
       "source_file": "scripts/knowledge_base/measure_graphify_usage.py",
       "source_location": "L163",
       "id": "measure_graphify_usage_relativize_source_file",
-      "community": 23
+      "community": 24
     },
     {
       "label": "score_text()",
@@ -1089,7 +1089,7 @@
       "source_file": "scripts/knowledge_base/measure_graphify_usage.py",
       "source_location": "L180",
       "id": "measure_graphify_usage_score_text",
-      "community": 23
+      "community": 24
     },
     {
       "label": "aggregate_file_scores()",
@@ -1097,7 +1097,7 @@
       "source_file": "scripts/knowledge_base/measure_graphify_usage.py",
       "source_location": "L195",
       "id": "measure_graphify_usage_aggregate_file_scores",
-      "community": 23
+      "community": 24
     },
     {
       "label": "matched_terms()",
@@ -1105,7 +1105,7 @@
       "source_file": "scripts/knowledge_base/measure_graphify_usage.py",
       "source_location": "L202",
       "id": "measure_graphify_usage_matched_terms",
-      "community": 23
+      "community": 24
     },
     {
       "label": "is_workflow_doc_scenario()",
@@ -1113,7 +1113,7 @@
       "source_file": "scripts/knowledge_base/measure_graphify_usage.py",
       "source_location": "L213",
       "id": "measure_graphify_usage_is_workflow_doc_scenario",
-      "community": 23
+      "community": 24
     },
     {
       "label": "is_workflow_doc_candidate()",
@@ -1121,7 +1121,7 @@
       "source_file": "scripts/knowledge_base/measure_graphify_usage.py",
       "source_location": "L217",
       "id": "measure_graphify_usage_is_workflow_doc_candidate",
-      "community": 23
+      "community": 24
     },
     {
       "label": "workflow_doc_path_boost()",
@@ -1129,7 +1129,7 @@
       "source_file": "scripts/knowledge_base/measure_graphify_usage.py",
       "source_location": "L221",
       "id": "measure_graphify_usage_workflow_doc_path_boost",
-      "community": 23
+      "community": 24
     },
     {
       "label": "workflow_doc_priority_multiplier()",
@@ -1137,7 +1137,7 @@
       "source_file": "scripts/knowledge_base/measure_graphify_usage.py",
       "source_location": "L250",
       "id": "measure_graphify_usage_workflow_doc_priority_multiplier",
-      "community": 23
+      "community": 24
     },
     {
       "label": "augment_workflow_doc_candidates()",
@@ -1145,7 +1145,7 @@
       "source_file": "scripts/knowledge_base/measure_graphify_usage.py",
       "source_location": "L262",
       "id": "measure_graphify_usage_augment_workflow_doc_candidates",
-      "community": 23
+      "community": 24
     },
     {
       "label": "evaluate_relevance()",
@@ -1153,7 +1153,7 @@
       "source_file": "scripts/knowledge_base/measure_graphify_usage.py",
       "source_location": "L292",
       "id": "measure_graphify_usage_evaluate_relevance",
-      "community": 23
+      "community": 24
     },
     {
       "label": "graphify_results()",
@@ -1161,7 +1161,7 @@
       "source_file": "scripts/knowledge_base/measure_graphify_usage.py",
       "source_location": "L307",
       "id": "measure_graphify_usage_graphify_results",
-      "community": 23
+      "community": 24
     },
     {
       "label": "iter_repo_text_files()",
@@ -1169,7 +1169,7 @@
       "source_file": "scripts/knowledge_base/measure_graphify_usage.py",
       "source_location": "L396",
       "id": "measure_graphify_usage_iter_repo_text_files",
-      "community": 23
+      "community": 24
     },
     {
       "label": "baseline_results()",
@@ -1177,7 +1177,7 @@
       "source_file": "scripts/knowledge_base/measure_graphify_usage.py",
       "source_location": "L409",
       "id": "measure_graphify_usage_baseline_results",
-      "community": 23
+      "community": 24
     },
     {
       "label": "build_summary()",
@@ -1185,7 +1185,7 @@
       "source_file": "scripts/knowledge_base/measure_graphify_usage.py",
       "source_location": "L447",
       "id": "measure_graphify_usage_build_summary",
-      "community": 23
+      "community": 24
     },
     {
       "label": "build_trace()",
@@ -1193,7 +1193,7 @@
       "source_file": "scripts/knowledge_base/measure_graphify_usage.py",
       "source_location": "L475",
       "id": "measure_graphify_usage_build_trace",
-      "community": 23
+      "community": 24
     },
     {
       "label": "emit_usage_events()",
@@ -1201,7 +1201,7 @@
       "source_file": "scripts/knowledge_base/measure_graphify_usage.py",
       "source_location": "L484",
       "id": "measure_graphify_usage_emit_usage_events",
-      "community": 23
+      "community": 24
     },
     {
       "label": "write_outputs()",
@@ -1209,7 +1209,7 @@
       "source_file": "scripts/knowledge_base/measure_graphify_usage.py",
       "source_location": "L519",
       "id": "measure_graphify_usage_write_outputs",
-      "community": 23
+      "community": 24
     },
     {
       "label": "main()",
@@ -1217,7 +1217,7 @@
       "source_file": "scripts/knowledge_base/measure_graphify_usage.py",
       "source_location": "L579",
       "id": "measure_graphify_usage_main",
-      "community": 23
+      "community": 24
     },
     {
       "label": "push_graph_to_neo4j.py",
@@ -1281,7 +1281,7 @@
       "source_file": "scripts/knowledge_base/test_graphify_hook_helper.py",
       "source_location": "L1",
       "id": "test_graphify_hook_helper",
-      "community": 19
+      "community": 21
     },
     {
       "label": "TestGraphifyHookHelper",
@@ -1289,7 +1289,7 @@
       "source_file": "scripts/knowledge_base/test_graphify_hook_helper.py",
       "source_location": "L14",
       "id": "test_graphify_hook_helper_testgraphifyhookhelper",
-      "community": 19
+      "community": 21
     },
     {
       "label": ".setUp()",
@@ -1297,7 +1297,7 @@
       "source_file": "scripts/knowledge_base/test_graphify_hook_helper.py",
       "source_location": "L15",
       "id": "test_graphify_hook_helper_testgraphifyhookhelper_setup",
-      "community": 19
+      "community": 21
     },
     {
       "label": ".tearDown()",
@@ -1305,7 +1305,7 @@
       "source_file": "scripts/knowledge_base/test_graphify_hook_helper.py",
       "source_location": "L46",
       "id": "test_graphify_hook_helper_testgraphifyhookhelper_teardown",
-      "community": 19
+      "community": 21
     },
     {
       "label": ".write_manifest()",
@@ -1313,7 +1313,7 @@
       "source_file": "scripts/knowledge_base/test_graphify_hook_helper.py",
       "source_location": "L49",
       "id": "test_graphify_hook_helper_testgraphifyhookhelper_write_manifest",
-      "community": 19
+      "community": 21
     },
     {
       "label": ".args()",
@@ -1321,7 +1321,7 @@
       "source_file": "scripts/knowledge_base/test_graphify_hook_helper.py",
       "source_location": "L52",
       "id": "test_graphify_hook_helper_testgraphifyhookhelper_args",
-      "community": 19
+      "community": 21
     },
     {
       "label": ".test_infers_repo_slug_and_resolves_manifest_paths_from_governance_root()",
@@ -1329,7 +1329,7 @@
       "source_file": "scripts/knowledge_base/test_graphify_hook_helper.py",
       "source_location": "L62",
       "id": "test_graphify_hook_helper_testgraphifyhookhelper_test_infers_repo_slug_and_resolves_manifest_paths_from_governance_root",
-      "community": 19
+      "community": 21
     },
     {
       "label": ".test_accepts_explicit_knocktracker_slug()",
@@ -1337,7 +1337,7 @@
       "source_file": "scripts/knowledge_base/test_graphify_hook_helper.py",
       "source_location": "L73",
       "id": "test_graphify_hook_helper_testgraphifyhookhelper_test_accepts_explicit_knocktracker_slug",
-      "community": 19
+      "community": 21
     },
     {
       "label": ".test_unsafe_product_repo_output_aborts_before_builder_call()",
@@ -1345,7 +1345,7 @@
       "source_file": "scripts/knowledge_base/test_graphify_hook_helper.py",
       "source_location": "L83",
       "id": "test_graphify_hook_helper_testgraphifyhookhelper_test_unsafe_product_repo_output_aborts_before_builder_call",
-      "community": 19
+      "community": 21
     },
     {
       "label": ".test_install_refuses_unmanaged_existing_hooks()",
@@ -1353,7 +1353,7 @@
       "source_file": "scripts/knowledge_base/test_graphify_hook_helper.py",
       "source_location": "L99",
       "id": "test_graphify_hook_helper_testgraphifyhookhelper_test_install_refuses_unmanaged_existing_hooks",
-      "community": 19
+      "community": 21
     },
     {
       "label": ".test_install_backs_up_unmanaged_hook_and_writes_managed_body()",
@@ -1361,7 +1361,7 @@
       "source_file": "scripts/knowledge_base/test_graphify_hook_helper.py",
       "source_location": "L110",
       "id": "test_graphify_hook_helper_testgraphifyhookhelper_test_install_backs_up_unmanaged_hook_and_writes_managed_body",
-      "community": 19
+      "community": 21
     },
     {
       "label": ".test_dry_run_payload_includes_command_and_hook_targets()",
@@ -1369,7 +1369,7 @@
       "source_file": "scripts/knowledge_base/test_graphify_hook_helper.py",
       "source_location": "L126",
       "id": "test_graphify_hook_helper_testgraphifyhookhelper_test_dry_run_payload_includes_command_and_hook_targets",
-      "community": 19
+      "community": 21
     },
     {
       "label": "test_graphify_usage_logging_contract.py",
@@ -1377,7 +1377,7 @@
       "source_file": "scripts/knowledge_base/test_graphify_usage_logging_contract.py",
       "source_location": "L1",
       "id": "test_graphify_usage_logging_contract",
-      "community": 68
+      "community": 69
     },
     {
       "label": "check()",
@@ -1385,7 +1385,7 @@
       "source_file": "scripts/knowledge_base/test_graphify_usage_logging_contract.py",
       "source_location": "L19",
       "id": "test_graphify_usage_logging_contract_check",
-      "community": 68
+      "community": 69
     },
     {
       "label": "run_command()",
@@ -1393,7 +1393,7 @@
       "source_file": "scripts/knowledge_base/test_graphify_usage_logging_contract.py",
       "source_location": "L27",
       "id": "test_graphify_usage_logging_contract_run_command",
-      "community": 68
+      "community": 69
     },
     {
       "label": "test_schema_shape()",
@@ -1401,7 +1401,7 @@
       "source_file": "scripts/knowledge_base/test_graphify_usage_logging_contract.py",
       "source_location": "L31",
       "id": "test_graphify_usage_logging_contract_test_schema_shape",
-      "community": 68
+      "community": 69
     },
     {
       "label": "test_logger_backwards_compatible()",
@@ -1409,7 +1409,7 @@
       "source_file": "scripts/knowledge_base/test_graphify_usage_logging_contract.py",
       "source_location": "L42",
       "id": "test_graphify_usage_logging_contract_test_logger_backwards_compatible",
-      "community": 68
+      "community": 69
     },
     {
       "label": "test_logger_query_trace_fields()",
@@ -1417,7 +1417,7 @@
       "source_file": "scripts/knowledge_base/test_graphify_usage_logging_contract.py",
       "source_location": "L74",
       "id": "test_graphify_usage_logging_contract_test_logger_query_trace_fields",
-      "community": 68
+      "community": 69
     },
     {
       "label": "test_measurement_outputs_query_traces()",
@@ -1425,7 +1425,7 @@
       "source_file": "scripts/knowledge_base/test_graphify_usage_logging_contract.py",
       "source_location": "L128",
       "id": "test_graphify_usage_logging_contract_test_measurement_outputs_query_traces",
-      "community": 68
+      "community": 69
     },
     {
       "label": "test_measurement_falls_back_from_stale_governance_repo_path()",
@@ -1433,7 +1433,7 @@
       "source_file": "scripts/knowledge_base/test_graphify_usage_logging_contract.py",
       "source_location": "L193",
       "id": "test_graphify_usage_logging_contract_test_measurement_falls_back_from_stale_governance_repo_path",
-      "community": 68
+      "community": 69
     },
     {
       "label": "main()",
@@ -1441,7 +1441,7 @@
       "source_file": "scripts/knowledge_base/test_graphify_usage_logging_contract.py",
       "source_location": "L247",
       "id": "test_graphify_usage_logging_contract_main",
-      "community": 68
+      "community": 69
     },
     {
       "label": "update_knowledge_index.py",
@@ -1561,7 +1561,7 @@
       "source_file": "scripts/lam/test_runtime_inventory.py",
       "source_location": "L1",
       "id": "test_runtime_inventory",
-      "community": 46
+      "community": 45
     },
     {
       "label": "FakeResponse",
@@ -1569,7 +1569,7 @@
       "source_file": "scripts/lam/test_runtime_inventory.py",
       "source_location": "L23",
       "id": "test_runtime_inventory_fakeresponse",
-      "community": 46
+      "community": 45
     },
     {
       "label": ".__init__()",
@@ -1577,7 +1577,7 @@
       "source_file": "scripts/lam/test_runtime_inventory.py",
       "source_location": "L24",
       "id": "test_runtime_inventory_fakeresponse_init",
-      "community": 46
+      "community": 45
     },
     {
       "label": ".__enter__()",
@@ -1585,7 +1585,7 @@
       "source_file": "scripts/lam/test_runtime_inventory.py",
       "source_location": "L27",
       "id": "test_runtime_inventory_fakeresponse_enter",
-      "community": 46
+      "community": 45
     },
     {
       "label": ".__exit__()",
@@ -1593,7 +1593,7 @@
       "source_file": "scripts/lam/test_runtime_inventory.py",
       "source_location": "L30",
       "id": "test_runtime_inventory_fakeresponse_exit",
-      "community": 46
+      "community": 45
     },
     {
       "label": ".read()",
@@ -1601,7 +1601,7 @@
       "source_file": "scripts/lam/test_runtime_inventory.py",
       "source_location": "L33",
       "id": "test_runtime_inventory_fakeresponse_read",
-      "community": 46
+      "community": 45
     },
     {
       "label": "TestRuntimeInventory",
@@ -1609,7 +1609,7 @@
       "source_file": "scripts/lam/test_runtime_inventory.py",
       "source_location": "L37",
       "id": "test_runtime_inventory_testruntimeinventory",
-      "community": 46
+      "community": 45
     },
     {
       "label": ".test_windows_timeout_reports_unreachable_without_payloads()",
@@ -1617,7 +1617,7 @@
       "source_file": "scripts/lam/test_runtime_inventory.py",
       "source_location": "L38",
       "id": "test_runtime_inventory_testruntimeinventory_test_windows_timeout_reports_unreachable_without_payloads",
-      "community": 46
+      "community": 45
     },
     {
       "label": ".test_windows_tags_lists_models_without_payloads()",
@@ -1625,7 +1625,7 @@
       "source_file": "scripts/lam/test_runtime_inventory.py",
       "source_location": "L46",
       "id": "test_runtime_inventory_testruntimeinventory_test_windows_tags_lists_models_without_payloads",
-      "community": 46
+      "community": 45
     },
     {
       "label": ".test_pii_guardrail_missing_patterns_fails_closed()",
@@ -1633,7 +1633,7 @@
       "source_file": "scripts/lam/test_runtime_inventory.py",
       "source_location": "L55",
       "id": "test_runtime_inventory_testruntimeinventory_test_pii_guardrail_missing_patterns_fails_closed",
-      "community": 46
+      "community": 45
     },
     {
       "label": ".test_pii_guardrail_happy_path_detects_email_and_allows_clean_probe()",
@@ -1641,7 +1641,7 @@
       "source_file": "scripts/lam/test_runtime_inventory.py",
       "source_location": "L61",
       "id": "test_runtime_inventory_testruntimeinventory_test_pii_guardrail_happy_path_detects_email_and_allows_clean_probe",
-      "community": 46
+      "community": 45
     },
     {
       "label": ".test_inventory_has_no_payload_routing()",
@@ -1649,7 +1649,7 @@
       "source_file": "scripts/lam/test_runtime_inventory.py",
       "source_location": "L68",
       "id": "test_runtime_inventory_testruntimeinventory_test_inventory_has_no_payload_routing",
-      "community": 46
+      "community": 45
     },
     {
       "label": ".test_qwen36_large_worker_is_mac_mlx_on_demand_only()",
@@ -1657,7 +1657,7 @@
       "source_file": "scripts/lam/test_runtime_inventory.py",
       "source_location": "L86",
       "id": "test_runtime_inventory_testruntimeinventory_test_qwen36_large_worker_is_mac_mlx_on_demand_only",
-      "community": 46
+      "community": 45
     },
     {
       "label": ".test_qwen36_config_and_inventory_budget_stay_aligned()",
@@ -1665,7 +1665,7 @@
       "source_file": "scripts/lam/test_runtime_inventory.py",
       "source_location": "L95",
       "id": "test_runtime_inventory_testruntimeinventory_test_qwen36_config_and_inventory_budget_stay_aligned",
-      "community": 46
+      "community": 45
     },
     {
       "label": ".test_local_qwen_ladder_and_gemma_shadow_policy_are_explicit()",
@@ -1673,7 +1673,7 @@
       "source_file": "scripts/lam/test_runtime_inventory.py",
       "source_location": "L103",
       "id": "test_runtime_inventory_testruntimeinventory_test_local_qwen_ladder_and_gemma_shadow_policy_are_explicit",
-      "community": 46
+      "community": 45
     },
     {
       "label": "delegation_gate.py",
@@ -1681,7 +1681,7 @@
       "source_file": "scripts/orchestrator/delegation_gate.py",
       "source_location": "L1",
       "id": "delegation_gate",
-      "community": 34
+      "community": 33
     },
     {
       "label": "OwnerRule",
@@ -1689,7 +1689,7 @@
       "source_file": "scripts/orchestrator/delegation_gate.py",
       "source_location": "L24",
       "id": "delegation_gate_ownerrule",
-      "community": 34
+      "community": 33
     },
     {
       "label": "GateDecision",
@@ -1697,7 +1697,7 @@
       "source_file": "scripts/orchestrator/delegation_gate.py",
       "source_location": "L32",
       "id": "delegation_gate_gatedecision",
-      "community": 34
+      "community": 33
     },
     {
       "label": ".as_dict()",
@@ -1705,7 +1705,7 @@
       "source_file": "scripts/orchestrator/delegation_gate.py",
       "source_location": "L39",
       "id": "delegation_gate_gatedecision_as_dict",
-      "community": 34
+      "community": 33
     },
     {
       "label": "_normalize()",
@@ -1713,7 +1713,7 @@
       "source_file": "scripts/orchestrator/delegation_gate.py",
       "source_location": "L49",
       "id": "delegation_gate_normalize",
-      "community": 34
+      "community": 33
     },
     {
       "label": "_contains_term()",
@@ -1721,7 +1721,7 @@
       "source_file": "scripts/orchestrator/delegation_gate.py",
       "source_location": "L53",
       "id": "delegation_gate_contains_term",
-      "community": 34
+      "community": 33
     },
     {
       "label": "load_rules()",
@@ -1729,7 +1729,7 @@
       "source_file": "scripts/orchestrator/delegation_gate.py",
       "source_location": "L60",
       "id": "delegation_gate_load_rules",
-      "community": 34
+      "community": 33
     },
     {
       "label": "deterministic_match()",
@@ -1737,7 +1737,7 @@
       "source_file": "scripts/orchestrator/delegation_gate.py",
       "source_location": "L93",
       "id": "delegation_gate_deterministic_match",
-      "community": 34
+      "community": 33
     },
     {
       "label": "classifier_match()",
@@ -1745,7 +1745,7 @@
       "source_file": "scripts/orchestrator/delegation_gate.py",
       "source_location": "L118",
       "id": "delegation_gate_classifier_match",
-      "community": 34
+      "community": 33
     },
     {
       "label": "apply_policy()",
@@ -1753,7 +1753,7 @@
       "source_file": "scripts/orchestrator/delegation_gate.py",
       "source_location": "L132",
       "id": "delegation_gate_apply_policy",
-      "community": 34
+      "community": 33
     },
     {
       "label": "decide()",
@@ -1761,7 +1761,7 @@
       "source_file": "scripts/orchestrator/delegation_gate.py",
       "source_location": "L159",
       "id": "delegation_gate_decide",
-      "community": 34
+      "community": 33
     },
     {
       "label": "_load_classifier()",
@@ -1769,7 +1769,7 @@
       "source_file": "scripts/orchestrator/delegation_gate.py",
       "source_location": "L174",
       "id": "delegation_gate_load_classifier",
-      "community": 34
+      "community": 33
     },
     {
       "label": "_run_cli()",
@@ -1777,7 +1777,7 @@
       "source_file": "scripts/orchestrator/delegation_gate.py",
       "source_location": "L183",
       "id": "delegation_gate_run_cli",
-      "community": 34
+      "community": 33
     },
     {
       "label": "hitl_relay_queue.py",
@@ -1785,7 +1785,7 @@
       "source_file": "scripts/orchestrator/hitl_relay_queue.py",
       "source_location": "L1",
       "id": "hitl_relay_queue",
-      "community": 8
+      "community": 10
     },
     {
       "label": "QueueResult",
@@ -1793,7 +1793,7 @@
       "source_file": "scripts/orchestrator/hitl_relay_queue.py",
       "source_location": "L38",
       "id": "hitl_relay_queue_queueresult",
-      "community": 8
+      "community": 10
     },
     {
       "label": "utc_now()",
@@ -1801,7 +1801,7 @@
       "source_file": "scripts/orchestrator/hitl_relay_queue.py",
       "source_location": "L46",
       "id": "hitl_relay_queue_utc_now",
-      "community": 8
+      "community": 10
     },
     {
       "label": "ensure_queue()",
@@ -1809,7 +1809,7 @@
       "source_file": "scripts/orchestrator/hitl_relay_queue.py",
       "source_location": "L50",
       "id": "hitl_relay_queue_ensure_queue",
-      "community": 8
+      "community": 10
     },
     {
       "label": "packet_uuid()",
@@ -1817,7 +1817,7 @@
       "source_file": "scripts/orchestrator/hitl_relay_queue.py",
       "source_location": "L55",
       "id": "hitl_relay_queue_packet_uuid",
-      "community": 8
+      "community": 10
     },
     {
       "label": "atomic_write_json()",
@@ -1825,7 +1825,7 @@
       "source_file": "scripts/orchestrator/hitl_relay_queue.py",
       "source_location": "L59",
       "id": "hitl_relay_queue_atomic_write_json",
-      "community": 8
+      "community": 10
     },
     {
       "label": "append_audit()",
@@ -1833,7 +1833,7 @@
       "source_file": "scripts/orchestrator/hitl_relay_queue.py",
       "source_location": "L67",
       "id": "hitl_relay_queue_append_audit",
-      "community": 8
+      "community": 10
     },
     {
       "label": "load_packet()",
@@ -1841,7 +1841,7 @@
       "source_file": "scripts/orchestrator/hitl_relay_queue.py",
       "source_location": "L74",
       "id": "hitl_relay_queue_load_packet",
-      "community": 8
+      "community": 10
     },
     {
       "label": "_base_packet()",
@@ -1849,7 +1849,7 @@
       "source_file": "scripts/orchestrator/hitl_relay_queue.py",
       "source_location": "L81",
       "id": "hitl_relay_queue_base_packet",
-      "community": 8
+      "community": 10
     },
     {
       "label": "build_request()",
@@ -1857,7 +1857,7 @@
       "source_file": "scripts/orchestrator/hitl_relay_queue.py",
       "source_location": "L108",
       "id": "hitl_relay_queue_build_request",
-      "community": 8
+      "community": 10
     },
     {
       "label": "enqueue_request()",
@@ -1865,7 +1865,7 @@
       "source_file": "scripts/orchestrator/hitl_relay_queue.py",
       "source_location": "L147",
       "id": "hitl_relay_queue_enqueue_request",
-      "community": 8
+      "community": 10
     },
     {
       "label": "process_response()",
@@ -1873,7 +1873,7 @@
       "source_file": "scripts/orchestrator/hitl_relay_queue.py",
       "source_location": "L152",
       "id": "hitl_relay_queue_process_response",
-      "community": 8
+      "community": 10
     },
     {
       "label": "_build_response_packet()",
@@ -1881,7 +1881,7 @@
       "source_file": "scripts/orchestrator/hitl_relay_queue.py",
       "source_location": "L244",
       "id": "hitl_relay_queue_build_response_packet",
-      "community": 8
+      "community": 10
     },
     {
       "label": "_build_decision_packet()",
@@ -1889,7 +1889,7 @@
       "source_file": "scripts/orchestrator/hitl_relay_queue.py",
       "source_location": "L291",
       "id": "hitl_relay_queue_build_decision_packet",
-      "community": 8
+      "community": 10
     },
     {
       "label": "_build_instruction_packet()",
@@ -1897,7 +1897,7 @@
       "source_file": "scripts/orchestrator/hitl_relay_queue.py",
       "source_location": "L307",
       "id": "hitl_relay_queue_build_instruction_packet",
-      "community": 8
+      "community": 10
     },
     {
       "label": "_build_resume_packet()",
@@ -1905,7 +1905,7 @@
       "source_file": "scripts/orchestrator/hitl_relay_queue.py",
       "source_location": "L326",
       "id": "hitl_relay_queue_build_resume_packet",
-      "community": 8
+      "community": 10
     },
     {
       "label": "_validated_write()",
@@ -1913,7 +1913,7 @@
       "source_file": "scripts/orchestrator/hitl_relay_queue.py",
       "source_location": "L346",
       "id": "hitl_relay_queue_validated_write",
-      "community": 8
+      "community": 10
     },
     {
       "label": "_dead_letter()",
@@ -1921,7 +1921,7 @@
       "source_file": "scripts/orchestrator/hitl_relay_queue.py",
       "source_location": "L366",
       "id": "hitl_relay_queue_dead_letter",
-      "community": 8
+      "community": 10
     },
     {
       "label": "replay_audit()",
@@ -1929,7 +1929,7 @@
       "source_file": "scripts/orchestrator/hitl_relay_queue.py",
       "source_location": "L384",
       "id": "hitl_relay_queue_replay_audit",
-      "community": 8
+      "community": 10
     },
     {
       "label": "_run_cli()",
@@ -1937,7 +1937,7 @@
       "source_file": "scripts/orchestrator/hitl_relay_queue.py",
       "source_location": "L400",
       "id": "hitl_relay_queue_run_cli",
-      "community": 8
+      "community": 10
     },
     {
       "label": "packet_queue.py",
@@ -1945,7 +1945,7 @@
       "source_file": "scripts/orchestrator/packet_queue.py",
       "source_location": "L1",
       "id": "packet_queue",
-      "community": 14
+      "community": 15
     },
     {
       "label": "_load_packet_validator()",
@@ -1953,7 +1953,7 @@
       "source_file": "scripts/orchestrator/packet_queue.py",
       "source_location": "L33",
       "id": "packet_queue_load_packet_validator",
-      "community": 14
+      "community": 15
     },
     {
       "label": "QueueDecision",
@@ -1961,7 +1961,7 @@
       "source_file": "scripts/orchestrator/packet_queue.py",
       "source_location": "L47",
       "id": "packet_queue_queuedecision",
-      "community": 14
+      "community": 15
     },
     {
       "label": "utc_now()",
@@ -1969,7 +1969,7 @@
       "source_file": "scripts/orchestrator/packet_queue.py",
       "source_location": "L53",
       "id": "packet_queue_utc_now",
-      "community": 14
+      "community": 15
     },
     {
       "label": "sha256_file()",
@@ -1977,7 +1977,7 @@
       "source_file": "scripts/orchestrator/packet_queue.py",
       "source_location": "L57",
       "id": "packet_queue_sha256_file",
-      "community": 14
+      "community": 15
     },
     {
       "label": "ensure_queue()",
@@ -1985,7 +1985,7 @@
       "source_file": "scripts/orchestrator/packet_queue.py",
       "source_location": "L65",
       "id": "packet_queue_ensure_queue",
-      "community": 14
+      "community": 15
     },
     {
       "label": "load_packet()",
@@ -1993,7 +1993,7 @@
       "source_file": "scripts/orchestrator/packet_queue.py",
       "source_location": "L71",
       "id": "packet_queue_load_packet",
-      "community": 14
+      "community": 15
     },
     {
       "label": "atomic_write_packet()",
@@ -2001,7 +2001,7 @@
       "source_file": "scripts/orchestrator/packet_queue.py",
       "source_location": "L81",
       "id": "packet_queue_atomic_write_packet",
-      "community": 14
+      "community": 15
     },
     {
       "label": "_repo_relative_path()",
@@ -2009,7 +2009,7 @@
       "source_file": "scripts/orchestrator/packet_queue.py",
       "source_location": "L89",
       "id": "packet_queue_repo_relative_path",
-      "community": 14
+      "community": 15
     },
     {
       "label": "_load_plan()",
@@ -2017,7 +2017,7 @@
       "source_file": "scripts/orchestrator/packet_queue.py",
       "source_location": "L100",
       "id": "packet_queue_load_plan",
-      "community": 14
+      "community": 15
     },
     {
       "label": "_validate_fallback_ref()",
@@ -2025,7 +2025,7 @@
       "source_file": "scripts/orchestrator/packet_queue.py",
       "source_location": "L113",
       "id": "packet_queue_validate_fallback_ref",
-      "community": 14
+      "community": 15
     },
     {
       "label": "_validate_execution_scope_ref()",
@@ -2033,7 +2033,7 @@
       "source_file": "scripts/orchestrator/packet_queue.py",
       "source_location": "L124",
       "id": "packet_queue_validate_execution_scope_ref",
-      "community": 14
+      "community": 15
     },
     {
       "label": "_validate_local_refs()",
@@ -2041,7 +2041,7 @@
       "source_file": "scripts/orchestrator/packet_queue.py",
       "source_location": "L147",
       "id": "packet_queue_validate_local_refs",
-      "community": 14
+      "community": 15
     },
     {
       "label": "validate_for_dispatch()",
@@ -2049,7 +2049,7 @@
       "source_file": "scripts/orchestrator/packet_queue.py",
       "source_location": "L156",
       "id": "packet_queue_validate_for_dispatch",
-      "community": 14
+      "community": 15
     },
     {
       "label": "_audit_path()",
@@ -2057,7 +2057,7 @@
       "source_file": "scripts/orchestrator/packet_queue.py",
       "source_location": "L218",
       "id": "packet_queue_audit_path",
-      "community": 14
+      "community": 15
     },
     {
       "label": "append_audit()",
@@ -2065,7 +2065,7 @@
       "source_file": "scripts/orchestrator/packet_queue.py",
       "source_location": "L222",
       "id": "packet_queue_append_audit",
-      "community": 14
+      "community": 15
     },
     {
       "label": "transition_packet()",
@@ -2073,7 +2073,7 @@
       "source_file": "scripts/orchestrator/packet_queue.py",
       "source_location": "L228",
       "id": "packet_queue_transition_packet",
-      "community": 14
+      "community": 15
     },
     {
       "label": "_write_transition_audit()",
@@ -2081,7 +2081,7 @@
       "source_file": "scripts/orchestrator/packet_queue.py",
       "source_location": "L287",
       "id": "packet_queue_write_transition_audit",
-      "community": 14
+      "community": 15
     },
     {
       "label": "replay_audit()",
@@ -2089,7 +2089,7 @@
       "source_file": "scripts/orchestrator/packet_queue.py",
       "source_location": "L316",
       "id": "packet_queue_replay_audit",
-      "community": 14
+      "community": 15
     },
     {
       "label": "_run_cli()",
@@ -2097,7 +2097,7 @@
       "source_file": "scripts/orchestrator/packet_queue.py",
       "source_location": "L348",
       "id": "packet_queue_run_cli",
-      "community": 14
+      "community": 15
     },
     {
       "label": "Replay audit events into logical latest states.      `latest_states` includes ac",
@@ -2105,7 +2105,7 @@
       "source_file": "scripts/orchestrator/packet_queue.py",
       "source_location": "L317",
       "id": "packet_queue_rationale_317",
-      "community": 14
+      "community": 15
     },
     {
       "label": "read_only_observer.py",
@@ -2257,7 +2257,7 @@
       "source_file": "scripts/orchestrator/self_learning.py",
       "source_location": "L1",
       "id": "self_learning",
-      "community": 17
+      "community": 19
     },
     {
       "label": "LearningEntry",
@@ -2265,7 +2265,7 @@
       "source_file": "scripts/orchestrator/self_learning.py",
       "source_location": "L26",
       "id": "self_learning_learningentry",
-      "community": 17
+      "community": 19
     },
     {
       "label": "LearningMatch",
@@ -2273,7 +2273,7 @@
       "source_file": "scripts/orchestrator/self_learning.py",
       "source_location": "L38",
       "id": "self_learning_learningmatch",
-      "community": 17
+      "community": 19
     },
     {
       "label": "utc_now()",
@@ -2281,7 +2281,7 @@
       "source_file": "scripts/orchestrator/self_learning.py",
       "source_location": "L47",
       "id": "self_learning_utc_now",
-      "community": 17
+      "community": 19
     },
     {
       "label": "tokenize()",
@@ -2289,7 +2289,7 @@
       "source_file": "scripts/orchestrator/self_learning.py",
       "source_location": "L51",
       "id": "self_learning_tokenize",
-      "community": 17
+      "community": 19
     },
     {
       "label": "_rel()",
@@ -2297,7 +2297,7 @@
       "source_file": "scripts/orchestrator/self_learning.py",
       "source_location": "L59",
       "id": "self_learning_rel",
-      "community": 17
+      "community": 19
     },
     {
       "label": "_entry_id()",
@@ -2305,7 +2305,7 @@
       "source_file": "scripts/orchestrator/self_learning.py",
       "source_location": "L66",
       "id": "self_learning_entry_id",
-      "community": 17
+      "community": 19
     },
     {
       "label": "_date_from_text()",
@@ -2313,7 +2313,7 @@
       "source_file": "scripts/orchestrator/self_learning.py",
       "source_location": "L70",
       "id": "self_learning_date_from_text",
-      "community": 17
+      "community": 19
     },
     {
       "label": "_markdown_table_fields()",
@@ -2321,7 +2321,7 @@
       "source_file": "scripts/orchestrator/self_learning.py",
       "source_location": "L75",
       "id": "self_learning_markdown_table_fields",
-      "community": 17
+      "community": 19
     },
     {
       "label": "load_fail_fast()",
@@ -2329,7 +2329,7 @@
       "source_file": "scripts/orchestrator/self_learning.py",
       "source_location": "L90",
       "id": "self_learning_load_fail_fast",
-      "community": 17
+      "community": 19
     },
     {
       "label": "load_error_patterns()",
@@ -2337,7 +2337,7 @@
       "source_file": "scripts/orchestrator/self_learning.py",
       "source_location": "L123",
       "id": "self_learning_load_error_patterns",
-      "community": 17
+      "community": 19
     },
     {
       "label": "load_session_error_patterns()",
@@ -2345,7 +2345,7 @@
       "source_file": "scripts/orchestrator/self_learning.py",
       "source_location": "L153",
       "id": "self_learning_load_session_error_patterns",
-      "community": 17
+      "community": 19
     },
     {
       "label": "_section()",
@@ -2353,7 +2353,7 @@
       "source_file": "scripts/orchestrator/self_learning.py",
       "source_location": "L191",
       "id": "self_learning_section",
-      "community": 17
+      "community": 19
     },
     {
       "label": "load_closeouts()",
@@ -2361,7 +2361,7 @@
       "source_file": "scripts/orchestrator/self_learning.py",
       "source_location": "L202",
       "id": "self_learning_load_closeouts",
-      "community": 17
+      "community": 19
     },
     {
       "label": "load_operator_context()",
@@ -2369,7 +2369,7 @@
       "source_file": "scripts/orchestrator/self_learning.py",
       "source_location": "L229",
       "id": "self_learning_load_operator_context",
-      "community": 17
+      "community": 19
     },
     {
       "label": "load_compendium_attention()",
@@ -2377,7 +2377,7 @@
       "source_file": "scripts/orchestrator/self_learning.py",
       "source_location": "L252",
       "id": "self_learning_load_compendium_attention",
-      "community": 17
+      "community": 19
     },
     {
       "label": "load_graph_attention()",
@@ -2385,7 +2385,7 @@
       "source_file": "scripts/orchestrator/self_learning.py",
       "source_location": "L259",
       "id": "self_learning_load_graph_attention",
-      "community": 17
+      "community": 19
     },
     {
       "label": "load_entries()",
@@ -2393,7 +2393,7 @@
       "source_file": "scripts/orchestrator/self_learning.py",
       "source_location": "L266",
       "id": "self_learning_load_entries",
-      "community": 17
+      "community": 19
     },
     {
       "label": "duplicate_counts()",
@@ -2401,7 +2401,7 @@
       "source_file": "scripts/orchestrator/self_learning.py",
       "source_location": "L276",
       "id": "self_learning_duplicate_counts",
-      "community": 17
+      "community": 19
     },
     {
       "label": "lookup_patterns()",
@@ -2409,7 +2409,7 @@
       "source_file": "scripts/orchestrator/self_learning.py",
       "source_location": "L285",
       "id": "self_learning_lookup_patterns",
-      "community": 17
+      "community": 19
     },
     {
       "label": "query_from_packet()",
@@ -2417,7 +2417,7 @@
       "source_file": "scripts/orchestrator/self_learning.py",
       "source_location": "L313",
       "id": "self_learning_query_from_packet",
-      "community": 17
+      "community": 19
     },
     {
       "label": "enrich_packet()",
@@ -2425,7 +2425,7 @@
       "source_file": "scripts/orchestrator/self_learning.py",
       "source_location": "L326",
       "id": "self_learning_enrich_packet",
-      "community": 17
+      "community": 19
     },
     {
       "label": "atomic_write_yaml()",
@@ -2433,7 +2433,7 @@
       "source_file": "scripts/orchestrator/self_learning.py",
       "source_location": "L343",
       "id": "self_learning_atomic_write_yaml",
-      "community": 17
+      "community": 19
     },
     {
       "label": "record_failure()",
@@ -2441,7 +2441,7 @@
       "source_file": "scripts/orchestrator/self_learning.py",
       "source_location": "L350",
       "id": "self_learning_record_failure",
-      "community": 17
+      "community": 19
     },
     {
       "label": "build_report()",
@@ -2449,7 +2449,7 @@
       "source_file": "scripts/orchestrator/self_learning.py",
       "source_location": "L382",
       "id": "self_learning_build_report",
-      "community": 17
+      "community": 19
     },
     {
       "label": "report_markdown()",
@@ -2457,7 +2457,7 @@
       "source_file": "scripts/orchestrator/self_learning.py",
       "source_location": "L415",
       "id": "self_learning_report_markdown",
-      "community": 17
+      "community": 19
     },
     {
       "label": "_run_cli()",
@@ -2465,7 +2465,7 @@
       "source_file": "scripts/orchestrator/self_learning.py",
       "source_location": "L442",
       "id": "self_learning_run_cli",
-      "community": 17
+      "community": 19
     },
     {
       "label": "test_delegation_gate.py",
@@ -2473,7 +2473,7 @@
       "source_file": "scripts/orchestrator/test_delegation_gate.py",
       "source_location": "L1",
       "id": "test_delegation_gate",
-      "community": 34
+      "community": 33
     },
     {
       "label": "test_rules_cover_all_da_delegation_task_types()",
@@ -2481,7 +2481,7 @@
       "source_file": "scripts/orchestrator/test_delegation_gate.py",
       "source_location": "L13",
       "id": "test_delegation_gate_test_rules_cover_all_da_delegation_task_types",
-      "community": 34
+      "community": 33
     },
     {
       "label": "test_high_confidence_agent_owned_work_blocks()",
@@ -2489,7 +2489,7 @@
       "source_file": "scripts/orchestrator/test_delegation_gate.py",
       "source_location": "L29",
       "id": "test_delegation_gate_test_high_confidence_agent_owned_work_blocks",
-      "community": 34
+      "community": 33
     },
     {
       "label": "test_high_confidence_bash_owned_work_blocks()",
@@ -2497,7 +2497,7 @@
       "source_file": "scripts/orchestrator/test_delegation_gate.py",
       "source_location": "L40",
       "id": "test_delegation_gate_test_high_confidence_bash_owned_work_blocks",
-      "community": 34
+      "community": 33
     },
     {
       "label": "test_explore_is_warn_only_for_implementation_scoped_owned_work()",
@@ -2505,7 +2505,7 @@
       "source_file": "scripts/orchestrator/test_delegation_gate.py",
       "source_location": "L50",
       "id": "test_delegation_gate_test_explore_is_warn_only_for_implementation_scoped_owned_work",
-      "community": 34
+      "community": 33
     },
     {
       "label": "test_explore_allows_non_implementation_routing_context()",
@@ -2513,7 +2513,7 @@
       "source_file": "scripts/orchestrator/test_delegation_gate.py",
       "source_location": "L61",
       "id": "test_delegation_gate_test_explore_allows_non_implementation_routing_context",
-      "community": 34
+      "community": 33
     },
     {
       "label": "test_read_is_never_gated()",
@@ -2521,7 +2521,7 @@
       "source_file": "scripts/orchestrator/test_delegation_gate.py",
       "source_location": "L70",
       "id": "test_delegation_gate_test_read_is_never_gated",
-      "community": 34
+      "community": 33
     },
     {
       "label": "test_bypass_flag_allows_and_records_source()",
@@ -2529,7 +2529,7 @@
       "source_file": "scripts/orchestrator/test_delegation_gate.py",
       "source_location": "L80",
       "id": "test_delegation_gate_test_bypass_flag_allows_and_records_source",
-      "community": 34
+      "community": 33
     },
     {
       "label": "test_classifier_fallback_warns_when_rules_are_inconclusive()",
@@ -2537,7 +2537,7 @@
       "source_file": "scripts/orchestrator/test_delegation_gate.py",
       "source_location": "L91",
       "id": "test_delegation_gate_test_classifier_fallback_warns_when_rules_are_inconclusive",
-      "community": 34
+      "community": 33
     },
     {
       "label": "test_delegation_hook.py",
@@ -2633,7 +2633,7 @@
       "source_file": "scripts/orchestrator/test_hitl_relay_final_e2e.py",
       "source_location": "L1",
       "id": "test_hitl_relay_final_e2e",
-      "community": 8
+      "community": 10
     },
     {
       "label": "_final_request()",
@@ -2641,7 +2641,7 @@
       "source_file": "scripts/orchestrator/test_hitl_relay_final_e2e.py",
       "source_location": "L20",
       "id": "test_hitl_relay_final_e2e_final_request",
-      "community": 8
+      "community": 10
     },
     {
       "label": "_process()",
@@ -2649,7 +2649,7 @@
       "source_file": "scripts/orchestrator/test_hitl_relay_final_e2e.py",
       "source_location": "L48",
       "id": "test_hitl_relay_final_e2e_process",
-      "community": 8
+      "community": 10
     },
     {
       "label": "_load()",
@@ -2657,7 +2657,7 @@
       "source_file": "scripts/orchestrator/test_hitl_relay_final_e2e.py",
       "source_location": "L79",
       "id": "test_hitl_relay_final_e2e_load",
-      "community": 8
+      "community": 10
     },
     {
       "label": "test_final_e2e_approval_path_preserves_full_identity_chain()",
@@ -2665,7 +2665,7 @@
       "source_file": "scripts/orchestrator/test_hitl_relay_final_e2e.py",
       "source_location": "L83",
       "id": "test_hitl_relay_final_e2e_test_final_e2e_approval_path_preserves_full_identity_chain",
-      "community": 8
+      "community": 10
     },
     {
       "label": "test_final_e2e_request_changes_is_not_treated_as_approval()",
@@ -2673,7 +2673,7 @@
       "source_file": "scripts/orchestrator/test_hitl_relay_final_e2e.py",
       "source_location": "L127",
       "id": "test_hitl_relay_final_e2e_test_final_e2e_request_changes_is_not_treated_as_approval",
-      "community": 8
+      "community": 10
     },
     {
       "label": "test_final_e2e_ambiguous_response_requests_clarification_without_instruction()",
@@ -2681,7 +2681,7 @@
       "source_file": "scripts/orchestrator/test_hitl_relay_final_e2e.py",
       "source_location": "L147",
       "id": "test_hitl_relay_final_e2e_test_final_e2e_ambiguous_response_requests_clarification_without_instruction",
-      "community": 8
+      "community": 10
     },
     {
       "label": "test_final_e2e_stale_session_creates_resume_instead_of_instruction()",
@@ -2689,7 +2689,7 @@
       "source_file": "scripts/orchestrator/test_hitl_relay_final_e2e.py",
       "source_location": "L166",
       "id": "test_hitl_relay_final_e2e_test_final_e2e_stale_session_creates_resume_instead_of_instruction",
-      "community": 8
+      "community": 10
     },
     {
       "label": "test_final_e2e_duplicate_replay_and_expired_replies_fail_closed()",
@@ -2697,7 +2697,7 @@
       "source_file": "scripts/orchestrator/test_hitl_relay_final_e2e.py",
       "source_location": "L189",
       "id": "test_hitl_relay_final_e2e_test_final_e2e_duplicate_replay_and_expired_replies_fail_closed",
-      "community": 8
+      "community": 10
     },
     {
       "label": "test_final_e2e_external_channel_pii_is_refused_without_instruction()",
@@ -2705,7 +2705,7 @@
       "source_file": "scripts/orchestrator/test_hitl_relay_final_e2e.py",
       "source_location": "L225",
       "id": "test_hitl_relay_final_e2e_test_final_e2e_external_channel_pii_is_refused_without_instruction",
-      "community": 8
+      "community": 10
     },
     {
       "label": "test_hitl_relay_queue.py",
@@ -2713,7 +2713,7 @@
       "source_file": "scripts/orchestrator/test_hitl_relay_queue.py",
       "source_location": "L1",
       "id": "test_hitl_relay_queue",
-      "community": 8
+      "community": 10
     },
     {
       "label": "_request()",
@@ -2721,7 +2721,7 @@
       "source_file": "scripts/orchestrator/test_hitl_relay_queue.py",
       "source_location": "L15",
       "id": "test_hitl_relay_queue_request",
-      "community": 8
+      "community": 10
     },
     {
       "label": "_process()",
@@ -2729,7 +2729,7 @@
       "source_file": "scripts/orchestrator/test_hitl_relay_queue.py",
       "source_location": "L34",
       "id": "test_hitl_relay_queue_process",
-      "community": 8
+      "community": 10
     },
     {
       "label": "test_local_cli_checkpoint_fixture_creates_valid_hitl_request()",
@@ -2737,7 +2737,7 @@
       "source_file": "scripts/orchestrator/test_hitl_relay_queue.py",
       "source_location": "L59",
       "id": "test_hitl_relay_queue_test_local_cli_checkpoint_fixture_creates_valid_hitl_request",
-      "community": 8
+      "community": 10
     },
     {
       "label": "test_valid_approval_response_produces_bounded_session_instruction()",
@@ -2745,7 +2745,7 @@
       "source_file": "scripts/orchestrator/test_hitl_relay_queue.py",
       "source_location": "L72",
       "id": "test_hitl_relay_queue_test_valid_approval_response_produces_bounded_session_instruction",
-      "community": 8
+      "community": 10
     },
     {
       "label": "test_request_changes_response_preserves_feedback_path_without_approval()",
@@ -2753,7 +2753,7 @@
       "source_file": "scripts/orchestrator/test_hitl_relay_queue.py",
       "source_location": "L92",
       "id": "test_hitl_relay_queue_test_request_changes_response_preserves_feedback_path_without_approval",
-      "community": 8
+      "community": 10
     },
     {
       "label": "test_ambiguous_response_produces_clarification_and_no_instruction()",
@@ -2761,7 +2761,7 @@
       "source_file": "scripts/orchestrator/test_hitl_relay_queue.py",
       "source_location": "L107",
       "id": "test_hitl_relay_queue_test_ambiguous_response_produces_clarification_and_no_instruction",
-      "community": 8
+      "community": 10
     },
     {
       "label": "test_stale_session_fixture_produces_resume_packet()",
@@ -2769,7 +2769,7 @@
       "source_file": "scripts/orchestrator/test_hitl_relay_queue.py",
       "source_location": "L121",
       "id": "test_hitl_relay_queue_test_stale_session_fixture_produces_resume_packet",
-      "community": 8
+      "community": 10
     },
     {
       "label": "test_invalid_packet_lands_in_dead_letter_with_validation_errors()",
@@ -2777,7 +2777,7 @@
       "source_file": "scripts/orchestrator/test_hitl_relay_queue.py",
       "source_location": "L137",
       "id": "test_hitl_relay_queue_test_invalid_packet_lands_in_dead_letter_with_validation_errors",
-      "community": 8
+      "community": 10
     },
     {
       "label": "test_expired_response_fails_closed_to_dead_letter()",
@@ -2785,7 +2785,7 @@
       "source_file": "scripts/orchestrator/test_hitl_relay_queue.py",
       "source_location": "L151",
       "id": "test_hitl_relay_queue_test_expired_response_fails_closed_to_dead_letter",
-      "community": 8
+      "community": 10
     },
     {
       "label": "test_replay_reconstructs_decision_path()",
@@ -2793,7 +2793,7 @@
       "source_file": "scripts/orchestrator/test_hitl_relay_queue.py",
       "source_location": "L164",
       "id": "test_hitl_relay_queue_test_replay_reconstructs_decision_path",
-      "community": 8
+      "community": 10
     },
     {
       "label": "test_packet_queue.py",
@@ -2801,7 +2801,7 @@
       "source_file": "scripts/orchestrator/test_packet_queue.py",
       "source_location": "L1",
       "id": "test_packet_queue",
-      "community": 14
+      "community": 15
     },
     {
       "label": "_packet()",
@@ -2809,7 +2809,7 @@
       "source_file": "scripts/orchestrator/test_packet_queue.py",
       "source_location": "L20",
       "id": "test_packet_queue_packet",
-      "community": 14
+      "community": 15
     },
     {
       "label": "TestPacketQueue",
@@ -2817,7 +2817,7 @@
       "source_file": "scripts/orchestrator/test_packet_queue.py",
       "source_location": "L60",
       "id": "test_packet_queue_testpacketqueue",
-      "community": 14
+      "community": 15
     },
     {
       "label": "._write_inbound()",
@@ -2825,7 +2825,7 @@
       "source_file": "scripts/orchestrator/test_packet_queue.py",
       "source_location": "L61",
       "id": "test_packet_queue_testpacketqueue_write_inbound",
-      "community": 14
+      "community": 15
     },
     {
       "label": "._write_execution_scope()",
@@ -2833,7 +2833,7 @@
       "source_file": "scripts/orchestrator/test_packet_queue.py",
       "source_location": "L68",
       "id": "test_packet_queue_testpacketqueue_write_execution_scope",
-      "community": 14
+      "community": 15
     },
     {
       "label": ".test_valid_packet_dry_run_replays_through_queue_without_moving()",
@@ -2841,7 +2841,7 @@
       "source_file": "scripts/orchestrator/test_packet_queue.py",
       "source_location": "L86",
       "id": "test_packet_queue_testpacketqueue_test_valid_packet_dry_run_replays_through_queue_without_moving",
-      "community": 14
+      "community": 15
     },
     {
       "label": ".test_valid_packet_real_dispatch_moves_file()",
@@ -2849,7 +2849,7 @@
       "source_file": "scripts/orchestrator/test_packet_queue.py",
       "source_location": "L116",
       "id": "test_packet_queue_testpacketqueue_test_valid_packet_real_dispatch_moves_file",
-      "community": 14
+      "community": 15
     },
     {
       "label": ".test_invalid_packet_fails_schema_before_dispatch()",
@@ -2857,7 +2857,7 @@
       "source_file": "scripts/orchestrator/test_packet_queue.py",
       "source_location": "L136",
       "id": "test_packet_queue_testpacketqueue_test_invalid_packet_fails_schema_before_dispatch",
-      "community": 14
+      "community": 15
     },
     {
       "label": ".test_pii_packet_halts_before_non_lam_dispatch()",
@@ -2865,7 +2865,7 @@
       "source_file": "scripts/orchestrator/test_packet_queue.py",
       "source_location": "L157",
       "id": "test_packet_queue_testpacketqueue_test_pii_packet_halts_before_non_lam_dispatch",
-      "community": 14
+      "community": 15
     },
     {
       "label": ".test_repeated_known_failure_context_halts_dispatch()",
@@ -2873,7 +2873,7 @@
       "source_file": "scripts/orchestrator/test_packet_queue.py",
       "source_location": "L179",
       "id": "test_packet_queue_testpacketqueue_test_repeated_known_failure_context_halts_dispatch",
-      "community": 14
+      "community": 15
     },
     {
       "label": ".test_pii_halt_reason_takes_precedence_over_known_failure_halt()",
@@ -2881,7 +2881,7 @@
       "source_file": "scripts/orchestrator/test_packet_queue.py",
       "source_location": "L212",
       "id": "test_packet_queue_testpacketqueue_test_pii_halt_reason_takes_precedence_over_known_failure_halt",
-      "community": 14
+      "community": 15
     },
     {
       "label": ".test_dispatch_requires_approved_issue_backed_plan()",
@@ -2889,7 +2889,7 @@
       "source_file": "scripts/orchestrator/test_packet_queue.py",
       "source_location": "L246",
       "id": "test_packet_queue_testpacketqueue_test_dispatch_requires_approved_issue_backed_plan",
-      "community": 14
+      "community": 15
     },
     {
       "label": ".test_dispatch_refuses_schema_valid_packet_without_governance()",
@@ -2897,7 +2897,7 @@
       "source_file": "scripts/orchestrator/test_packet_queue.py",
       "source_location": "L267",
       "id": "test_packet_queue_testpacketqueue_test_dispatch_refuses_schema_valid_packet_without_governance",
-      "community": 14
+      "community": 15
     },
     {
       "label": ".test_dispatch_requires_local_review_artifact_refs_to_exist()",
@@ -2905,7 +2905,7 @@
       "source_file": "scripts/orchestrator/test_packet_queue.py",
       "source_location": "L287",
       "id": "test_packet_queue_testpacketqueue_test_dispatch_requires_local_review_artifact_refs_to_exist",
-      "community": 14
+      "community": 15
     },
     {
       "label": ".test_dispatch_refuses_markdown_execution_scope_ref()",
@@ -2913,7 +2913,7 @@
       "source_file": "scripts/orchestrator/test_packet_queue.py",
       "source_location": "L308",
       "id": "test_packet_queue_testpacketqueue_test_dispatch_refuses_markdown_execution_scope_ref",
-      "community": 14
+      "community": 15
     },
     {
       "label": ".test_dispatch_accepts_json_execution_scope_ref()",
@@ -2921,7 +2921,7 @@
       "source_file": "scripts/orchestrator/test_packet_queue.py",
       "source_location": "L329",
       "id": "test_packet_queue_testpacketqueue_test_dispatch_accepts_json_execution_scope_ref",
-      "community": 14
+      "community": 15
     },
     {
       "label": ".test_replay_counts_refused_events_deterministically()",
@@ -2929,7 +2929,7 @@
       "source_file": "scripts/orchestrator/test_packet_queue.py",
       "source_location": "L360",
       "id": "test_packet_queue_testpacketqueue_test_replay_counts_refused_events_deterministically",
-      "community": 14
+      "community": 15
     },
     {
       "label": ".test_dry_run_authorization_does_not_allow_real_dispatch()",
@@ -2937,7 +2937,7 @@
       "source_file": "scripts/orchestrator/test_packet_queue.py",
       "source_location": "L379",
       "id": "test_packet_queue_testpacketqueue_test_dry_run_authorization_does_not_allow_real_dispatch",
-      "community": 14
+      "community": 15
     },
     {
       "label": "test_read_only_observer.py",
@@ -3001,7 +3001,7 @@
       "source_file": "scripts/orchestrator/test_self_learning.py",
       "source_location": "L1",
       "id": "test_self_learning",
-      "community": 17
+      "community": 19
     },
     {
       "label": "_write_fixture()",
@@ -3009,7 +3009,7 @@
       "source_file": "scripts/orchestrator/test_self_learning.py",
       "source_location": "L17",
       "id": "test_self_learning_write_fixture",
-      "community": 17
+      "community": 19
     },
     {
       "label": "TestSelfLearning",
@@ -3017,7 +3017,7 @@
       "source_file": "scripts/orchestrator/test_self_learning.py",
       "source_location": "L88",
       "id": "test_self_learning_testselflearning",
-      "community": 17
+      "community": 19
     },
     {
       "label": ".test_lookup_returns_cited_prior_patterns()",
@@ -3025,7 +3025,7 @@
       "source_file": "scripts/orchestrator/test_self_learning.py",
       "source_location": "L89",
       "id": "test_self_learning_testselflearning_test_lookup_returns_cited_prior_patterns",
-      "community": 17
+      "community": 19
     },
     {
       "label": ".test_enrich_packet_injects_known_failure_context()",
@@ -3033,7 +3033,7 @@
       "source_file": "scripts/orchestrator/test_self_learning.py",
       "source_location": "L101",
       "id": "test_self_learning_testselflearning_test_enrich_packet_injects_known_failure_context",
-      "community": 17
+      "community": 19
     },
     {
       "label": ".test_session_error_runbook_is_indexed_for_lookup()",
@@ -3041,7 +3041,7 @@
       "source_file": "scripts/orchestrator/test_self_learning.py",
       "source_location": "L119",
       "id": "test_self_learning_testselflearning_test_session_error_runbook_is_indexed_for_lookup",
-      "community": 17
+      "community": 19
     },
     {
       "label": ".test_report_surfaces_session_error_source()",
@@ -3049,7 +3049,7 @@
       "source_file": "scripts/orchestrator/test_self_learning.py",
       "source_location": "L129",
       "id": "test_self_learning_testselflearning_test_report_surfaces_session_error_source",
-      "community": 17
+      "community": 19
     },
     {
       "label": ".test_record_failure_is_append_only_and_issue_backed()",
@@ -3057,7 +3057,7 @@
       "source_file": "scripts/orchestrator/test_self_learning.py",
       "source_location": "L140",
       "id": "test_self_learning_testselflearning_test_record_failure_is_append_only_and_issue_backed",
-      "community": 17
+      "community": 19
     },
     {
       "label": ".test_record_failure_rejects_out_of_range_issue_numbers()",
@@ -3065,7 +3065,7 @@
       "source_file": "scripts/orchestrator/test_self_learning.py",
       "source_location": "L165",
       "id": "test_self_learning_testselflearning_test_record_failure_rejects_out_of_range_issue_numbers",
-      "community": 17
+      "community": 19
     },
     {
       "label": ".test_report_flags_duplicates_and_graphify_attention_only()",
@@ -3073,7 +3073,7 @@
       "source_file": "scripts/orchestrator/test_self_learning.py",
       "source_location": "L187",
       "id": "test_self_learning_testselflearning_test_report_flags_duplicates_and_graphify_attention_only",
-      "community": 17
+      "community": 19
     },
     {
       "label": "assert_execution_scope.py",
@@ -3081,7 +3081,7 @@
       "source_file": "scripts/overlord/assert_execution_scope.py",
       "source_location": "L1",
       "id": "assert_execution_scope",
-      "community": 16
+      "community": 17
     },
     {
       "label": "LaneClaim",
@@ -3089,7 +3089,7 @@
       "source_file": "scripts/overlord/assert_execution_scope.py",
       "source_location": "L16",
       "id": "assert_execution_scope_laneclaim",
-      "community": 16
+      "community": 17
     },
     {
       "label": "HandoffEvidence",
@@ -3097,7 +3097,7 @@
       "source_file": "scripts/overlord/assert_execution_scope.py",
       "source_location": "L24",
       "id": "assert_execution_scope_handoffevidence",
-      "community": 16
+      "community": 17
     },
     {
       "label": "ExecutionScope",
@@ -3105,7 +3105,7 @@
       "source_file": "scripts/overlord/assert_execution_scope.py",
       "source_location": "L35",
       "id": "assert_execution_scope_executionscope",
-      "community": 16
+      "community": 17
     },
     {
       "label": "_run_git()",
@@ -3113,7 +3113,7 @@
       "source_file": "scripts/overlord/assert_execution_scope.py",
       "source_location": "L46",
       "id": "assert_execution_scope_run_git",
-      "community": 16
+      "community": 17
     },
     {
       "label": "_normalize_repo_path()",
@@ -3121,7 +3121,7 @@
       "source_file": "scripts/overlord/assert_execution_scope.py",
       "source_location": "L56",
       "id": "assert_execution_scope_normalize_repo_path",
-      "community": 16
+      "community": 17
     },
     {
       "label": "_normalize_repo_relative_file_path()",
@@ -3129,7 +3129,7 @@
       "source_file": "scripts/overlord/assert_execution_scope.py",
       "source_location": "L62",
       "id": "assert_execution_scope_normalize_repo_relative_file_path",
-      "community": 16
+      "community": 17
     },
     {
       "label": "_normalize_active_exception_ref()",
@@ -3137,7 +3137,7 @@
       "source_file": "scripts/overlord/assert_execution_scope.py",
       "source_location": "L79",
       "id": "assert_execution_scope_normalize_active_exception_ref",
-      "community": 16
+      "community": 17
     },
     {
       "label": "_normalize_evidence_ref()",
@@ -3145,7 +3145,7 @@
       "source_file": "scripts/overlord/assert_execution_scope.py",
       "source_location": "L93",
       "id": "assert_execution_scope_normalize_evidence_ref",
-      "community": 16
+      "community": 17
     },
     {
       "label": "_parse_iso8601_timestamp()",
@@ -3153,7 +3153,7 @@
       "source_file": "scripts/overlord/assert_execution_scope.py",
       "source_location": "L103",
       "id": "assert_execution_scope_parse_iso8601_timestamp",
-      "community": 16
+      "community": 17
     },
     {
       "label": "_load_handoff_evidence()",
@@ -3161,7 +3161,7 @@
       "source_file": "scripts/overlord/assert_execution_scope.py",
       "source_location": "L118",
       "id": "assert_execution_scope_load_handoff_evidence",
-      "community": 16
+      "community": 17
     },
     {
       "label": "_load_lane_claim()",
@@ -3169,7 +3169,7 @@
       "source_file": "scripts/overlord/assert_execution_scope.py",
       "source_location": "L184",
       "id": "assert_execution_scope_load_lane_claim",
-      "community": 16
+      "community": 17
     },
     {
       "label": "_load_scope()",
@@ -3177,7 +3177,7 @@
       "source_file": "scripts/overlord/assert_execution_scope.py",
       "source_location": "L210",
       "id": "assert_execution_scope_load_scope",
-      "community": 16
+      "community": 17
     },
     {
       "label": "_git_root()",
@@ -3185,7 +3185,7 @@
       "source_file": "scripts/overlord/assert_execution_scope.py",
       "source_location": "L291",
       "id": "assert_execution_scope_git_root",
-      "community": 16
+      "community": 17
     },
     {
       "label": "_current_branch()",
@@ -3193,7 +3193,7 @@
       "source_file": "scripts/overlord/assert_execution_scope.py",
       "source_location": "L298",
       "id": "assert_execution_scope_current_branch",
-      "community": 16
+      "community": 17
     },
     {
       "label": "_branch_issue_number()",
@@ -3201,7 +3201,7 @@
       "source_file": "scripts/overlord/assert_execution_scope.py",
       "source_location": "L308",
       "id": "assert_execution_scope_branch_issue_number",
-      "community": 16
+      "community": 17
     },
     {
       "label": "_changed_paths()",
@@ -3209,7 +3209,7 @@
       "source_file": "scripts/overlord/assert_execution_scope.py",
       "source_location": "L313",
       "id": "assert_execution_scope_changed_paths",
-      "community": 16
+      "community": 17
     },
     {
       "label": "_changed_paths_from_file()",
@@ -3217,7 +3217,7 @@
       "source_file": "scripts/overlord/assert_execution_scope.py",
       "source_location": "L341",
       "id": "assert_execution_scope_changed_paths_from_file",
-      "community": 16
+      "community": 17
     },
     {
       "label": "_path_allowed()",
@@ -3225,7 +3225,7 @@
       "source_file": "scripts/overlord/assert_execution_scope.py",
       "source_location": "L352",
       "id": "assert_execution_scope_path_allowed",
-      "community": 16
+      "community": 17
     },
     {
       "label": "_model_family()",
@@ -3233,7 +3233,7 @@
       "source_file": "scripts/overlord/assert_execution_scope.py",
       "source_location": "L356",
       "id": "assert_execution_scope_model_family",
-      "community": 16
+      "community": 17
     },
     {
       "label": "_same_model_or_family()",
@@ -3241,7 +3241,7 @@
       "source_file": "scripts/overlord/assert_execution_scope.py",
       "source_location": "L377",
       "id": "assert_execution_scope_same_model_or_family",
-      "community": 16
+      "community": 17
     },
     {
       "label": "_validate_execution_mode()",
@@ -3249,7 +3249,7 @@
       "source_file": "scripts/overlord/assert_execution_scope.py",
       "source_location": "L383",
       "id": "assert_execution_scope_validate_execution_mode",
-      "community": 16
+      "community": 17
     },
     {
       "label": "_format_path()",
@@ -3257,7 +3257,7 @@
       "source_file": "scripts/overlord/assert_execution_scope.py",
       "source_location": "L413",
       "id": "assert_execution_scope_format_path",
-      "community": 16
+      "community": 17
     },
     {
       "label": "_resolve_expected_execution_root()",
@@ -3265,7 +3265,7 @@
       "source_file": "scripts/overlord/assert_execution_scope.py",
       "source_location": "L417",
       "id": "assert_execution_scope_resolve_expected_execution_root",
-      "community": 16
+      "community": 17
     },
     {
       "label": "_validate_active_exception_ref()",
@@ -3273,7 +3273,7 @@
       "source_file": "scripts/overlord/assert_execution_scope.py",
       "source_location": "L423",
       "id": "assert_execution_scope_validate_active_exception_ref",
-      "community": 16
+      "community": 17
     },
     {
       "label": "_validate_lane_claim()",
@@ -3281,7 +3281,7 @@
       "source_file": "scripts/overlord/assert_execution_scope.py",
       "source_location": "L438",
       "id": "assert_execution_scope_validate_lane_claim",
-      "community": 16
+      "community": 17
     },
     {
       "label": "check_scope()",
@@ -3289,7 +3289,7 @@
       "source_file": "scripts/overlord/assert_execution_scope.py",
       "source_location": "L466",
       "id": "assert_execution_scope_check_scope",
-      "community": 16
+      "community": 17
     },
     {
       "label": "main()",
@@ -3297,7 +3297,7 @@
       "source_file": "scripts/overlord/assert_execution_scope.py",
       "source_location": "L550",
       "id": "assert_execution_scope_main",
-      "community": 16
+      "community": 17
     },
     {
       "label": "automerge_policy_check.py",
@@ -3305,7 +3305,7 @@
       "source_file": "scripts/overlord/automerge_policy_check.py",
       "source_location": "L1",
       "id": "automerge_policy_check",
-      "community": 47
+      "community": 46
     },
     {
       "label": "_labels()",
@@ -3313,7 +3313,7 @@
       "source_file": "scripts/overlord/automerge_policy_check.py",
       "source_location": "L22",
       "id": "automerge_policy_check_labels",
-      "community": 47
+      "community": 46
     },
     {
       "label": "_check_required_checks()",
@@ -3321,7 +3321,7 @@
       "source_file": "scripts/overlord/automerge_policy_check.py",
       "source_location": "L26",
       "id": "automerge_policy_check_check_required_checks",
-      "community": 47
+      "community": 46
     },
     {
       "label": "evaluate()",
@@ -3329,7 +3329,7 @@
       "source_file": "scripts/overlord/automerge_policy_check.py",
       "source_location": "L46",
       "id": "automerge_policy_check_evaluate",
-      "community": 47
+      "community": 46
     },
     {
       "label": "main()",
@@ -3337,7 +3337,7 @@
       "source_file": "scripts/overlord/automerge_policy_check.py",
       "source_location": "L133",
       "id": "automerge_policy_check_main",
-      "community": 47
+      "community": 46
     },
     {
       "label": "build_effectiveness_metrics.py",
@@ -3409,7 +3409,7 @@
       "source_file": "scripts/overlord/build_org_governance_compendium.py",
       "source_location": "L1",
       "id": "build_org_governance_compendium",
-      "community": 35
+      "community": 34
     },
     {
       "label": "RepoInfo",
@@ -3417,7 +3417,7 @@
       "source_file": "scripts/overlord/build_org_governance_compendium.py",
       "source_location": "L94",
       "id": "build_org_governance_compendium_repoinfo",
-      "community": 35
+      "community": 34
     },
     {
       "label": "FileInfo",
@@ -3425,7 +3425,7 @@
       "source_file": "scripts/overlord/build_org_governance_compendium.py",
       "source_location": "L102",
       "id": "build_org_governance_compendium_fileinfo",
-      "community": 35
+      "community": 34
     },
     {
       "label": "run()",
@@ -3433,7 +3433,7 @@
       "source_file": "scripts/overlord/build_org_governance_compendium.py",
       "source_location": "L110",
       "id": "build_org_governance_compendium_run",
-      "community": 35
+      "community": 34
     },
     {
       "label": "tracked_files()",
@@ -3441,7 +3441,7 @@
       "source_file": "scripts/overlord/build_org_governance_compendium.py",
       "source_location": "L117",
       "id": "build_org_governance_compendium_tracked_files",
-      "community": 35
+      "community": 34
     },
     {
       "label": "is_rule_file()",
@@ -3449,7 +3449,7 @@
       "source_file": "scripts/overlord/build_org_governance_compendium.py",
       "source_location": "L124",
       "id": "build_org_governance_compendium_is_rule_file",
-      "community": 35
+      "community": 34
     },
     {
       "label": "read_text()",
@@ -3457,7 +3457,7 @@
       "source_file": "scripts/overlord/build_org_governance_compendium.py",
       "source_location": "L136",
       "id": "build_org_governance_compendium_read_text",
-      "community": 35
+      "community": 34
     },
     {
       "label": "category_for()",
@@ -3465,7 +3465,7 @@
       "source_file": "scripts/overlord/build_org_governance_compendium.py",
       "source_location": "L143",
       "id": "build_org_governance_compendium_category_for",
-      "community": 35
+      "community": 34
     },
     {
       "label": "first_heading()",
@@ -3473,7 +3473,7 @@
       "source_file": "scripts/overlord/build_org_governance_compendium.py",
       "source_location": "L163",
       "id": "build_org_governance_compendium_first_heading",
-      "community": 35
+      "community": 34
     },
     {
       "label": "frontmatter_field()",
@@ -3481,7 +3481,7 @@
       "source_file": "scripts/overlord/build_org_governance_compendium.py",
       "source_location": "L171",
       "id": "build_org_governance_compendium_frontmatter_field",
-      "community": 35
+      "community": 34
     },
     {
       "label": "first_comment()",
@@ -3489,7 +3489,7 @@
       "source_file": "scripts/overlord/build_org_governance_compendium.py",
       "source_location": "L183",
       "id": "build_org_governance_compendium_first_comment",
-      "community": 35
+      "community": 34
     },
     {
       "label": "workflow_logic()",
@@ -3497,7 +3497,7 @@
       "source_file": "scripts/overlord/build_org_governance_compendium.py",
       "source_location": "L195",
       "id": "build_org_governance_compendium_workflow_logic",
-      "community": 35
+      "community": 34
     },
     {
       "label": "settings_logic()",
@@ -3505,7 +3505,7 @@
       "source_file": "scripts/overlord/build_org_governance_compendium.py",
       "source_location": "L221",
       "id": "build_org_governance_compendium_settings_logic",
-      "community": 35
+      "community": 34
     },
     {
       "label": "script_logic()",
@@ -3513,7 +3513,7 @@
       "source_file": "scripts/overlord/build_org_governance_compendium.py",
       "source_location": "L242",
       "id": "build_org_governance_compendium_script_logic",
-      "community": 35
+      "community": 34
     },
     {
       "label": "markdown_logic()",
@@ -3521,7 +3521,7 @@
       "source_file": "scripts/overlord/build_org_governance_compendium.py",
       "source_location": "L253",
       "id": "build_org_governance_compendium_markdown_logic",
-      "community": 35
+      "community": 34
     },
     {
       "label": "describe_file()",
@@ -3529,7 +3529,7 @@
       "source_file": "scripts/overlord/build_org_governance_compendium.py",
       "source_location": "L261",
       "id": "build_org_governance_compendium_describe_file",
-      "community": 35
+      "community": 34
     },
     {
       "label": "schema_logic()",
@@ -3537,7 +3537,7 @@
       "source_file": "scripts/overlord/build_org_governance_compendium.py",
       "source_location": "L285",
       "id": "build_org_governance_compendium_schema_logic",
-      "community": 35
+      "community": 34
     },
     {
       "label": "one_line()",
@@ -3545,7 +3545,7 @@
       "source_file": "scripts/overlord/build_org_governance_compendium.py",
       "source_location": "L298",
       "id": "build_org_governance_compendium_one_line",
-      "community": 35
+      "community": 34
     },
     {
       "label": "esc()",
@@ -3553,7 +3553,7 @@
       "source_file": "scripts/overlord/build_org_governance_compendium.py",
       "source_location": "L304",
       "id": "build_org_governance_compendium_esc",
-      "community": 35
+      "community": 34
     },
     {
       "label": "graph_summary()",
@@ -3561,7 +3561,7 @@
       "source_file": "scripts/overlord/build_org_governance_compendium.py",
       "source_location": "L308",
       "id": "build_org_governance_compendium_graph_summary",
-      "community": 35
+      "community": 34
     },
     {
       "label": "build()",
@@ -3569,7 +3569,7 @@
       "source_file": "scripts/overlord/build_org_governance_compendium.py",
       "source_location": "L350",
       "id": "build_org_governance_compendium_build",
-      "community": 35
+      "community": 34
     },
     {
       "label": "main()",
@@ -3577,7 +3577,7 @@
       "source_file": "scripts/overlord/build_org_governance_compendium.py",
       "source_location": "L434",
       "id": "build_org_governance_compendium_main",
-      "community": 35
+      "community": 34
     },
     {
       "label": "check_execution_environment.py",
@@ -3585,7 +3585,7 @@
       "source_file": "scripts/overlord/check_execution_environment.py",
       "source_location": "L1",
       "id": "check_execution_environment",
-      "community": 16
+      "community": 17
     },
     {
       "label": "main()",
@@ -3593,7 +3593,7 @@
       "source_file": "scripts/overlord/check_execution_environment.py",
       "source_location": "L12",
       "id": "check_execution_environment_main",
-      "community": 16
+      "community": 17
     },
     {
       "label": "check_local_ci_gate_workflow_contract.py",
@@ -3713,7 +3713,7 @@
       "source_file": "scripts/overlord/check_org_repo_inventory.py",
       "source_location": "L1",
       "id": "check_org_repo_inventory",
-      "community": 43
+      "community": 42
     },
     {
       "label": "OrgRepo",
@@ -3721,7 +3721,7 @@
       "source_file": "scripts/overlord/check_org_repo_inventory.py",
       "source_location": "L27",
       "id": "check_org_repo_inventory_orgrepo",
-      "community": 43
+      "community": 42
     },
     {
       "label": "InventoryDrift",
@@ -3729,7 +3729,7 @@
       "source_file": "scripts/overlord/check_org_repo_inventory.py",
       "source_location": "L38",
       "id": "check_org_repo_inventory_inventorydrift",
-      "community": 43
+      "community": 42
     },
     {
       "label": ".has_blocking_drift()",
@@ -3737,7 +3737,7 @@
       "source_file": "scripts/overlord/check_org_repo_inventory.py",
       "source_location": "L44",
       "id": "check_org_repo_inventory_inventorydrift_has_blocking_drift",
-      "community": 43
+      "community": 42
     },
     {
       "label": "_load_json()",
@@ -3745,7 +3745,7 @@
       "source_file": "scripts/overlord/check_org_repo_inventory.py",
       "source_location": "L48",
       "id": "check_org_repo_inventory_load_json",
-      "community": 43
+      "community": 42
     },
     {
       "label": "_inventory_rows_from_payload()",
@@ -3753,7 +3753,7 @@
       "source_file": "scripts/overlord/check_org_repo_inventory.py",
       "source_location": "L52",
       "id": "check_org_repo_inventory_inventory_rows_from_payload",
-      "community": 43
+      "community": 42
     },
     {
       "label": "_default_branch_name()",
@@ -3761,7 +3761,7 @@
       "source_file": "scripts/overlord/check_org_repo_inventory.py",
       "source_location": "L64",
       "id": "check_org_repo_inventory_default_branch_name",
-      "community": 43
+      "community": 42
     },
     {
       "label": "parse_inventory()",
@@ -3769,7 +3769,7 @@
       "source_file": "scripts/overlord/check_org_repo_inventory.py",
       "source_location": "L74",
       "id": "check_org_repo_inventory_parse_inventory",
-      "community": 43
+      "community": 42
     },
     {
       "label": "load_inventory_file()",
@@ -3777,7 +3777,7 @@
       "source_file": "scripts/overlord/check_org_repo_inventory.py",
       "source_location": "L95",
       "id": "check_org_repo_inventory_load_inventory_file",
-      "community": 43
+      "community": 42
     },
     {
       "label": "load_live_inventory()",
@@ -3785,7 +3785,7 @@
       "source_file": "scripts/overlord/check_org_repo_inventory.py",
       "source_location": "L99",
       "id": "check_org_repo_inventory_load_live_inventory",
-      "community": 43
+      "community": 42
     },
     {
       "label": "compare_inventory()",
@@ -3793,7 +3793,7 @@
       "source_file": "scripts/overlord/check_org_repo_inventory.py",
       "source_location": "L114",
       "id": "check_org_repo_inventory_compare_inventory",
-      "community": 43
+      "community": 42
     },
     {
       "label": "render_text()",
@@ -3801,7 +3801,7 @@
       "source_file": "scripts/overlord/check_org_repo_inventory.py",
       "source_location": "L154",
       "id": "check_org_repo_inventory_render_text",
-      "community": 43
+      "community": 42
     },
     {
       "label": "render_markdown()",
@@ -3809,7 +3809,7 @@
       "source_file": "scripts/overlord/check_org_repo_inventory.py",
       "source_location": "L181",
       "id": "check_org_repo_inventory_render_markdown",
-      "community": 43
+      "community": 42
     },
     {
       "label": "_repo_list()",
@@ -3817,7 +3817,7 @@
       "source_file": "scripts/overlord/check_org_repo_inventory.py",
       "source_location": "L211",
       "id": "check_org_repo_inventory_repo_list",
-      "community": 43
+      "community": 42
     },
     {
       "label": "render_json()",
@@ -3825,7 +3825,7 @@
       "source_file": "scripts/overlord/check_org_repo_inventory.py",
       "source_location": "L218",
       "id": "check_org_repo_inventory_render_json",
-      "community": 43
+      "community": 42
     },
     {
       "label": "main()",
@@ -3833,7 +3833,7 @@
       "source_file": "scripts/overlord/check_org_repo_inventory.py",
       "source_location": "L232",
       "id": "check_org_repo_inventory_main",
-      "community": 43
+      "community": 42
     },
     {
       "label": "check_overlord_backlog_github_alignment.py",
@@ -3985,7 +3985,7 @@
       "source_file": "scripts/overlord/check_progress_github_issue_staleness.py",
       "source_location": "L1",
       "id": "check_progress_github_issue_staleness",
-      "community": 45
+      "community": 44
     },
     {
       "label": "IssueRef",
@@ -3993,7 +3993,7 @@
       "source_file": "scripts/overlord/check_progress_github_issue_staleness.py",
       "source_location": "L40",
       "id": "check_progress_github_issue_staleness_issueref",
-      "community": 45
+      "community": 44
     },
     {
       "label": "fail()",
@@ -4001,7 +4001,7 @@
       "source_file": "scripts/overlord/check_progress_github_issue_staleness.py",
       "source_location": "L47",
       "id": "check_progress_github_issue_staleness_fail",
-      "community": 45
+      "community": 44
     },
     {
       "label": "parse_args()",
@@ -4009,7 +4009,7 @@
       "source_file": "scripts/overlord/check_progress_github_issue_staleness.py",
       "source_location": "L52",
       "id": "check_progress_github_issue_staleness_parse_args",
-      "community": 45
+      "community": 44
     },
     {
       "label": "current_repo_slug()",
@@ -4017,7 +4017,7 @@
       "source_file": "scripts/overlord/check_progress_github_issue_staleness.py",
       "source_location": "L60",
       "id": "check_progress_github_issue_staleness_current_repo_slug",
-      "community": 45
+      "community": 44
     },
     {
       "label": "gh_json()",
@@ -4025,7 +4025,7 @@
       "source_file": "scripts/overlord/check_progress_github_issue_staleness.py",
       "source_location": "L69",
       "id": "check_progress_github_issue_staleness_gh_json",
-      "community": 45
+      "community": 44
     },
     {
       "label": "backlog_issues()",
@@ -4033,7 +4033,7 @@
       "source_file": "scripts/overlord/check_progress_github_issue_staleness.py",
       "source_location": "L80",
       "id": "check_progress_github_issue_staleness_backlog_issues",
-      "community": 45
+      "community": 44
     },
     {
       "label": "normalize_heading()",
@@ -4041,7 +4041,7 @@
       "source_file": "scripts/overlord/check_progress_github_issue_staleness.py",
       "source_location": "L107",
       "id": "check_progress_github_issue_staleness_normalize_heading",
-      "community": 45
+      "community": 44
     },
     {
       "label": "section_state()",
@@ -4049,7 +4049,7 @@
       "source_file": "scripts/overlord/check_progress_github_issue_staleness.py",
       "source_location": "L111",
       "id": "check_progress_github_issue_staleness_section_state",
-      "community": 45
+      "community": 44
     },
     {
       "label": "collect_active_issue_refs()",
@@ -4057,7 +4057,7 @@
       "source_file": "scripts/overlord/check_progress_github_issue_staleness.py",
       "source_location": "L119",
       "id": "check_progress_github_issue_staleness_collect_active_issue_refs",
-      "community": 45
+      "community": 44
     },
     {
       "label": "build_summary()",
@@ -4065,7 +4065,7 @@
       "source_file": "scripts/overlord/check_progress_github_issue_staleness.py",
       "source_location": "L138",
       "id": "check_progress_github_issue_staleness_build_summary",
-      "community": 45
+      "community": 44
     },
     {
       "label": "main()",
@@ -4073,7 +4073,7 @@
       "source_file": "scripts/overlord/check_progress_github_issue_staleness.py",
       "source_location": "L167",
       "id": "check_progress_github_issue_staleness_main",
-      "community": 45
+      "community": 44
     },
     {
       "label": "check_stage6_closeout.py",
@@ -4081,87 +4081,87 @@
       "source_file": "scripts/overlord/check_stage6_closeout.py",
       "source_location": "L1",
       "id": "check_stage6_closeout",
-      "community": 32
+      "community": 12
     },
     {
       "label": "CloseoutDecision",
       "file_type": "code",
       "source_file": "scripts/overlord/check_stage6_closeout.py",
-      "source_location": "L50",
+      "source_location": "L53",
       "id": "check_stage6_closeout_closeoutdecision",
-      "community": 32
+      "community": 12
     },
     {
       "label": "_normalize()",
       "file_type": "code",
       "source_file": "scripts/overlord/check_stage6_closeout.py",
-      "source_location": "L58",
+      "source_location": "L61",
       "id": "check_stage6_closeout_normalize",
-      "community": 32
+      "community": 12
     },
     {
       "label": "_read_changed_files()",
       "file_type": "code",
       "source_file": "scripts/overlord/check_stage6_closeout.py",
-      "source_location": "L64",
+      "source_location": "L67",
       "id": "check_stage6_closeout_read_changed_files",
-      "community": 32
+      "community": 12
     },
     {
       "label": "_issue_number()",
       "file_type": "code",
       "source_file": "scripts/overlord/check_stage6_closeout.py",
-      "source_location": "L68",
+      "source_location": "L71",
       "id": "check_stage6_closeout_issue_number",
-      "community": 32
+      "community": 12
     },
     {
       "label": "_is_governance_surface()",
       "file_type": "code",
       "source_file": "scripts/overlord/check_stage6_closeout.py",
-      "source_location": "L73",
+      "source_location": "L76",
       "id": "check_stage6_closeout_is_governance_surface",
-      "community": 32
+      "community": 12
     },
     {
       "label": "_is_planning_only()",
       "file_type": "code",
       "source_file": "scripts/overlord/check_stage6_closeout.py",
-      "source_location": "L77",
+      "source_location": "L80",
       "id": "check_stage6_closeout_is_planning_only",
-      "community": 32
+      "community": 12
     },
     {
       "label": "_matching_closeouts()",
       "file_type": "code",
       "source_file": "scripts/overlord/check_stage6_closeout.py",
-      "source_location": "L81",
+      "source_location": "L84",
       "id": "check_stage6_closeout_matching_closeouts",
-      "community": 32
+      "community": 12
     },
     {
       "label": "evaluate()",
       "file_type": "code",
       "source_file": "scripts/overlord/check_stage6_closeout.py",
-      "source_location": "L90",
+      "source_location": "L93",
       "id": "check_stage6_closeout_evaluate",
-      "community": 32
+      "community": 12
     },
     {
       "label": "build_parser()",
       "file_type": "code",
       "source_file": "scripts/overlord/check_stage6_closeout.py",
-      "source_location": "L136",
+      "source_location": "L139",
       "id": "check_stage6_closeout_build_parser",
-      "community": 32
+      "community": 12
     },
     {
       "label": "main()",
       "file_type": "code",
       "source_file": "scripts/overlord/check_stage6_closeout.py",
-      "source_location": "L144",
+      "source_location": "L147",
       "id": "check_stage6_closeout_main",
-      "community": 32
+      "community": 12
     },
     {
       "label": "check_worker_handoff_route.py",
@@ -4169,7 +4169,7 @@
       "source_file": "scripts/overlord/check_worker_handoff_route.py",
       "source_location": "L1",
       "id": "check_worker_handoff_route",
-      "community": 16
+      "community": 17
     },
     {
       "label": "_normalize_repo_path()",
@@ -4177,7 +4177,7 @@
       "source_file": "scripts/overlord/check_worker_handoff_route.py",
       "source_location": "L29",
       "id": "check_worker_handoff_route_normalize_repo_path",
-      "community": 16
+      "community": 17
     },
     {
       "label": "_actionable_next_step()",
@@ -4185,7 +4185,7 @@
       "source_file": "scripts/overlord/check_worker_handoff_route.py",
       "source_location": "L33",
       "id": "check_worker_handoff_route_actionable_next_step",
-      "community": 16
+      "community": 17
     },
     {
       "label": "_result()",
@@ -4193,7 +4193,7 @@
       "source_file": "scripts/overlord/check_worker_handoff_route.py",
       "source_location": "L44",
       "id": "check_worker_handoff_route_result",
-      "community": 16
+      "community": 17
     },
     {
       "label": "_find_scope()",
@@ -4201,7 +4201,7 @@
       "source_file": "scripts/overlord/check_worker_handoff_route.py",
       "source_location": "L52",
       "id": "check_worker_handoff_route_find_scope",
-      "community": 16
+      "community": 17
     },
     {
       "label": "check_route()",
@@ -4209,7 +4209,7 @@
       "source_file": "scripts/overlord/check_worker_handoff_route.py",
       "source_location": "L64",
       "id": "check_worker_handoff_route_check_route",
-      "community": 16
+      "community": 17
     },
     {
       "label": "parse_args()",
@@ -4217,7 +4217,7 @@
       "source_file": "scripts/overlord/check_worker_handoff_route.py",
       "source_location": "L142",
       "id": "check_worker_handoff_route_parse_args",
-      "community": 16
+      "community": 17
     },
     {
       "label": "main()",
@@ -4225,7 +4225,7 @@
       "source_file": "scripts/overlord/check_worker_handoff_route.py",
       "source_location": "L152",
       "id": "check_worker_handoff_route_main",
-      "community": 16
+      "community": 17
     },
     {
       "label": "check_workflow_local_coverage.py",
@@ -4233,7 +4233,7 @@
       "source_file": "scripts/overlord/check_workflow_local_coverage.py",
       "source_location": "L1",
       "id": "check_workflow_local_coverage",
-      "community": 36
+      "community": 35
     },
     {
       "label": "_normalize_path()",
@@ -4241,7 +4241,7 @@
       "source_file": "scripts/overlord/check_workflow_local_coverage.py",
       "source_location": "L17",
       "id": "check_workflow_local_coverage_normalize_path",
-      "community": 36
+      "community": 35
     },
     {
       "label": "_load_inventory()",
@@ -4249,7 +4249,7 @@
       "source_file": "scripts/overlord/check_workflow_local_coverage.py",
       "source_location": "L23",
       "id": "check_workflow_local_coverage_load_inventory",
-      "community": 36
+      "community": 35
     },
     {
       "label": "_actual_workflows()",
@@ -4257,7 +4257,7 @@
       "source_file": "scripts/overlord/check_workflow_local_coverage.py",
       "source_location": "L27",
       "id": "check_workflow_local_coverage_actual_workflows",
-      "community": 36
+      "community": 35
     },
     {
       "label": "_command_file_candidates()",
@@ -4265,7 +4265,7 @@
       "source_file": "scripts/overlord/check_workflow_local_coverage.py",
       "source_location": "L36",
       "id": "check_workflow_local_coverage_command_file_candidates",
-      "community": 36
+      "community": 35
     },
     {
       "label": "_validate_coverage()",
@@ -4273,7 +4273,7 @@
       "source_file": "scripts/overlord/check_workflow_local_coverage.py",
       "source_location": "L49",
       "id": "check_workflow_local_coverage_validate_coverage",
-      "community": 36
+      "community": 35
     },
     {
       "label": "_validate_required_snippets()",
@@ -4281,7 +4281,7 @@
       "source_file": "scripts/overlord/check_workflow_local_coverage.py",
       "source_location": "L95",
       "id": "check_workflow_local_coverage_validate_required_snippets",
-      "community": 36
+      "community": 35
     },
     {
       "label": "check_inventory()",
@@ -4289,7 +4289,7 @@
       "source_file": "scripts/overlord/check_workflow_local_coverage.py",
       "source_location": "L110",
       "id": "check_workflow_local_coverage_check_inventory",
-      "community": 36
+      "community": 35
     },
     {
       "label": "main()",
@@ -4297,7 +4297,7 @@
       "source_file": "scripts/overlord/check_workflow_local_coverage.py",
       "source_location": "L160",
       "id": "check_workflow_local_coverage_main",
-      "community": 36
+      "community": 35
     },
     {
       "label": "codex_ingestion.py",
@@ -4305,7 +4305,7 @@
       "source_file": "scripts/overlord/codex_ingestion.py",
       "source_location": "L1",
       "id": "codex_ingestion",
-      "community": 9
+      "community": 13
     },
     {
       "label": "Finding",
@@ -4313,7 +4313,7 @@
       "source_file": "scripts/overlord/codex_ingestion.py",
       "source_location": "L61",
       "id": "codex_ingestion_finding",
-      "community": 9
+      "community": 13
     },
     {
       "label": "priority()",
@@ -4321,7 +4321,7 @@
       "source_file": "scripts/overlord/codex_ingestion.py",
       "source_location": "L72",
       "id": "codex_ingestion_priority",
-      "community": 9
+      "community": 13
     },
     {
       "label": "fail_fast_severity()",
@@ -4329,7 +4329,7 @@
       "source_file": "scripts/overlord/codex_ingestion.py",
       "source_location": "L80",
       "id": "codex_ingestion_fail_fast_severity",
-      "community": 9
+      "community": 13
     },
     {
       "label": "est_hours()",
@@ -4337,7 +4337,7 @@
       "source_file": "scripts/overlord/codex_ingestion.py",
       "source_location": "L90",
       "id": "codex_ingestion_est_hours",
-      "community": 9
+      "community": 13
     },
     {
       "label": "today_string()",
@@ -4345,7 +4345,7 @@
       "source_file": "scripts/overlord/codex_ingestion.py",
       "source_location": "L102",
       "id": "codex_ingestion_today_string",
-      "community": 9
+      "community": 13
     },
     {
       "label": "run()",
@@ -4353,7 +4353,7 @@
       "source_file": "scripts/overlord/codex_ingestion.py",
       "source_location": "L111",
       "id": "codex_ingestion_run",
-      "community": 9
+      "community": 13
     },
     {
       "label": "load_json()",
@@ -4361,7 +4361,7 @@
       "source_file": "scripts/overlord/codex_ingestion.py",
       "source_location": "L115",
       "id": "codex_ingestion_load_json",
-      "community": 9
+      "community": 13
     },
     {
       "label": "write_json()",
@@ -4369,7 +4369,7 @@
       "source_file": "scripts/overlord/codex_ingestion.py",
       "source_location": "L120",
       "id": "codex_ingestion_write_json",
-      "community": 9
+      "community": 13
     },
     {
       "label": "extract_json_from_stdout()",
@@ -4377,7 +4377,7 @@
       "source_file": "scripts/overlord/codex_ingestion.py",
       "source_location": "L125",
       "id": "codex_ingestion_extract_json_from_stdout",
-      "community": 9
+      "community": 13
     },
     {
       "label": "summarize_failure_output()",
@@ -4385,7 +4385,7 @@
       "source_file": "scripts/overlord/codex_ingestion.py",
       "source_location": "L139",
       "id": "codex_ingestion_summarize_failure_output",
-      "community": 9
+      "community": 13
     },
     {
       "label": "skip_payload()",
@@ -4393,7 +4393,7 @@
       "source_file": "scripts/overlord/codex_ingestion.py",
       "source_location": "L170",
       "id": "codex_ingestion_skip_payload",
-      "community": 9
+      "community": 13
     },
     {
       "label": "list_backlog_files()",
@@ -4401,7 +4401,7 @@
       "source_file": "scripts/overlord/codex_ingestion.py",
       "source_location": "L174",
       "id": "codex_ingestion_list_backlog_files",
-      "community": 9
+      "community": 13
     },
     {
       "label": "git_lines()",
@@ -4409,7 +4409,7 @@
       "source_file": "scripts/overlord/codex_ingestion.py",
       "source_location": "L181",
       "id": "codex_ingestion_git_lines",
-      "community": 9
+      "community": 13
     },
     {
       "label": "bounded_text()",
@@ -4417,7 +4417,7 @@
       "source_file": "scripts/overlord/codex_ingestion.py",
       "source_location": "L186",
       "id": "codex_ingestion_bounded_text",
-      "community": 9
+      "community": 13
     },
     {
       "label": "build_review_context()",
@@ -4425,7 +4425,7 @@
       "source_file": "scripts/overlord/codex_ingestion.py",
       "source_location": "L193",
       "id": "codex_ingestion_build_review_context",
-      "community": 9
+      "community": 13
     },
     {
       "label": "build_schema_file()",
@@ -4433,7 +4433,7 @@
       "source_file": "scripts/overlord/codex_ingestion.py",
       "source_location": "L221",
       "id": "codex_ingestion_build_schema_file",
-      "community": 9
+      "community": 13
     },
     {
       "label": "normalize_review()",
@@ -4441,7 +4441,7 @@
       "source_file": "scripts/overlord/codex_ingestion.py",
       "source_location": "L286",
       "id": "codex_ingestion_normalize_review",
-      "community": 9
+      "community": 13
     },
     {
       "label": "classify_finding()",
@@ -4449,7 +4449,7 @@
       "source_file": "scripts/overlord/codex_ingestion.py",
       "source_location": "L319",
       "id": "codex_ingestion_classify_finding",
-      "community": 9
+      "community": 13
     },
     {
       "label": "detect_duplicate()",
@@ -4457,7 +4457,7 @@
       "source_file": "scripts/overlord/codex_ingestion.py",
       "source_location": "L327",
       "id": "codex_ingestion_detect_duplicate",
-      "community": 9
+      "community": 13
     },
     {
       "label": "validate_location()",
@@ -4465,7 +4465,7 @@
       "source_file": "scripts/overlord/codex_ingestion.py",
       "source_location": "L343",
       "id": "codex_ingestion_validate_location",
-      "community": 9
+      "community": 13
     },
     {
       "label": "extract_claim_anchors()",
@@ -4473,7 +4473,7 @@
       "source_file": "scripts/overlord/codex_ingestion.py",
       "source_location": "L364",
       "id": "codex_ingestion_extract_claim_anchors",
-      "community": 9
+      "community": 13
     },
     {
       "label": "looks_like_camel_identifier()",
@@ -4481,7 +4481,7 @@
       "source_file": "scripts/overlord/codex_ingestion.py",
       "source_location": "L384",
       "id": "codex_ingestion_looks_like_camel_identifier",
-      "community": 9
+      "community": 13
     },
     {
       "label": "read_context_window()",
@@ -4489,7 +4489,7 @@
       "source_file": "scripts/overlord/codex_ingestion.py",
       "source_location": "L392",
       "id": "codex_ingestion_read_context_window",
-      "community": 9
+      "community": 13
     },
     {
       "label": "context_matches_anchors()",
@@ -4497,7 +4497,7 @@
       "source_file": "scripts/overlord/codex_ingestion.py",
       "source_location": "L398",
       "id": "codex_ingestion_context_matches_anchors",
-      "community": 9
+      "community": 13
     },
     {
       "label": "markdown_escape()",
@@ -4505,7 +4505,7 @@
       "source_file": "scripts/overlord/codex_ingestion.py",
       "source_location": "L405",
       "id": "codex_ingestion_markdown_escape",
-      "community": 9
+      "community": 13
     },
     {
       "label": "find_section_span()",
@@ -4513,7 +4513,7 @@
       "source_file": "scripts/overlord/codex_ingestion.py",
       "source_location": "L409",
       "id": "codex_ingestion_find_section_span",
-      "community": 9
+      "community": 13
     },
     {
       "label": "append_progress_candidate()",
@@ -4521,7 +4521,7 @@
       "source_file": "scripts/overlord/codex_ingestion.py",
       "source_location": "L420",
       "id": "codex_ingestion_append_progress_candidate",
-      "community": 9
+      "community": 13
     },
     {
       "label": "append_fail_fast_candidate()",
@@ -4529,7 +4529,7 @@
       "source_file": "scripts/overlord/codex_ingestion.py",
       "source_location": "L448",
       "id": "codex_ingestion_append_fail_fast_candidate",
-      "community": 9
+      "community": 13
     },
     {
       "label": "append_fail_fast_table_entry()",
@@ -4537,7 +4537,7 @@
       "source_file": "scripts/overlord/codex_ingestion.py",
       "source_location": "L455",
       "id": "codex_ingestion_append_fail_fast_table_entry",
-      "community": 9
+      "community": 13
     },
     {
       "label": "append_fail_fast_block_entry()",
@@ -4545,7 +4545,7 @@
       "source_file": "scripts/overlord/codex_ingestion.py",
       "source_location": "L478",
       "id": "codex_ingestion_append_fail_fast_block_entry",
-      "community": 9
+      "community": 13
     },
     {
       "label": "build_parser()",
@@ -4553,7 +4553,7 @@
       "source_file": "scripts/overlord/codex_ingestion.py",
       "source_location": "L500",
       "id": "codex_ingestion_build_parser",
-      "community": 9
+      "community": 13
     },
     {
       "label": "cmd_status()",
@@ -4561,7 +4561,7 @@
       "source_file": "scripts/overlord/codex_ingestion.py",
       "source_location": "L527",
       "id": "codex_ingestion_cmd_status",
-      "community": 9
+      "community": 13
     },
     {
       "label": "cmd_generate()",
@@ -4569,7 +4569,7 @@
       "source_file": "scripts/overlord/codex_ingestion.py",
       "source_location": "L541",
       "id": "codex_ingestion_cmd_generate",
-      "community": 9
+      "community": 13
     },
     {
       "label": "cmd_qualify()",
@@ -4577,7 +4577,7 @@
       "source_file": "scripts/overlord/codex_ingestion.py",
       "source_location": "L657",
       "id": "codex_ingestion_cmd_qualify",
-      "community": 9
+      "community": 13
     },
     {
       "label": "cmd_promote()",
@@ -4585,7 +4585,7 @@
       "source_file": "scripts/overlord/codex_ingestion.py",
       "source_location": "L831",
       "id": "codex_ingestion_cmd_promote",
-      "community": 9
+      "community": 13
     },
     {
       "label": "main()",
@@ -4593,7 +4593,7 @@
       "source_file": "scripts/overlord/codex_ingestion.py",
       "source_location": "L888",
       "id": "codex_ingestion_main",
-      "community": 9
+      "community": 13
     },
     {
       "label": "deploy_governance_tooling.py",
@@ -4601,231 +4601,263 @@
       "source_file": "scripts/overlord/deploy_governance_tooling.py",
       "source_location": "L1",
       "id": "deploy_governance_tooling",
-      "community": 24
+      "community": 5
     },
     {
       "label": "GovernanceDeployError",
       "file_type": "code",
       "source_file": "scripts/overlord/deploy_governance_tooling.py",
-      "source_location": "L22",
+      "source_location": "L23",
       "id": "deploy_governance_tooling_governancedeployerror",
-      "community": 24
+      "community": 5
     },
     {
       "label": "ToolingPlan",
       "file_type": "code",
       "source_file": "scripts/overlord/deploy_governance_tooling.py",
-      "source_location": "L27",
+      "source_location": "L28",
       "id": "deploy_governance_tooling_toolingplan",
-      "community": 24
+      "community": 5
     },
     {
       "label": ".managed_files()",
       "file_type": "code",
       "source_file": "scripts/overlord/deploy_governance_tooling.py",
-      "source_location": "L40",
+      "source_location": "L41",
       "id": "deploy_governance_tooling_toolingplan_managed_files",
-      "community": 24
+      "community": 5
     },
     {
       "label": ".planned_write_set()",
       "file_type": "code",
       "source_file": "scripts/overlord/deploy_governance_tooling.py",
-      "source_location": "L54",
+      "source_location": "L53",
       "id": "deploy_governance_tooling_toolingplan_planned_write_set",
-      "community": 24
+      "community": 5
     },
     {
       "label": ".planned_rollback_set()",
       "file_type": "code",
       "source_file": "scripts/overlord/deploy_governance_tooling.py",
-      "source_location": "L57",
+      "source_location": "L56",
       "id": "deploy_governance_tooling_toolingplan_planned_rollback_set",
-      "community": 24
+      "community": 5
     },
     {
       "label": ".to_json()",
       "file_type": "code",
       "source_file": "scripts/overlord/deploy_governance_tooling.py",
-      "source_location": "L60",
+      "source_location": "L59",
       "id": "deploy_governance_tooling_toolingplan_to_json",
-      "community": 24
+      "community": 5
     },
     {
       "label": "_fail()",
       "file_type": "code",
       "source_file": "scripts/overlord/deploy_governance_tooling.py",
-      "source_location": "L79",
+      "source_location": "L78",
       "id": "deploy_governance_tooling_fail",
-      "community": 24
+      "community": 5
     },
     {
       "label": "_run_git()",
       "file_type": "code",
       "source_file": "scripts/overlord/deploy_governance_tooling.py",
-      "source_location": "L83",
+      "source_location": "L82",
       "id": "deploy_governance_tooling_run_git",
-      "community": 24
+      "community": 5
     },
     {
       "label": "_git_root()",
       "file_type": "code",
       "source_file": "scripts/overlord/deploy_governance_tooling.py",
-      "source_location": "L87",
+      "source_location": "L86",
       "id": "deploy_governance_tooling_git_root",
-      "community": 24
+      "community": 5
     },
     {
       "label": "_git_is_dirty()",
       "file_type": "code",
       "source_file": "scripts/overlord/deploy_governance_tooling.py",
-      "source_location": "L94",
+      "source_location": "L93",
       "id": "deploy_governance_tooling_git_is_dirty",
-      "community": 24
+      "community": 5
     },
     {
       "label": "_git_head()",
       "file_type": "code",
       "source_file": "scripts/overlord/deploy_governance_tooling.py",
-      "source_location": "L101",
+      "source_location": "L100",
       "id": "deploy_governance_tooling_git_head",
-      "community": 24
+      "community": 5
     },
     {
       "label": "_load_manifest()",
       "file_type": "code",
       "source_file": "scripts/overlord/deploy_governance_tooling.py",
-      "source_location": "L108",
+      "source_location": "L107",
       "id": "deploy_governance_tooling_load_manifest",
-      "community": 24
+      "community": 5
+    },
+    {
+      "label": "_load_json()",
+      "file_type": "code",
+      "source_file": "scripts/overlord/deploy_governance_tooling.py",
+      "source_location": "L117",
+      "id": "deploy_governance_tooling_load_json",
+      "community": 5
     },
     {
       "label": "_consumer_record_relpath()",
       "file_type": "code",
       "source_file": "scripts/overlord/deploy_governance_tooling.py",
-      "source_location": "L118",
+      "source_location": "L127",
       "id": "deploy_governance_tooling_consumer_record_relpath",
-      "community": 24
+      "community": 5
+    },
+    {
+      "label": "_profile_desired_state()",
+      "file_type": "code",
+      "source_file": "scripts/overlord/deploy_governance_tooling.py",
+      "source_location": "L136",
+      "id": "deploy_governance_tooling_profile_desired_state",
+      "community": 5
     },
     {
       "label": "_package_version()",
       "file_type": "code",
       "source_file": "scripts/overlord/deploy_governance_tooling.py",
-      "source_location": "L127",
+      "source_location": "L144",
       "id": "deploy_governance_tooling_package_version",
-      "community": 24
+      "community": 5
+    },
+    {
+      "label": "_managed_file_contract_entries()",
+      "file_type": "code",
+      "source_file": "scripts/overlord/deploy_governance_tooling.py",
+      "source_location": "L164",
+      "id": "deploy_governance_tooling_managed_file_contract_entries",
+      "community": 5
+    },
+    {
+      "label": "_profile_constraints()",
+      "file_type": "code",
+      "source_file": "scripts/overlord/deploy_governance_tooling.py",
+      "source_location": "L207",
+      "id": "deploy_governance_tooling_profile_constraints",
+      "community": 5
     },
     {
       "label": "_record_state()",
       "file_type": "code",
       "source_file": "scripts/overlord/deploy_governance_tooling.py",
-      "source_location": "L138",
+      "source_location": "L215",
       "id": "deploy_governance_tooling_record_state",
-      "community": 24
+      "community": 5
     },
     {
       "label": "_ensure_relative_to()",
       "file_type": "code",
       "source_file": "scripts/overlord/deploy_governance_tooling.py",
-      "source_location": "L152",
+      "source_location": "L229",
       "id": "deploy_governance_tooling_ensure_relative_to",
-      "community": 24
+      "community": 5
     },
     {
       "label": "_build_local_ci_plan()",
       "file_type": "code",
       "source_file": "scripts/overlord/deploy_governance_tooling.py",
-      "source_location": "L159",
+      "source_location": "L236",
       "id": "deploy_governance_tooling_build_local_ci_plan",
-      "community": 24
+      "community": 5
     },
     {
       "label": "build_plan()",
       "file_type": "code",
       "source_file": "scripts/overlord/deploy_governance_tooling.py",
-      "source_location": "L170",
+      "source_location": "L247",
       "id": "deploy_governance_tooling_build_plan",
-      "community": 24
+      "community": 5
     },
     {
       "label": "_refuse_dirty()",
       "file_type": "code",
       "source_file": "scripts/overlord/deploy_governance_tooling.py",
-      "source_location": "L201",
+      "source_location": "L279",
       "id": "deploy_governance_tooling_refuse_dirty",
-      "community": 24
+      "community": 5
     },
     {
       "label": "_refuse_unmanaged_record()",
       "file_type": "code",
       "source_file": "scripts/overlord/deploy_governance_tooling.py",
-      "source_location": "L206",
+      "source_location": "L284",
       "id": "deploy_governance_tooling_refuse_unmanaged_record",
-      "community": 24
+      "community": 5
     },
     {
       "label": "_consumer_record()",
       "file_type": "code",
       "source_file": "scripts/overlord/deploy_governance_tooling.py",
-      "source_location": "L211",
+      "source_location": "L289",
       "id": "deploy_governance_tooling_consumer_record",
-      "community": 24
+      "community": 5
     },
     {
       "label": "apply()",
       "file_type": "code",
       "source_file": "scripts/overlord/deploy_governance_tooling.py",
-      "source_location": "L238",
+      "source_location": "L322",
       "id": "deploy_governance_tooling_apply",
-      "community": 24
+      "community": 5
     },
     {
       "label": "verify()",
       "file_type": "code",
       "source_file": "scripts/overlord/deploy_governance_tooling.py",
-      "source_location": "L248",
+      "source_location": "L332",
       "id": "deploy_governance_tooling_verify",
-      "community": 24
+      "community": 5
     },
     {
       "label": "_required_record_fields()",
       "file_type": "code",
       "source_file": "scripts/overlord/deploy_governance_tooling.py",
-      "source_location": "L277",
+      "source_location": "L361",
       "id": "deploy_governance_tooling_required_record_fields",
-      "community": 24
+      "community": 5
     },
     {
       "label": "rollback()",
       "file_type": "code",
       "source_file": "scripts/overlord/deploy_governance_tooling.py",
-      "source_location": "L299",
+      "source_location": "L383",
       "id": "deploy_governance_tooling_rollback",
-      "community": 24
+      "community": 5
     },
     {
       "label": "print_json()",
       "file_type": "code",
       "source_file": "scripts/overlord/deploy_governance_tooling.py",
-      "source_location": "L327",
+      "source_location": "L411",
       "id": "deploy_governance_tooling_print_json",
-      "community": 24
+      "community": 5
     },
     {
       "label": "add_common_args()",
       "file_type": "code",
       "source_file": "scripts/overlord/deploy_governance_tooling.py",
-      "source_location": "L332",
+      "source_location": "L416",
       "id": "deploy_governance_tooling_add_common_args",
-      "community": 24
+      "community": 5
     },
     {
       "label": "main()",
       "file_type": "code",
       "source_file": "scripts/overlord/deploy_governance_tooling.py",
-      "source_location": "L342",
+      "source_location": "L426",
       "id": "deploy_governance_tooling_main",
-      "community": 24
+      "community": 5
     },
     {
       "label": "deploy_local_ci_gate.py",
@@ -4833,7 +4865,7 @@
       "source_file": "scripts/overlord/deploy_local_ci_gate.py",
       "source_location": "L1",
       "id": "deploy_local_ci_gate",
-      "community": 40
+      "community": 5
     },
     {
       "label": "DeployError",
@@ -4841,7 +4873,7 @@
       "source_file": "scripts/overlord/deploy_local_ci_gate.py",
       "source_location": "L23",
       "id": "deploy_local_ci_gate_deployerror",
-      "community": 40
+      "community": 5
     },
     {
       "label": "DeployPlan",
@@ -4849,7 +4881,7 @@
       "source_file": "scripts/overlord/deploy_local_ci_gate.py",
       "source_location": "L28",
       "id": "deploy_local_ci_gate_deployplan",
-      "community": 40
+      "community": 5
     },
     {
       "label": ".planned_write_set()",
@@ -4857,7 +4889,7 @@
       "source_file": "scripts/overlord/deploy_local_ci_gate.py",
       "source_location": "L38",
       "id": "deploy_local_ci_gate_deployplan_planned_write_set",
-      "community": 40
+      "community": 5
     },
     {
       "label": ".to_json()",
@@ -4865,7 +4897,7 @@
       "source_file": "scripts/overlord/deploy_local_ci_gate.py",
       "source_location": "L45",
       "id": "deploy_local_ci_gate_deployplan_to_json",
-      "community": 40
+      "community": 5
     },
     {
       "label": "_fail()",
@@ -4873,7 +4905,7 @@
       "source_file": "scripts/overlord/deploy_local_ci_gate.py",
       "source_location": "L62",
       "id": "deploy_local_ci_gate_fail",
-      "community": 40
+      "community": 5
     },
     {
       "label": "_is_relative_to()",
@@ -4881,7 +4913,7 @@
       "source_file": "scripts/overlord/deploy_local_ci_gate.py",
       "source_location": "L66",
       "id": "deploy_local_ci_gate_is_relative_to",
-      "community": 40
+      "community": 5
     },
     {
       "label": "_existing_shim_state()",
@@ -4889,7 +4921,7 @@
       "source_file": "scripts/overlord/deploy_local_ci_gate.py",
       "source_location": "L74",
       "id": "deploy_local_ci_gate_existing_shim_state",
-      "community": 40
+      "community": 5
     },
     {
       "label": "_resolve_shim_path()",
@@ -4897,7 +4929,7 @@
       "source_file": "scripts/overlord/deploy_local_ci_gate.py",
       "source_location": "L83",
       "id": "deploy_local_ci_gate_resolve_shim_path",
-      "community": 40
+      "community": 5
     },
     {
       "label": "build_plan()",
@@ -4905,7 +4937,7 @@
       "source_file": "scripts/overlord/deploy_local_ci_gate.py",
       "source_location": "L98",
       "id": "deploy_local_ci_gate_build_plan",
-      "community": 40
+      "community": 5
     },
     {
       "label": "managed_shim_body()",
@@ -4913,7 +4945,7 @@
       "source_file": "scripts/overlord/deploy_local_ci_gate.py",
       "source_location": "L121",
       "id": "deploy_local_ci_gate_managed_shim_body",
-      "community": 40
+      "community": 5
     },
     {
       "label": "_refuse_unmanaged_overwrite()",
@@ -4921,7 +4953,7 @@
       "source_file": "scripts/overlord/deploy_local_ci_gate.py",
       "source_location": "L150",
       "id": "deploy_local_ci_gate_refuse_unmanaged_overwrite",
-      "community": 40
+      "community": 5
     },
     {
       "label": "_write_managed_shim()",
@@ -4929,7 +4961,7 @@
       "source_file": "scripts/overlord/deploy_local_ci_gate.py",
       "source_location": "L160",
       "id": "deploy_local_ci_gate_write_managed_shim",
-      "community": 40
+      "community": 5
     },
     {
       "label": "print_json()",
@@ -4937,7 +4969,7 @@
       "source_file": "scripts/overlord/deploy_local_ci_gate.py",
       "source_location": "L171",
       "id": "deploy_local_ci_gate_print_json",
-      "community": 40
+      "community": 5
     },
     {
       "label": "add_common_args()",
@@ -4945,7 +4977,7 @@
       "source_file": "scripts/overlord/deploy_local_ci_gate.py",
       "source_location": "L176",
       "id": "deploy_local_ci_gate_add_common_args",
-      "community": 40
+      "community": 5
     },
     {
       "label": "_common_preview_payload()",
@@ -4953,7 +4985,7 @@
       "source_file": "scripts/overlord/deploy_local_ci_gate.py",
       "source_location": "L184",
       "id": "deploy_local_ci_gate_common_preview_payload",
-      "community": 40
+      "community": 5
     },
     {
       "label": "main()",
@@ -4961,7 +4993,7 @@
       "source_file": "scripts/overlord/deploy_local_ci_gate.py",
       "source_location": "L204",
       "id": "deploy_local_ci_gate_main",
-      "community": 40
+      "community": 5
     },
     {
       "label": "governed_repos.py",
@@ -5577,7 +5609,7 @@
       "source_file": "scripts/overlord/test_assert_execution_scope.py",
       "source_location": "L1",
       "id": "test_assert_execution_scope",
-      "community": 10
+      "community": 11
     },
     {
       "label": "_git()",
@@ -5585,7 +5617,7 @@
       "source_file": "scripts/overlord/test_assert_execution_scope.py",
       "source_location": "L27",
       "id": "test_assert_execution_scope_git",
-      "community": 10
+      "community": 11
     },
     {
       "label": "RepoFixture",
@@ -5593,7 +5625,7 @@
       "source_file": "scripts/overlord/test_assert_execution_scope.py",
       "source_location": "L37",
       "id": "test_assert_execution_scope_repofixture",
-      "community": 10
+      "community": 11
     },
     {
       "label": ".__init__()",
@@ -5601,7 +5633,7 @@
       "source_file": "scripts/overlord/test_assert_execution_scope.py",
       "source_location": "L38",
       "id": "test_assert_execution_scope_repofixture_init",
-      "community": 10
+      "community": 11
     },
     {
       "label": ".write()",
@@ -5609,7 +5641,7 @@
       "source_file": "scripts/overlord/test_assert_execution_scope.py",
       "source_location": "L50",
       "id": "test_assert_execution_scope_repofixture_write",
-      "community": 10
+      "community": 11
     },
     {
       "label": "TestAssertExecutionScope",
@@ -5617,7 +5649,7 @@
       "source_file": "scripts/overlord/test_assert_execution_scope.py",
       "source_location": "L56",
       "id": "test_assert_execution_scope_testassertexecutionscope",
-      "community": 10
+      "community": 11
     },
     {
       "label": "._scope_file()",
@@ -5625,7 +5657,7 @@
       "source_file": "scripts/overlord/test_assert_execution_scope.py",
       "source_location": "L57",
       "id": "test_assert_execution_scope_testassertexecutionscope_scope_file",
-      "community": 10
+      "community": 11
     },
     {
       "label": "._run_main()",
@@ -5633,7 +5665,7 @@
       "source_file": "scripts/overlord/test_assert_execution_scope.py",
       "source_location": "L87",
       "id": "test_assert_execution_scope_testassertexecutionscope_run_main",
-      "community": 10
+      "community": 11
     },
     {
       "label": "._changed_files_file()",
@@ -5641,7 +5673,7 @@
       "source_file": "scripts/overlord/test_assert_execution_scope.py",
       "source_location": "L105",
       "id": "test_assert_execution_scope_testassertexecutionscope_changed_files_file",
-      "community": 10
+      "community": 11
     },
     {
       "label": "._write_exception_file()",
@@ -5649,7 +5681,7 @@
       "source_file": "scripts/overlord/test_assert_execution_scope.py",
       "source_location": "L110",
       "id": "test_assert_execution_scope_testassertexecutionscope_write_exception_file",
-      "community": 10
+      "community": 11
     },
     {
       "label": "._handoff()",
@@ -5657,7 +5689,7 @@
       "source_file": "scripts/overlord/test_assert_execution_scope.py",
       "source_location": "L113",
       "id": "test_assert_execution_scope_testassertexecutionscope_handoff",
-      "community": 10
+      "community": 11
     },
     {
       "label": "._lane_claim()",
@@ -5665,7 +5697,7 @@
       "source_file": "scripts/overlord/test_assert_execution_scope.py",
       "source_location": "L132",
       "id": "test_assert_execution_scope_testassertexecutionscope_lane_claim",
-      "community": 10
+      "community": 11
     },
     {
       "label": ".test_allows_changes_in_allowed_paths_dirty_tree_mode()",
@@ -5673,7 +5705,7 @@
       "source_file": "scripts/overlord/test_assert_execution_scope.py",
       "source_location": "L140",
       "id": "test_assert_execution_scope_testassertexecutionscope_test_allows_changes_in_allowed_paths_dirty_tree_mode",
-      "community": 10
+      "community": 11
     },
     {
       "label": ".test_planning_only_diff_inside_allowed_paths_passes()",
@@ -5681,7 +5713,7 @@
       "source_file": "scripts/overlord/test_assert_execution_scope.py",
       "source_location": "L153",
       "id": "test_assert_execution_scope_testassertexecutionscope_test_planning_only_diff_inside_allowed_paths_passes",
-      "community": 10
+      "community": 11
     },
     {
       "label": ".test_planning_only_diff_outside_allowed_paths_fails()",
@@ -5689,7 +5721,7 @@
       "source_file": "scripts/overlord/test_assert_execution_scope.py",
       "source_location": "L165",
       "id": "test_assert_execution_scope_testassertexecutionscope_test_planning_only_diff_outside_allowed_paths_fails",
-      "community": 10
+      "community": 11
     },
     {
       "label": ".test_non_planning_without_handoff_fails()",
@@ -5697,7 +5729,7 @@
       "source_file": "scripts/overlord/test_assert_execution_scope.py",
       "source_location": "L178",
       "id": "test_assert_execution_scope_testassertexecutionscope_test_non_planning_without_handoff_fails",
-      "community": 10
+      "community": 11
     },
     {
       "label": ".test_non_planning_rejects_unsafe_handoff_evidence_ref()",
@@ -5705,7 +5737,7 @@
       "source_file": "scripts/overlord/test_assert_execution_scope.py",
       "source_location": "L190",
       "id": "test_assert_execution_scope_testassertexecutionscope_test_non_planning_rejects_unsafe_handoff_evidence_ref",
-      "community": 10
+      "community": 11
     },
     {
       "label": ".test_non_planning_with_accepted_handoff_passes()",
@@ -5713,7 +5745,7 @@
       "source_file": "scripts/overlord/test_assert_execution_scope.py",
       "source_location": "L212",
       "id": "test_assert_execution_scope_testassertexecutionscope_test_non_planning_with_accepted_handoff_passes",
-      "community": 10
+      "community": 11
     },
     {
       "label": ".test_same_model_or_family_without_active_exception_fails()",
@@ -5721,7 +5753,7 @@
       "source_file": "scripts/overlord/test_assert_execution_scope.py",
       "source_location": "L232",
       "id": "test_assert_execution_scope_testassertexecutionscope_test_same_model_or_family_without_active_exception_fails",
-      "community": 10
+      "community": 11
     },
     {
       "label": ".test_gpt_major_decimal_variants_without_active_exception_fail()",
@@ -5729,7 +5761,7 @@
       "source_file": "scripts/overlord/test_assert_execution_scope.py",
       "source_location": "L252",
       "id": "test_assert_execution_scope_testassertexecutionscope_test_gpt_major_decimal_variants_without_active_exception_fail",
-      "community": 10
+      "community": 11
     },
     {
       "label": ".test_gpt_major_decimal_variants_with_active_exception_pass()",
@@ -5737,7 +5769,7 @@
       "source_file": "scripts/overlord/test_assert_execution_scope.py",
       "source_location": "L272",
       "id": "test_assert_execution_scope_testassertexecutionscope_test_gpt_major_decimal_variants_with_active_exception_pass",
-      "community": 10
+      "community": 11
     },
     {
       "label": ".test_active_exception_with_expiry_passes()",
@@ -5745,7 +5777,7 @@
       "source_file": "scripts/overlord/test_assert_execution_scope.py",
       "source_location": "L295",
       "id": "test_assert_execution_scope_testassertexecutionscope_test_active_exception_with_expiry_passes",
-      "community": 10
+      "community": 11
     },
     {
       "label": ".test_active_exception_ref_nonexistent_file_fails()",
@@ -5753,7 +5785,7 @@
       "source_file": "scripts/overlord/test_assert_execution_scope.py",
       "source_location": "L318",
       "id": "test_assert_execution_scope_testassertexecutionscope_test_active_exception_ref_nonexistent_file_fails",
-      "community": 10
+      "community": 11
     },
     {
       "label": ".test_active_exception_ref_existing_file_with_anchor_passes()",
@@ -5761,7 +5793,7 @@
       "source_file": "scripts/overlord/test_assert_execution_scope.py",
       "source_location": "L341",
       "id": "test_assert_execution_scope_testassertexecutionscope_test_active_exception_ref_existing_file_with_anchor_passes",
-      "community": 10
+      "community": 11
     },
     {
       "label": ".test_diff_mode_and_dirty_tree_mode_share_path_normalization()",
@@ -5769,7 +5801,7 @@
       "source_file": "scripts/overlord/test_assert_execution_scope.py",
       "source_location": "L364",
       "id": "test_assert_execution_scope_testassertexecutionscope_test_diff_mode_and_dirty_tree_mode_share_path_normalization",
-      "community": 10
+      "community": 11
     },
     {
       "label": ".test_portable_expected_root_sentinel_passes_in_copied_checkout()",
@@ -5777,7 +5809,7 @@
       "source_file": "scripts/overlord/test_assert_execution_scope.py",
       "source_location": "L378",
       "id": "test_assert_execution_scope_testassertexecutionscope_test_portable_expected_root_sentinel_passes_in_copied_checkout",
-      "community": 10
+      "community": 11
     },
     {
       "label": ".test_refuses_wrong_root()",
@@ -5785,7 +5817,7 @@
       "source_file": "scripts/overlord/test_assert_execution_scope.py",
       "source_location": "L391",
       "id": "test_assert_execution_scope_testassertexecutionscope_test_refuses_wrong_root",
-      "community": 10
+      "community": 11
     },
     {
       "label": ".test_refuses_wrong_branch()",
@@ -5793,7 +5825,7 @@
       "source_file": "scripts/overlord/test_assert_execution_scope.py",
       "source_location": "L403",
       "id": "test_assert_execution_scope_testassertexecutionscope_test_refuses_wrong_branch",
-      "community": 10
+      "community": 11
     },
     {
       "label": ".test_require_lane_claim_passes_when_issue_matches_branch_and_scope()",
@@ -5801,7 +5833,7 @@
       "source_file": "scripts/overlord/test_assert_execution_scope.py",
       "source_location": "L414",
       "id": "test_assert_execution_scope_testassertexecutionscope_test_require_lane_claim_passes_when_issue_matches_branch_and_scope",
-      "community": 10
+      "community": 11
     },
     {
       "label": ".test_require_lane_claim_fails_when_missing()",
@@ -5809,7 +5841,7 @@
       "source_file": "scripts/overlord/test_assert_execution_scope.py",
       "source_location": "L431",
       "id": "test_assert_execution_scope_testassertexecutionscope_test_require_lane_claim_fails_when_missing",
-      "community": 10
+      "community": 11
     },
     {
       "label": ".test_require_lane_claim_fails_when_current_branch_issue_mismatches()",
@@ -5817,7 +5849,7 @@
       "source_file": "scripts/overlord/test_assert_execution_scope.py",
       "source_location": "L442",
       "id": "test_assert_execution_scope_testassertexecutionscope_test_require_lane_claim_fails_when_current_branch_issue_mismatches",
-      "community": 10
+      "community": 11
     },
     {
       "label": ".test_require_lane_claim_fails_when_expected_branch_issue_mismatches()",
@@ -5825,7 +5857,7 @@
       "source_file": "scripts/overlord/test_assert_execution_scope.py",
       "source_location": "L458",
       "id": "test_assert_execution_scope_testassertexecutionscope_test_require_lane_claim_fails_when_expected_branch_issue_mismatches",
-      "community": 10
+      "community": 11
     },
     {
       "label": ".test_detached_checkout_uses_github_head_ref()",
@@ -5833,7 +5865,7 @@
       "source_file": "scripts/overlord/test_assert_execution_scope.py",
       "source_location": "L474",
       "id": "test_assert_execution_scope_testassertexecutionscope_test_detached_checkout_uses_github_head_ref",
-      "community": 10
+      "community": 11
     },
     {
       "label": ".test_refuses_dirty_forbidden_root()",
@@ -5841,7 +5873,7 @@
       "source_file": "scripts/overlord/test_assert_execution_scope.py",
       "source_location": "L493",
       "id": "test_assert_execution_scope_testassertexecutionscope_test_refuses_dirty_forbidden_root",
-      "community": 10
+      "community": 11
     },
     {
       "label": ".test_declared_active_parallel_root_warns_instead_of_failing()",
@@ -5849,7 +5881,7 @@
       "source_file": "scripts/overlord/test_assert_execution_scope.py",
       "source_location": "L507",
       "id": "test_assert_execution_scope_testassertexecutionscope_test_declared_active_parallel_root_warns_instead_of_failing",
-      "community": 10
+      "community": 11
     },
     {
       "label": ".test_active_parallel_root_does_not_hide_inactive_dirty_root()",
@@ -5857,7 +5889,7 @@
       "source_file": "scripts/overlord/test_assert_execution_scope.py",
       "source_location": "L532",
       "id": "test_assert_execution_scope_testassertexecutionscope_test_active_parallel_root_does_not_hide_inactive_dirty_root",
-      "community": 10
+      "community": 11
     },
     {
       "label": ".test_clean_active_parallel_root_does_not_warn()",
@@ -5865,7 +5897,7 @@
       "source_file": "scripts/overlord/test_assert_execution_scope.py",
       "source_location": "L559",
       "id": "test_assert_execution_scope_testassertexecutionscope_test_clean_active_parallel_root_does_not_warn",
-      "community": 10
+      "community": 11
     },
     {
       "label": ".test_refuses_active_parallel_root_not_in_forbidden_roots()",
@@ -5873,7 +5905,7 @@
       "source_file": "scripts/overlord/test_assert_execution_scope.py",
       "source_location": "L581",
       "id": "test_assert_execution_scope_testassertexecutionscope_test_refuses_active_parallel_root_not_in_forbidden_roots",
-      "community": 10
+      "community": 11
     },
     {
       "label": ".test_refuses_active_parallel_root_without_reason()",
@@ -5881,7 +5913,7 @@
       "source_file": "scripts/overlord/test_assert_execution_scope.py",
       "source_location": "L603",
       "id": "test_assert_execution_scope_testassertexecutionscope_test_refuses_active_parallel_root_without_reason",
-      "community": 10
+      "community": 11
     },
     {
       "label": ".test_refuses_out_of_scope_changes()",
@@ -5889,7 +5921,7 @@
       "source_file": "scripts/overlord/test_assert_execution_scope.py",
       "source_location": "L625",
       "id": "test_assert_execution_scope_testassertexecutionscope_test_refuses_out_of_scope_changes",
-      "community": 10
+      "community": 11
     },
     {
       "label": "_working_directory()",
@@ -5897,7 +5929,7 @@
       "source_file": "scripts/overlord/test_assert_execution_scope.py",
       "source_location": "L640",
       "id": "test_assert_execution_scope_working_directory",
-      "community": 10
+      "community": 11
     },
     {
       "label": "test_automerge_policy_check.py",
@@ -5905,7 +5937,7 @@
       "source_file": "scripts/overlord/test_automerge_policy_check.py",
       "source_location": "L1",
       "id": "test_automerge_policy_check",
-      "community": 47
+      "community": 46
     },
     {
       "label": "eligible_payload()",
@@ -5913,7 +5945,7 @@
       "source_file": "scripts/overlord/test_automerge_policy_check.py",
       "source_location": "L14",
       "id": "test_automerge_policy_check_eligible_payload",
-      "community": 47
+      "community": 46
     },
     {
       "label": "TestAutomergePolicyCheck",
@@ -5921,7 +5953,7 @@
       "source_file": "scripts/overlord/test_automerge_policy_check.py",
       "source_location": "L44",
       "id": "test_automerge_policy_check_testautomergepolicycheck",
-      "community": 47
+      "community": 46
     },
     {
       "label": ".test_eligible_payload_passes()",
@@ -5929,7 +5961,7 @@
       "source_file": "scripts/overlord/test_automerge_policy_check.py",
       "source_location": "L45",
       "id": "test_automerge_policy_check_testautomergepolicycheck_test_eligible_payload_passes",
-      "community": 47
+      "community": 46
     },
     {
       "label": ".test_blocks_draft_red_unreviewed_conflicted_pr()",
@@ -5937,7 +5969,7 @@
       "source_file": "scripts/overlord/test_automerge_policy_check.py",
       "source_location": "L55",
       "id": "test_automerge_policy_check_testautomergepolicycheck_test_blocks_draft_red_unreviewed_conflicted_pr",
-      "community": 47
+      "community": 46
     },
     {
       "label": ".test_pending_required_check_is_pending_not_final_failure()",
@@ -5945,7 +5977,7 @@
       "source_file": "scripts/overlord/test_automerge_policy_check.py",
       "source_location": "L82",
       "id": "test_automerge_policy_check_testautomergepolicycheck_test_pending_required_check_is_pending_not_final_failure",
-      "community": 47
+      "community": 46
     },
     {
       "label": ".test_blocks_local_main_mergeability_probe()",
@@ -5953,7 +5985,7 @@
       "source_file": "scripts/overlord/test_automerge_policy_check.py",
       "source_location": "L95",
       "id": "test_automerge_policy_check_testautomergepolicycheck_test_blocks_local_main_mergeability_probe",
-      "community": 47
+      "community": 46
     },
     {
       "label": ".test_blocks_disabled_repo_missing_opt_in_and_blocking_label()",
@@ -5961,7 +5993,7 @@
       "source_file": "scripts/overlord/test_automerge_policy_check.py",
       "source_location": "L105",
       "id": "test_automerge_policy_check_testautomergepolicycheck_test_blocks_disabled_repo_missing_opt_in_and_blocking_label",
-      "community": 47
+      "community": 46
     },
     {
       "label": ".test_cli_returns_two_for_blocked_payload_and_writes_json()",
@@ -5969,7 +6001,7 @@
       "source_file": "scripts/overlord/test_automerge_policy_check.py",
       "source_location": "L120",
       "id": "test_automerge_policy_check_testautomergepolicycheck_test_cli_returns_two_for_blocked_payload_and_writes_json",
-      "community": 47
+      "community": 46
     },
     {
       "label": ".test_cli_allow_pending_returns_zero_for_expected_pending_checks()",
@@ -5977,7 +6009,7 @@
       "source_file": "scripts/overlord/test_automerge_policy_check.py",
       "source_location": "L148",
       "id": "test_automerge_policy_check_testautomergepolicycheck_test_cli_allow_pending_returns_zero_for_expected_pending_checks",
-      "community": 47
+      "community": 46
     },
     {
       "label": "test_branch_switch_guard.py",
@@ -5985,7 +6017,7 @@
       "source_file": "scripts/overlord/test_branch_switch_guard.py",
       "source_location": "L1",
       "id": "test_branch_switch_guard",
-      "community": 54
+      "community": 53
     },
     {
       "label": "run_hook()",
@@ -5993,7 +6025,7 @@
       "source_file": "scripts/overlord/test_branch_switch_guard.py",
       "source_location": "L15",
       "id": "test_branch_switch_guard_run_hook",
-      "community": 54
+      "community": 53
     },
     {
       "label": "TestBranchSwitchGuard",
@@ -6001,7 +6033,7 @@
       "source_file": "scripts/overlord/test_branch_switch_guard.py",
       "source_location": "L26",
       "id": "test_branch_switch_guard_testbranchswitchguard",
-      "community": 54
+      "community": 53
     },
     {
       "label": ".test_blocks_unclaimed_issue_worktree_add()",
@@ -6009,7 +6041,7 @@
       "source_file": "scripts/overlord/test_branch_switch_guard.py",
       "source_location": "L27",
       "id": "test_branch_switch_guard_testbranchswitchguard_test_blocks_unclaimed_issue_worktree_add",
-      "community": 54
+      "community": 53
     },
     {
       "label": ".test_allows_explicit_planning_bootstrap_issue_worktree_add()",
@@ -6017,7 +6049,7 @@
       "source_file": "scripts/overlord/test_branch_switch_guard.py",
       "source_location": "L35",
       "id": "test_branch_switch_guard_testbranchswitchguard_test_allows_explicit_planning_bootstrap_issue_worktree_add",
-      "community": 54
+      "community": 53
     },
     {
       "label": ".test_allows_non_issue_worktree_add()",
@@ -6025,7 +6057,7 @@
       "source_file": "scripts/overlord/test_branch_switch_guard.py",
       "source_location": "L42",
       "id": "test_branch_switch_guard_testbranchswitchguard_test_allows_non_issue_worktree_add",
-      "community": 54
+      "community": 53
     },
     {
       "label": ".test_allows_issue_worktree_add_with_matching_claimed_scope()",
@@ -6033,7 +6065,7 @@
       "source_file": "scripts/overlord/test_branch_switch_guard.py",
       "source_location": "L47",
       "id": "test_branch_switch_guard_testbranchswitchguard_test_allows_issue_worktree_add_with_matching_claimed_scope",
-      "community": 54
+      "community": 53
     },
     {
       "label": ".test_blocks_issue_worktree_add_with_mismatched_claimed_scope()",
@@ -6041,7 +6073,7 @@
       "source_file": "scripts/overlord/test_branch_switch_guard.py",
       "source_location": "L63",
       "id": "test_branch_switch_guard_testbranchswitchguard_test_blocks_issue_worktree_add_with_mismatched_claimed_scope",
-      "community": 54
+      "community": 53
     },
     {
       "label": ".test_healthcareplatform_policy_rejects_non_sandbox_branch()",
@@ -6049,7 +6081,7 @@
       "source_file": "scripts/overlord/test_branch_switch_guard.py",
       "source_location": "L80",
       "id": "test_branch_switch_guard_testbranchswitchguard_test_healthcareplatform_policy_rejects_non_sandbox_branch",
-      "community": 54
+      "community": 53
     },
     {
       "label": ".test_healthcareplatform_policy_accepts_sandbox_pr_pending_lane()",
@@ -6057,7 +6089,7 @@
       "source_file": "scripts/overlord/test_branch_switch_guard.py",
       "source_location": "L89",
       "id": "test_branch_switch_guard_testbranchswitchguard_test_healthcareplatform_policy_accepts_sandbox_pr_pending_lane",
-      "community": 54
+      "community": 53
     },
     {
       "label": ".test_still_blocks_branch_checkout()",
@@ -6065,7 +6097,7 @@
       "source_file": "scripts/overlord/test_branch_switch_guard.py",
       "source_location": "L97",
       "id": "test_branch_switch_guard_testbranchswitchguard_test_still_blocks_branch_checkout",
-      "community": 54
+      "community": 53
     },
     {
       "label": ".test_heredoc_body_does_not_trigger_branch_matching()",
@@ -6073,7 +6105,7 @@
       "source_file": "scripts/overlord/test_branch_switch_guard.py",
       "source_location": "L103",
       "id": "test_branch_switch_guard_testbranchswitchguard_test_heredoc_body_does_not_trigger_branch_matching",
-      "community": 54
+      "community": 53
     },
     {
       "label": ".test_blocks_force_push_variants()",
@@ -6081,7 +6113,7 @@
       "source_file": "scripts/overlord/test_branch_switch_guard.py",
       "source_location": "L108",
       "id": "test_branch_switch_guard_testbranchswitchguard_test_blocks_force_push_variants",
-      "community": 54
+      "community": 53
     },
     {
       "label": "test_check_org_repo_inventory.py",
@@ -6089,7 +6121,7 @@
       "source_file": "scripts/overlord/test_check_org_repo_inventory.py",
       "source_location": "L1",
       "id": "test_check_org_repo_inventory",
-      "community": 55
+      "community": 54
     },
     {
       "label": "TestOrgRepoInventory",
@@ -6097,7 +6129,7 @@
       "source_file": "scripts/overlord/test_check_org_repo_inventory.py",
       "source_location": "L23",
       "id": "test_check_org_repo_inventory_testorgrepoinventory",
-      "community": 55
+      "community": 54
     },
     {
       "label": "._registry()",
@@ -6105,7 +6137,7 @@
       "source_file": "scripts/overlord/test_check_org_repo_inventory.py",
       "source_location": "L24",
       "id": "test_check_org_repo_inventory_testorgrepoinventory_registry",
-      "community": 55
+      "community": 54
     },
     {
       "label": "._inventory()",
@@ -6113,7 +6145,7 @@
       "source_file": "scripts/overlord/test_check_org_repo_inventory.py",
       "source_location": "L73",
       "id": "test_check_org_repo_inventory_testorgrepoinventory_inventory",
-      "community": 55
+      "community": 54
     },
     {
       "label": "._repo_row()",
@@ -6121,7 +6153,7 @@
       "source_file": "scripts/overlord/test_check_org_repo_inventory.py",
       "source_location": "L78",
       "id": "test_check_org_repo_inventory_testorgrepoinventory_repo_row",
-      "community": 55
+      "community": 54
     },
     {
       "label": "._run()",
@@ -6129,7 +6161,7 @@
       "source_file": "scripts/overlord/test_check_org_repo_inventory.py",
       "source_location": "L88",
       "id": "test_check_org_repo_inventory_testorgrepoinventory_run",
-      "community": 55
+      "community": 54
     },
     {
       "label": ".test_exact_active_inventory_passes()",
@@ -6137,7 +6169,7 @@
       "source_file": "scripts/overlord/test_check_org_repo_inventory.py",
       "source_location": "L95",
       "id": "test_check_org_repo_inventory_testorgrepoinventory_test_exact_active_inventory_passes",
-      "community": 55
+      "community": 54
     },
     {
       "label": ".test_missing_active_repo_fails()",
@@ -6145,7 +6177,7 @@
       "source_file": "scripts/overlord/test_check_org_repo_inventory.py",
       "source_location": "L109",
       "id": "test_check_org_repo_inventory_testorgrepoinventory_test_missing_active_repo_fails",
-      "community": 55
+      "community": 54
     },
     {
       "label": ".test_warn_only_reports_missing_active_repo_but_passes()",
@@ -6153,7 +6185,7 @@
       "source_file": "scripts/overlord/test_check_org_repo_inventory.py",
       "source_location": "L124",
       "id": "test_check_org_repo_inventory_testorgrepoinventory_test_warn_only_reports_missing_active_repo_but_passes",
-      "community": 55
+      "community": 54
     },
     {
       "label": ".test_stale_registry_repo_fails()",
@@ -6161,7 +6193,7 @@
       "source_file": "scripts/overlord/test_check_org_repo_inventory.py",
       "source_location": "L147",
       "id": "test_check_org_repo_inventory_testorgrepoinventory_test_stale_registry_repo_fails",
-      "community": 55
+      "community": 54
     },
     {
       "label": ".test_archived_unregistered_repo_is_notice_not_blocker()",
@@ -6169,7 +6201,7 @@
       "source_file": "scripts/overlord/test_check_org_repo_inventory.py",
       "source_location": "L159",
       "id": "test_check_org_repo_inventory_testorgrepoinventory_test_archived_unregistered_repo_is_notice_not_blocker",
-      "community": 55
+      "community": 54
     },
     {
       "label": ".test_archived_registry_repo_fails_without_archived_lifecycle_classification()",
@@ -6177,7 +6209,7 @@
       "source_file": "scripts/overlord/test_check_org_repo_inventory.py",
       "source_location": "L174",
       "id": "test_check_org_repo_inventory_testorgrepoinventory_test_archived_registry_repo_fails_without_archived_lifecycle_classification",
-      "community": 55
+      "community": 54
     },
     {
       "label": ".test_archived_registry_repo_passes_with_archived_lifecycle_classification()",
@@ -6185,7 +6217,7 @@
       "source_file": "scripts/overlord/test_check_org_repo_inventory.py",
       "source_location": "L189",
       "id": "test_check_org_repo_inventory_testorgrepoinventory_test_archived_registry_repo_passes_with_archived_lifecycle_classification",
-      "community": 55
+      "community": 54
     },
     {
       "label": "test_check_overlord_backlog_github_alignment.py",
@@ -6233,7 +6265,7 @@
       "source_file": "scripts/overlord/test_check_plan_preflight.py",
       "source_location": "L1",
       "id": "test_check_plan_preflight",
-      "community": 50
+      "community": 49
     },
     {
       "label": "_run()",
@@ -6241,7 +6273,7 @@
       "source_file": "scripts/overlord/test_check_plan_preflight.py",
       "source_location": "L17",
       "id": "test_check_plan_preflight_run",
-      "community": 50
+      "community": 49
     },
     {
       "label": "TestPlanPreflight",
@@ -6249,7 +6281,7 @@
       "source_file": "scripts/overlord/test_check_plan_preflight.py",
       "source_location": "L27",
       "id": "test_check_plan_preflight_testplanpreflight",
-      "community": 50
+      "community": 49
     },
     {
       "label": ".test_code_file_without_recent_plan_blocks_with_route_tokens()",
@@ -6257,7 +6289,7 @@
       "source_file": "scripts/overlord/test_check_plan_preflight.py",
       "source_location": "L28",
       "id": "test_check_plan_preflight_testplanpreflight_test_code_file_without_recent_plan_blocks_with_route_tokens",
-      "community": 50
+      "community": 49
     },
     {
       "label": ".test_read_only_intent_is_allowed()",
@@ -6265,7 +6297,7 @@
       "source_file": "scripts/overlord/test_check_plan_preflight.py",
       "source_location": "L40",
       "id": "test_check_plan_preflight_testplanpreflight_test_read_only_intent_is_allowed",
-      "community": 50
+      "community": 49
     },
     {
       "label": ".test_trivial_single_line_bypass_is_explicitly_bounded()",
@@ -6273,7 +6305,7 @@
       "source_file": "scripts/overlord/test_check_plan_preflight.py",
       "source_location": "L48",
       "id": "test_check_plan_preflight_testplanpreflight_test_trivial_single_line_bypass_is_explicitly_bounded",
-      "community": 50
+      "community": 49
     },
     {
       "label": ".test_general_bypass_without_trivial_marker_still_blocks()",
@@ -6281,7 +6313,7 @@
       "source_file": "scripts/overlord/test_check_plan_preflight.py",
       "source_location": "L62",
       "id": "test_check_plan_preflight_testplanpreflight_test_general_bypass_without_trivial_marker_still_blocks",
-      "community": 50
+      "community": 49
     },
     {
       "label": ".test_recent_plan_allows_governed_write()",
@@ -6289,7 +6321,7 @@
       "source_file": "scripts/overlord/test_check_plan_preflight.py",
       "source_location": "L69",
       "id": "test_check_plan_preflight_testplanpreflight_test_recent_plan_allows_governed_write",
-      "community": 50
+      "community": 49
     },
     {
       "label": ".test_stale_plan_does_not_clear_preflight()",
@@ -6297,7 +6329,7 @@
       "source_file": "scripts/overlord/test_check_plan_preflight.py",
       "source_location": "L82",
       "id": "test_check_plan_preflight_testplanpreflight_test_stale_plan_does_not_clear_preflight",
-      "community": 50
+      "community": 49
     },
     {
       "label": ".test_bash_write_command_detects_target()",
@@ -6305,7 +6337,7 @@
       "source_file": "scripts/overlord/test_check_plan_preflight.py",
       "source_location": "L97",
       "id": "test_check_plan_preflight_testplanpreflight_test_bash_write_command_detects_target",
-      "community": 50
+      "community": 49
     },
     {
       "label": ".test_quoted_awk_comparison_is_read_only()",
@@ -6313,7 +6345,7 @@
       "source_file": "scripts/overlord/test_check_plan_preflight.py",
       "source_location": "L109",
       "id": "test_check_plan_preflight_testplanpreflight_test_quoted_awk_comparison_is_read_only",
-      "community": 50
+      "community": 49
     },
     {
       "label": ".test_quoted_jq_comparison_is_read_only()",
@@ -6321,7 +6353,7 @@
       "source_file": "scripts/overlord/test_check_plan_preflight.py",
       "source_location": "L122",
       "id": "test_check_plan_preflight_testplanpreflight_test_quoted_jq_comparison_is_read_only",
-      "community": 50
+      "community": 49
     },
     {
       "label": ".test_common_read_only_analysis_pipelines_are_allowed()",
@@ -6329,7 +6361,7 @@
       "source_file": "scripts/overlord/test_check_plan_preflight.py",
       "source_location": "L135",
       "id": "test_check_plan_preflight_testplanpreflight_test_common_read_only_analysis_pipelines_are_allowed",
-      "community": 50
+      "community": 49
     },
     {
       "label": ".test_python_write_command_is_refused_with_routing_signal()",
@@ -6337,7 +6369,7 @@
       "source_file": "scripts/overlord/test_check_plan_preflight.py",
       "source_location": "L152",
       "id": "test_check_plan_preflight_testplanpreflight_test_python_write_command_is_refused_with_routing_signal",
-      "community": 50
+      "community": 49
     },
     {
       "label": "test_check_stage6_closeout.py",
@@ -6345,95 +6377,103 @@
       "source_file": "scripts/overlord/test_check_stage6_closeout.py",
       "source_location": "L1",
       "id": "test_check_stage6_closeout",
-      "community": 32
+      "community": 55
     },
     {
       "label": "_write()",
       "file_type": "code",
       "source_file": "scripts/overlord/test_check_stage6_closeout.py",
-      "source_location": "L11",
+      "source_location": "L20",
       "id": "test_check_stage6_closeout_write",
-      "community": 32
+      "community": 55
     },
     {
       "label": "_json()",
       "file_type": "code",
       "source_file": "scripts/overlord/test_check_stage6_closeout.py",
-      "source_location": "L16",
+      "source_location": "L25",
       "id": "test_check_stage6_closeout_json",
-      "community": 32
+      "community": 55
     },
     {
       "label": "TestCheckStage6Closeout",
       "file_type": "code",
       "source_file": "scripts/overlord/test_check_stage6_closeout.py",
-      "source_location": "L20",
+      "source_location": "L29",
       "id": "test_check_stage6_closeout_testcheckstage6closeout",
-      "community": 32
+      "community": 55
     },
     {
       "label": "._repo()",
       "file_type": "code",
       "source_file": "scripts/overlord/test_check_stage6_closeout.py",
-      "source_location": "L21",
+      "source_location": "L30",
       "id": "test_check_stage6_closeout_testcheckstage6closeout_repo",
-      "community": 32
+      "community": 55
     },
     {
       "label": "._closeout()",
       "file_type": "code",
       "source_file": "scripts/overlord/test_check_stage6_closeout.py",
-      "source_location": "L63",
+      "source_location": "L75",
       "id": "test_check_stage6_closeout_testcheckstage6closeout_closeout",
-      "community": 32
+      "community": 55
     },
     {
       "label": ".test_planning_only_changes_do_not_require_closeout()",
       "file_type": "code",
       "source_file": "scripts/overlord/test_check_stage6_closeout.py",
-      "source_location": "L102",
+      "source_location": "L114",
       "id": "test_check_stage6_closeout_testcheckstage6closeout_test_planning_only_changes_do_not_require_closeout",
-      "community": 32
+      "community": 55
+    },
+    {
+      "label": ".test_planning_evidence_surfaces_remain_planning_only()",
+      "file_type": "code",
+      "source_file": "scripts/overlord/test_check_stage6_closeout.py",
+      "source_location": "L126",
+      "id": "test_check_stage6_closeout_testcheckstage6closeout_test_planning_evidence_surfaces_remain_planning_only",
+      "community": 55
     },
     {
       "label": ".test_implementation_changes_without_closeout_fail()",
       "file_type": "code",
       "source_file": "scripts/overlord/test_check_stage6_closeout.py",
-      "source_location": "L114",
+      "source_location": "L143",
       "id": "test_check_stage6_closeout_testcheckstage6closeout_test_implementation_changes_without_closeout_fail",
-      "community": 32
+      "community": 55
     },
     {
       "label": ".test_valid_matching_closeout_passes()",
       "file_type": "code",
       "source_file": "scripts/overlord/test_check_stage6_closeout.py",
-      "source_location": "L127",
+      "source_location": "L156",
       "id": "test_check_stage6_closeout_testcheckstage6closeout_test_valid_matching_closeout_passes",
-      "community": 32
+      "community": 55
     },
     {
       "label": ".test_invalid_matching_closeout_fails()",
       "file_type": "code",
       "source_file": "scripts/overlord/test_check_stage6_closeout.py",
-      "source_location": "L141",
+      "source_location": "L170",
       "id": "test_check_stage6_closeout_testcheckstage6closeout_test_invalid_matching_closeout_fails",
-      "community": 32
+      "community": 55
     },
     {
       "label": ".test_multiple_matching_closeouts_fail()",
       "file_type": "code",
       "source_file": "scripts/overlord/test_check_stage6_closeout.py",
-      "source_location": "L155",
+      "source_location": "L184",
       "id": "test_check_stage6_closeout_testcheckstage6closeout_test_multiple_matching_closeouts_fail",
-      "community": 32
+      "community": 55
     },
     {
       "label": ".test_non_issue_branch_with_governance_changes_fails()",
       "file_type": "code",
       "source_file": "scripts/overlord/test_check_stage6_closeout.py",
-      "source_location": "L169",
+      "source_location": "L198",
       "id": "test_check_stage6_closeout_testcheckstage6closeout_test_non_issue_branch_with_governance_changes_fails",
-      "community": 32
+      "community": 55
     },
     {
       "label": "test_check_worker_handoff_route.py",
@@ -6441,7 +6481,7 @@
       "source_file": "scripts/overlord/test_check_worker_handoff_route.py",
       "source_location": "L1",
       "id": "test_check_worker_handoff_route",
-      "community": 41
+      "community": 40
     },
     {
       "label": "_git()",
@@ -6449,7 +6489,7 @@
       "source_file": "scripts/overlord/test_check_worker_handoff_route.py",
       "source_location": "L16",
       "id": "test_check_worker_handoff_route_git",
-      "community": 41
+      "community": 40
     },
     {
       "label": "RepoFixture",
@@ -6457,7 +6497,7 @@
       "source_file": "scripts/overlord/test_check_worker_handoff_route.py",
       "source_location": "L20",
       "id": "test_check_worker_handoff_route_repofixture",
-      "community": 41
+      "community": 40
     },
     {
       "label": ".__init__()",
@@ -6465,7 +6505,7 @@
       "source_file": "scripts/overlord/test_check_worker_handoff_route.py",
       "source_location": "L21",
       "id": "test_check_worker_handoff_route_repofixture_init",
-      "community": 41
+      "community": 40
     },
     {
       "label": ".write_scope()",
@@ -6473,7 +6513,7 @@
       "source_file": "scripts/overlord/test_check_worker_handoff_route.py",
       "source_location": "L32",
       "id": "test_check_worker_handoff_route_repofixture_write_scope",
-      "community": 41
+      "community": 40
     },
     {
       "label": ".write_exception()",
@@ -6481,7 +6521,7 @@
       "source_file": "scripts/overlord/test_check_worker_handoff_route.py",
       "source_location": "L39",
       "id": "test_check_worker_handoff_route_repofixture_write_exception",
-      "community": 41
+      "community": 40
     },
     {
       "label": "_scope()",
@@ -6489,7 +6529,7 @@
       "source_file": "scripts/overlord/test_check_worker_handoff_route.py",
       "source_location": "L45",
       "id": "test_check_worker_handoff_route_scope",
-      "community": 41
+      "community": 40
     },
     {
       "label": "TestWorkerHandoffRoute",
@@ -6497,7 +6537,7 @@
       "source_file": "scripts/overlord/test_check_worker_handoff_route.py",
       "source_location": "L79",
       "id": "test_check_worker_handoff_route_testworkerhandoffroute",
-      "community": 41
+      "community": 40
     },
     {
       "label": "._run()",
@@ -6505,7 +6545,7 @@
       "source_file": "scripts/overlord/test_check_worker_handoff_route.py",
       "source_location": "L80",
       "id": "test_check_worker_handoff_route_testworkerhandoffroute_run",
-      "community": 41
+      "community": 40
     },
     {
       "label": ".test_planner_lane_new_python_file_is_blocked_with_next_action()",
@@ -6513,7 +6553,7 @@
       "source_file": "scripts/overlord/test_check_worker_handoff_route.py",
       "source_location": "L101",
       "id": "test_check_worker_handoff_route_testworkerhandoffroute_test_planner_lane_new_python_file_is_blocked_with_next_action",
-      "community": 41
+      "community": 40
     },
     {
       "label": ".test_approved_worker_handoff_for_target_path_is_accepted()",
@@ -6521,7 +6561,7 @@
       "source_file": "scripts/overlord/test_check_worker_handoff_route.py",
       "source_location": "L113",
       "id": "test_check_worker_handoff_route_testworkerhandoffroute_test_approved_worker_handoff_for_target_path_is_accepted",
-      "community": 41
+      "community": 40
     },
     {
       "label": ".test_scope_present_but_target_path_missing_is_blocked()",
@@ -6529,7 +6569,7 @@
       "source_file": "scripts/overlord/test_check_worker_handoff_route.py",
       "source_location": "L123",
       "id": "test_check_worker_handoff_route_testworkerhandoffroute_test_scope_present_but_target_path_missing_is_blocked",
-      "community": 41
+      "community": 40
     },
     {
       "label": ".test_worker_handoff_wrong_issue_number_is_blocked()",
@@ -6537,7 +6577,7 @@
       "source_file": "scripts/overlord/test_check_worker_handoff_route.py",
       "source_location": "L134",
       "id": "test_check_worker_handoff_route_testworkerhandoffroute_test_worker_handoff_wrong_issue_number_is_blocked",
-      "community": 41
+      "community": 40
     },
     {
       "label": ".test_same_family_worker_handoff_without_exception_is_blocked()",
@@ -6545,7 +6585,7 @@
       "source_file": "scripts/overlord/test_check_worker_handoff_route.py",
       "source_location": "L144",
       "id": "test_check_worker_handoff_route_testworkerhandoffroute_test_same_family_worker_handoff_without_exception_is_blocked",
-      "community": 41
+      "community": 40
     },
     {
       "label": ".test_worker_handoff_with_unsafe_evidence_ref_is_blocked()",
@@ -6553,7 +6593,7 @@
       "source_file": "scripts/overlord/test_check_worker_handoff_route.py",
       "source_location": "L159",
       "id": "test_check_worker_handoff_route_testworkerhandoffroute_test_worker_handoff_with_unsafe_evidence_ref_is_blocked",
-      "community": 41
+      "community": 40
     },
     {
       "label": ".test_same_family_worker_handoff_with_active_exception_is_accepted()",
@@ -6561,7 +6601,7 @@
       "source_file": "scripts/overlord/test_check_worker_handoff_route.py",
       "source_location": "L172",
       "id": "test_check_worker_handoff_route_testworkerhandoffroute_test_same_family_worker_handoff_with_active_exception_is_accepted",
-      "community": 41
+      "community": 40
     },
     {
       "label": ".test_javascript_and_shell_targets_are_governed_code_files()",
@@ -6569,7 +6609,7 @@
       "source_file": "scripts/overlord/test_check_worker_handoff_route.py",
       "source_location": "L189",
       "id": "test_check_worker_handoff_route_testworkerhandoffroute_test_javascript_and_shell_targets_are_governed_code_files",
-      "community": 41
+      "community": 40
     },
     {
       "label": "test_deploy_governance_tooling.py",
@@ -6577,7 +6617,7 @@
       "source_file": "scripts/overlord/test_deploy_governance_tooling.py",
       "source_location": "L1",
       "id": "test_deploy_governance_tooling",
-      "community": 38
+      "community": 36
     },
     {
       "label": "TestDeployGovernanceTooling",
@@ -6585,7 +6625,7 @@
       "source_file": "scripts/overlord/test_deploy_governance_tooling.py",
       "source_location": "L26",
       "id": "test_deploy_governance_tooling_testdeploygovernancetooling",
-      "community": 38
+      "community": 36
     },
     {
       "label": ".setUp()",
@@ -6593,7 +6633,7 @@
       "source_file": "scripts/overlord/test_deploy_governance_tooling.py",
       "source_location": "L27",
       "id": "test_deploy_governance_tooling_testdeploygovernancetooling_setup",
-      "community": 38
+      "community": 36
     },
     {
       "label": ".tearDown()",
@@ -6601,7 +6641,7 @@
       "source_file": "scripts/overlord/test_deploy_governance_tooling.py",
       "source_location": "L40",
       "id": "test_deploy_governance_tooling_testdeploygovernancetooling_teardown",
-      "community": 38
+      "community": 36
     },
     {
       "label": "._invoke()",
@@ -6609,7 +6649,7 @@
       "source_file": "scripts/overlord/test_deploy_governance_tooling.py",
       "source_location": "L43",
       "id": "test_deploy_governance_tooling_testdeploygovernancetooling_invoke",
-      "community": 38
+      "community": 36
     },
     {
       "label": "._base_args()",
@@ -6617,7 +6657,7 @@
       "source_file": "scripts/overlord/test_deploy_governance_tooling.py",
       "source_location": "L50",
       "id": "test_deploy_governance_tooling_testdeploygovernancetooling_base_args",
-      "community": 38
+      "community": 36
     },
     {
       "label": "._record()",
@@ -6625,7 +6665,7 @@
       "source_file": "scripts/overlord/test_deploy_governance_tooling.py",
       "source_location": "L62",
       "id": "test_deploy_governance_tooling_testdeploygovernancetooling_record",
-      "community": 38
+      "community": 36
     },
     {
       "label": "._shim()",
@@ -6633,7 +6673,7 @@
       "source_file": "scripts/overlord/test_deploy_governance_tooling.py",
       "source_location": "L65",
       "id": "test_deploy_governance_tooling_testdeploygovernancetooling_shim",
-      "community": 38
+      "community": 36
     },
     {
       "label": ".test_dry_run_plans_managed_files_without_writing()",
@@ -6641,7 +6681,7 @@
       "source_file": "scripts/overlord/test_deploy_governance_tooling.py",
       "source_location": "L68",
       "id": "test_deploy_governance_tooling_testdeploygovernancetooling_test_dry_run_plans_managed_files_without_writing",
-      "community": 38
+      "community": 36
     },
     {
       "label": ".test_apply_writes_managed_shim_and_consumer_record()",
@@ -6649,87 +6689,95 @@
       "source_file": "scripts/overlord/test_deploy_governance_tooling.py",
       "source_location": "L82",
       "id": "test_deploy_governance_tooling_testdeploygovernancetooling_test_apply_writes_managed_shim_and_consumer_record",
-      "community": 38
+      "community": 36
+    },
+    {
+      "label": ".test_apply_consumer_profile_records_required_session_contract_surfaces()",
+      "file_type": "code",
+      "source_file": "scripts/overlord/test_deploy_governance_tooling.py",
+      "source_location": "L99",
+      "id": "test_deploy_governance_tooling_testdeploygovernancetooling_test_apply_consumer_profile_records_required_session_contract_surfaces",
+      "community": 36
     },
     {
       "label": ".test_verify_passes_after_apply()",
       "file_type": "code",
       "source_file": "scripts/overlord/test_deploy_governance_tooling.py",
-      "source_location": "L99",
+      "source_location": "L138",
       "id": "test_deploy_governance_tooling_testdeploygovernancetooling_test_verify_passes_after_apply",
-      "community": 38
+      "community": 36
     },
     {
       "label": ".test_rollback_removes_managed_files()",
       "file_type": "code",
       "source_file": "scripts/overlord/test_deploy_governance_tooling.py",
-      "source_location": "L110",
+      "source_location": "L149",
       "id": "test_deploy_governance_tooling_testdeploygovernancetooling_test_rollback_removes_managed_files",
-      "community": 38
+      "community": 36
     },
     {
       "label": ".test_apply_is_idempotent_for_managed_files()",
       "file_type": "code",
       "source_file": "scripts/overlord/test_deploy_governance_tooling.py",
-      "source_location": "L122",
+      "source_location": "L161",
       "id": "test_deploy_governance_tooling_testdeploygovernancetooling_test_apply_is_idempotent_for_managed_files",
-      "community": 38
+      "community": 36
     },
     {
       "label": ".test_apply_refuses_unmanaged_shim_by_default()",
       "file_type": "code",
       "source_file": "scripts/overlord/test_deploy_governance_tooling.py",
-      "source_location": "L133",
+      "source_location": "L172",
       "id": "test_deploy_governance_tooling_testdeploygovernancetooling_test_apply_refuses_unmanaged_shim_by_default",
-      "community": 38
+      "community": 36
     },
     {
       "label": ".test_apply_refuses_unmanaged_consumer_record_by_default()",
       "file_type": "code",
       "source_file": "scripts/overlord/test_deploy_governance_tooling.py",
-      "source_location": "L144",
+      "source_location": "L183",
       "id": "test_deploy_governance_tooling_testdeploygovernancetooling_test_apply_refuses_unmanaged_consumer_record_by_default",
-      "community": 38
+      "community": 36
     },
     {
       "label": ".test_apply_refuses_dirty_target_by_default()",
       "file_type": "code",
       "source_file": "scripts/overlord/test_deploy_governance_tooling.py",
-      "source_location": "L154",
+      "source_location": "L193",
       "id": "test_deploy_governance_tooling_testdeploygovernancetooling_test_apply_refuses_dirty_target_by_default",
-      "community": 38
+      "community": 36
     },
     {
       "label": ".test_verify_fails_when_record_is_missing()",
       "file_type": "code",
       "source_file": "scripts/overlord/test_deploy_governance_tooling.py",
-      "source_location": "L165",
+      "source_location": "L204",
       "id": "test_deploy_governance_tooling_testdeploygovernancetooling_test_verify_fails_when_record_is_missing",
-      "community": 38
+      "community": 36
     },
     {
       "label": ".test_verify_fails_when_managed_shim_body_is_tampered()",
       "file_type": "code",
       "source_file": "scripts/overlord/test_deploy_governance_tooling.py",
-      "source_location": "L174",
+      "source_location": "L213",
       "id": "test_deploy_governance_tooling_testdeploygovernancetooling_test_verify_fails_when_managed_shim_body_is_tampered",
-      "community": 38
+      "community": 36
     },
     {
       "label": ".test_rollback_refuses_unmanaged_record_before_removing_shim()",
       "file_type": "code",
       "source_file": "scripts/overlord/test_deploy_governance_tooling.py",
-      "source_location": "L190",
+      "source_location": "L229",
       "id": "test_deploy_governance_tooling_testdeploygovernancetooling_test_rollback_refuses_unmanaged_record_before_removing_shim",
-      "community": 38
+      "community": 36
     },
     {
       "label": ".test_real_e2e_apply_verify_rollback_against_temp_git_repo()",
       "file_type": "code",
       "source_file": "scripts/overlord/test_deploy_governance_tooling.py",
-      "source_location": "L203",
+      "source_location": "L242",
       "id": "test_deploy_governance_tooling_testdeploygovernancetooling_test_real_e2e_apply_verify_rollback_against_temp_git_repo",
-      "community": 38
+      "community": 36
     },
     {
       "label": "test_deploy_local_ci_gate.py",
@@ -6737,7 +6785,7 @@
       "source_file": "scripts/overlord/test_deploy_local_ci_gate.py",
       "source_location": "L1",
       "id": "test_deploy_local_ci_gate",
-      "community": 42
+      "community": 41
     },
     {
       "label": "TestDeployLocalCIGate",
@@ -6745,7 +6793,7 @@
       "source_file": "scripts/overlord/test_deploy_local_ci_gate.py",
       "source_location": "L26",
       "id": "test_deploy_local_ci_gate_testdeploylocalcigate",
-      "community": 42
+      "community": 41
     },
     {
       "label": ".setUp()",
@@ -6753,7 +6801,7 @@
       "source_file": "scripts/overlord/test_deploy_local_ci_gate.py",
       "source_location": "L27",
       "id": "test_deploy_local_ci_gate_testdeploylocalcigate_setup",
-      "community": 42
+      "community": 41
     },
     {
       "label": ".tearDown()",
@@ -6761,7 +6809,7 @@
       "source_file": "scripts/overlord/test_deploy_local_ci_gate.py",
       "source_location": "L36",
       "id": "test_deploy_local_ci_gate_testdeploylocalcigate_teardown",
-      "community": 42
+      "community": 41
     },
     {
       "label": "._invoke()",
@@ -6769,7 +6817,7 @@
       "source_file": "scripts/overlord/test_deploy_local_ci_gate.py",
       "source_location": "L39",
       "id": "test_deploy_local_ci_gate_testdeploylocalcigate_invoke",
-      "community": 42
+      "community": 41
     },
     {
       "label": "._shim()",
@@ -6777,7 +6825,7 @@
       "source_file": "scripts/overlord/test_deploy_local_ci_gate.py",
       "source_location": "L46",
       "id": "test_deploy_local_ci_gate_testdeploylocalcigate_shim",
-      "community": 42
+      "community": 41
     },
     {
       "label": "._write_fake_runner()",
@@ -6785,7 +6833,7 @@
       "source_file": "scripts/overlord/test_deploy_local_ci_gate.py",
       "source_location": "L49",
       "id": "test_deploy_local_ci_gate_testdeploylocalcigate_write_fake_runner",
-      "community": 42
+      "community": 41
     },
     {
       "label": ".test_resolve_reports_repo_local_target_and_write_set()",
@@ -6793,7 +6841,7 @@
       "source_file": "scripts/overlord/test_deploy_local_ci_gate.py",
       "source_location": "L57",
       "id": "test_deploy_local_ci_gate_testdeploylocalcigate_test_resolve_reports_repo_local_target_and_write_set",
-      "community": 42
+      "community": 41
     },
     {
       "label": ".test_dry_run_includes_managed_body_and_command_preview()",
@@ -6801,7 +6849,7 @@
       "source_file": "scripts/overlord/test_deploy_local_ci_gate.py",
       "source_location": "L81",
       "id": "test_deploy_local_ci_gate_testdeploylocalcigate_test_dry_run_includes_managed_body_and_command_preview",
-      "community": 42
+      "community": 41
     },
     {
       "label": ".test_install_refuses_unmanaged_existing_shim_without_override()",
@@ -6809,7 +6857,7 @@
       "source_file": "scripts/overlord/test_deploy_local_ci_gate.py",
       "source_location": "L109",
       "id": "test_deploy_local_ci_gate_testdeploylocalcigate_test_install_refuses_unmanaged_existing_shim_without_override",
-      "community": 42
+      "community": 41
     },
     {
       "label": ".test_install_with_backup_existing_renames_unmanaged_shim()",
@@ -6817,7 +6865,7 @@
       "source_file": "scripts/overlord/test_deploy_local_ci_gate.py",
       "source_location": "L127",
       "id": "test_deploy_local_ci_gate_testdeploylocalcigate_test_install_with_backup_existing_renames_unmanaged_shim",
-      "community": 42
+      "community": 41
     },
     {
       "label": ".test_installed_shim_uses_embedded_root_then_env_override()",
@@ -6825,7 +6873,7 @@
       "source_file": "scripts/overlord/test_deploy_local_ci_gate.py",
       "source_location": "L154",
       "id": "test_deploy_local_ci_gate_testdeploylocalcigate_test_installed_shim_uses_embedded_root_then_env_override",
-      "community": 42
+      "community": 41
     },
     {
       "label": ".test_installed_shim_remains_portable_when_copied_to_another_repo()",
@@ -6833,7 +6881,7 @@
       "source_file": "scripts/overlord/test_deploy_local_ci_gate.py",
       "source_location": "L186",
       "id": "test_deploy_local_ci_gate_testdeploylocalcigate_test_installed_shim_remains_portable_when_copied_to_another_repo",
-      "community": 42
+      "community": 41
     },
     {
       "label": ".test_installed_shim_propagates_runner_failure()",
@@ -6841,7 +6889,7 @@
       "source_file": "scripts/overlord/test_deploy_local_ci_gate.py",
       "source_location": "L215",
       "id": "test_deploy_local_ci_gate_testdeploylocalcigate_test_installed_shim_propagates_runner_failure",
-      "community": 42
+      "community": 41
     },
     {
       "label": ".test_installed_shim_propagates_real_runner_blocker_failure()",
@@ -6849,7 +6897,7 @@
       "source_file": "scripts/overlord/test_deploy_local_ci_gate.py",
       "source_location": "L231",
       "id": "test_deploy_local_ci_gate_testdeploylocalcigate_test_installed_shim_propagates_real_runner_blocker_failure",
-      "community": 42
+      "community": 41
     },
     {
       "label": ".test_refresh_updates_managed_shim_content()",
@@ -6857,7 +6905,7 @@
       "source_file": "scripts/overlord/test_deploy_local_ci_gate.py",
       "source_location": "L271",
       "id": "test_deploy_local_ci_gate_testdeploylocalcigate_test_refresh_updates_managed_shim_content",
-      "community": 42
+      "community": 41
     },
     {
       "label": ".test_rejects_shim_paths_outside_the_repo_local_allowlist()",
@@ -6865,7 +6913,7 @@
       "source_file": "scripts/overlord/test_deploy_local_ci_gate.py",
       "source_location": "L303",
       "id": "test_deploy_local_ci_gate_testdeploylocalcigate_test_rejects_shim_paths_outside_the_repo_local_allowlist",
-      "community": 42
+      "community": 41
     },
     {
       "label": "test_lane_bootstrap.py",
@@ -7345,7 +7393,7 @@
       "source_file": "scripts/overlord/test_schema_guard_hook.py",
       "source_location": "L1",
       "id": "test_schema_guard_hook",
-      "community": 51
+      "community": 50
     },
     {
       "label": "_payload()",
@@ -7353,7 +7401,7 @@
       "source_file": "scripts/overlord/test_schema_guard_hook.py",
       "source_location": "L16",
       "id": "test_schema_guard_hook_payload",
-      "community": 51
+      "community": 50
     },
     {
       "label": "_run_hook()",
@@ -7361,7 +7409,7 @@
       "source_file": "scripts/overlord/test_schema_guard_hook.py",
       "source_location": "L20",
       "id": "test_schema_guard_hook_run_hook",
-      "community": 51
+      "community": 50
     },
     {
       "label": "TestSchemaGuardHook",
@@ -7369,7 +7417,7 @@
       "source_file": "scripts/overlord/test_schema_guard_hook.py",
       "source_location": "L35",
       "id": "test_schema_guard_hook_testschemaguardhook",
-      "community": 51
+      "community": 50
     },
     {
       "label": ".test_blocked_bash_file_write_has_stderr()",
@@ -7377,7 +7425,7 @@
       "source_file": "scripts/overlord/test_schema_guard_hook.py",
       "source_location": "L36",
       "id": "test_schema_guard_hook_testschemaguardhook_test_blocked_bash_file_write_has_stderr",
-      "community": 51
+      "community": 50
     },
     {
       "label": ".test_trivial_plan_bypass_still_reaches_som_write_block()",
@@ -7385,7 +7433,7 @@
       "source_file": "scripts/overlord/test_schema_guard_hook.py",
       "source_location": "L46",
       "id": "test_schema_guard_hook_testschemaguardhook_test_trivial_plan_bypass_still_reaches_som_write_block",
-      "community": 51
+      "community": 50
     },
     {
       "label": ".test_missing_schema_has_explicit_stderr()",
@@ -7393,7 +7441,7 @@
       "source_file": "scripts/overlord/test_schema_guard_hook.py",
       "source_location": "L57",
       "id": "test_schema_guard_hook_testschemaguardhook_test_missing_schema_has_explicit_stderr",
-      "community": 51
+      "community": 50
     },
     {
       "label": ".test_malformed_input_payload_has_stderr()",
@@ -7401,7 +7449,7 @@
       "source_file": "scripts/overlord/test_schema_guard_hook.py",
       "source_location": "L66",
       "id": "test_schema_guard_hook_testschemaguardhook_test_malformed_input_payload_has_stderr",
-      "community": 51
+      "community": 50
     },
     {
       "label": ".test_validator_nonzero_is_summarized()",
@@ -7409,7 +7457,7 @@
       "source_file": "scripts/overlord/test_schema_guard_hook.py",
       "source_location": "L72",
       "id": "test_schema_guard_hook_testschemaguardhook_test_validator_nonzero_is_summarized",
-      "community": 51
+      "community": 50
     },
     {
       "label": ".test_allowed_read_only_command_remains_allowed()",
@@ -7417,7 +7465,7 @@
       "source_file": "scripts/overlord/test_schema_guard_hook.py",
       "source_location": "L88",
       "id": "test_schema_guard_hook_testschemaguardhook_test_allowed_read_only_command_remains_allowed",
-      "community": 51
+      "community": 50
     },
     {
       "label": ".test_quoted_awk_comparison_remains_allowed()",
@@ -7425,7 +7473,7 @@
       "source_file": "scripts/overlord/test_schema_guard_hook.py",
       "source_location": "L95",
       "id": "test_schema_guard_hook_testschemaguardhook_test_quoted_awk_comparison_remains_allowed",
-      "community": 51
+      "community": 50
     },
     {
       "label": ".test_quoted_jq_comparison_remains_allowed()",
@@ -7433,7 +7481,7 @@
       "source_file": "scripts/overlord/test_schema_guard_hook.py",
       "source_location": "L102",
       "id": "test_schema_guard_hook_testschemaguardhook_test_quoted_jq_comparison_remains_allowed",
-      "community": 51
+      "community": 50
     },
     {
       "label": ".test_common_read_only_analysis_pipelines_remain_allowed()",
@@ -7441,7 +7489,7 @@
       "source_file": "scripts/overlord/test_schema_guard_hook.py",
       "source_location": "L109",
       "id": "test_schema_guard_hook_testschemaguardhook_test_common_read_only_analysis_pipelines_remain_allowed",
-      "community": 51
+      "community": 50
     },
     {
       "label": ".test_python_file_write_policy_block_has_stderr()",
@@ -7449,7 +7497,7 @@
       "source_file": "scripts/overlord/test_schema_guard_hook.py",
       "source_location": "L125",
       "id": "test_schema_guard_hook_testschemaguardhook_test_python_file_write_policy_block_has_stderr",
-      "community": 51
+      "community": 50
     },
     {
       "label": "test_sweep_artifact_pr.py",
@@ -7521,103 +7569,119 @@
       "source_file": "scripts/overlord/test_validate_closeout.py",
       "source_location": "L1",
       "id": "test_validate_closeout",
-      "community": 11
+      "community": 47
     },
     {
       "label": "_write()",
       "file_type": "code",
       "source_file": "scripts/overlord/test_validate_closeout.py",
-      "source_location": "L11",
+      "source_location": "L20",
       "id": "test_validate_closeout_write",
-      "community": 11
+      "community": 47
     },
     {
       "label": "_json()",
       "file_type": "code",
       "source_file": "scripts/overlord/test_validate_closeout.py",
-      "source_location": "L16",
+      "source_location": "L25",
       "id": "test_validate_closeout_json",
-      "community": 11
+      "community": 47
     },
     {
       "label": "TestValidateCloseout",
       "file_type": "code",
       "source_file": "scripts/overlord/test_validate_closeout.py",
-      "source_location": "L20",
+      "source_location": "L29",
       "id": "test_validate_closeout_testvalidatecloseout",
-      "community": 11
+      "community": 47
     },
     {
       "label": "._repo()",
       "file_type": "code",
       "source_file": "scripts/overlord/test_validate_closeout.py",
-      "source_location": "L21",
+      "source_location": "L30",
       "id": "test_validate_closeout_testvalidatecloseout_repo",
-      "community": 11
+      "community": 47
     },
     {
       "label": "._closeout()",
       "file_type": "code",
       "source_file": "scripts/overlord/test_validate_closeout.py",
-      "source_location": "L69",
+      "source_location": "L78",
       "id": "test_validate_closeout_testvalidatecloseout_closeout",
-      "community": 11
+      "community": 47
     },
     {
       "label": ".test_valid_closeout_passes()",
       "file_type": "code",
       "source_file": "scripts/overlord/test_validate_closeout.py",
-      "source_location": "L109",
+      "source_location": "L118",
       "id": "test_validate_closeout_testvalidatecloseout_test_valid_closeout_passes",
-      "community": 11
+      "community": 47
     },
     {
       "label": ".test_missing_referenced_artifact_fails()",
       "file_type": "code",
       "source_file": "scripts/overlord/test_validate_closeout.py",
-      "source_location": "L115",
+      "source_location": "L124",
       "id": "test_validate_closeout_testvalidatecloseout_test_missing_referenced_artifact_fails",
-      "community": 11
+      "community": 47
     },
     {
       "label": ".test_residual_without_issue_ref_fails()",
       "file_type": "code",
       "source_file": "scripts/overlord/test_validate_closeout.py",
-      "source_location": "L122",
+      "source_location": "L131",
       "id": "test_validate_closeout_testvalidatecloseout_test_residual_without_issue_ref_fails",
-      "community": 11
+      "community": 47
     },
     {
       "label": ".test_handoff_without_lifecycle_record_fails()",
       "file_type": "code",
       "source_file": "scripts/overlord/test_validate_closeout.py",
-      "source_location": "L128",
+      "source_location": "L137",
       "id": "test_validate_closeout_testvalidatecloseout_test_handoff_without_lifecycle_record_fails",
-      "community": 11
+      "community": 47
     },
     {
       "label": ".test_placeholder_text_in_required_section_fails()",
       "file_type": "code",
       "source_file": "scripts/overlord/test_validate_closeout.py",
-      "source_location": "L134",
+      "source_location": "L143",
       "id": "test_validate_closeout_testvalidatecloseout_test_placeholder_text_in_required_section_fails",
-      "community": 11
+      "community": 47
     },
     {
       "label": ".test_gate_evidence_requires_artifact_or_command_result()",
       "file_type": "code",
       "source_file": "scripts/overlord/test_validate_closeout.py",
-      "source_location": "L143",
+      "source_location": "L152",
       "id": "test_validate_closeout_testvalidatecloseout_test_gate_evidence_requires_artifact_or_command_result",
-      "community": 11
+      "community": 47
+    },
+    {
+      "label": ".test_resolve_closeout_execution_mode_reads_scope()",
+      "file_type": "code",
+      "source_file": "scripts/overlord/test_validate_closeout.py",
+      "source_location": "L161",
+      "id": "test_validate_closeout_testvalidatecloseout_test_resolve_closeout_execution_mode_reads_scope",
+      "community": 47
+    },
+    {
+      "label": ".test_resolve_closeout_execution_mode_defaults_planning_only()",
+      "file_type": "code",
+      "source_file": "scripts/overlord/test_validate_closeout.py",
+      "source_location": "L168",
+      "id": "test_validate_closeout_testvalidatecloseout_test_resolve_closeout_execution_mode_defaults_planning_only",
+      "community": 47
     },
     {
       "label": ".test_hook_invokes_validator_before_graph_refresh()",
       "file_type": "code",
       "source_file": "scripts/overlord/test_validate_closeout.py",
-      "source_location": "L152",
+      "source_location": "L179",
       "id": "test_validate_closeout_testvalidatecloseout_test_hook_invokes_validator_before_graph_refresh",
-      "community": 11
+      "community": 47
     },
     {
       "label": "test_validate_governed_repos.py",
@@ -7625,7 +7689,7 @@
       "source_file": "scripts/overlord/test_validate_governed_repos.py",
       "source_location": "L1",
       "id": "test_validate_governed_repos",
-      "community": 52
+      "community": 51
     },
     {
       "label": "GovernedReposValidationTests",
@@ -7633,7 +7697,7 @@
       "source_file": "scripts/overlord/test_validate_governed_repos.py",
       "source_location": "L65",
       "id": "test_validate_governed_repos_governedreposvalidationtests",
-      "community": 52
+      "community": 51
     },
     {
       "label": ".write_registry()",
@@ -7641,7 +7705,7 @@
       "source_file": "scripts/overlord/test_validate_governed_repos.py",
       "source_location": "L66",
       "id": "test_validate_governed_repos_governedreposvalidationtests_write_registry",
-      "community": 52
+      "community": 51
     },
     {
       "label": ".assert_invalid()",
@@ -7649,7 +7713,7 @@
       "source_file": "scripts/overlord/test_validate_governed_repos.py",
       "source_location": "L73",
       "id": "test_validate_governed_repos_governedreposvalidationtests_assert_invalid",
-      "community": 52
+      "community": 51
     },
     {
       "label": ".test_valid_registry_classification_passes()",
@@ -7657,7 +7721,7 @@
       "source_file": "scripts/overlord/test_validate_governed_repos.py",
       "source_location": "L77",
       "id": "test_validate_governed_repos_governedreposvalidationtests_test_valid_registry_classification_passes",
-      "community": 52
+      "community": 51
     },
     {
       "label": ".test_missing_classification_fails()",
@@ -7665,7 +7729,7 @@
       "source_file": "scripts/overlord/test_validate_governed_repos.py",
       "source_location": "L80",
       "id": "test_validate_governed_repos_governedreposvalidationtests_test_missing_classification_fails",
-      "community": 52
+      "community": 51
     },
     {
       "label": ".test_extra_repository_field_fails()",
@@ -7673,7 +7737,7 @@
       "source_file": "scripts/overlord/test_validate_governed_repos.py",
       "source_location": "L85",
       "id": "test_validate_governed_repos_governedreposvalidationtests_test_extra_repository_field_fails",
-      "community": 52
+      "community": 51
     },
     {
       "label": ".test_extra_classification_field_fails()",
@@ -7681,7 +7745,7 @@
       "source_file": "scripts/overlord/test_validate_governed_repos.py",
       "source_location": "L90",
       "id": "test_validate_governed_repos_governedreposvalidationtests_test_extra_classification_field_fails",
-      "community": 52
+      "community": 51
     },
     {
       "label": ".test_missing_root_field_fails()",
@@ -7689,7 +7753,7 @@
       "source_file": "scripts/overlord/test_validate_governed_repos.py",
       "source_location": "L95",
       "id": "test_validate_governed_repos_governedreposvalidationtests_test_missing_root_field_fails",
-      "community": 52
+      "community": 51
     },
     {
       "label": ".test_invalid_lifecycle_status_fails()",
@@ -7697,7 +7761,7 @@
       "source_file": "scripts/overlord/test_validate_governed_repos.py",
       "source_location": "L100",
       "id": "test_validate_governed_repos_governedreposvalidationtests_test_invalid_lifecycle_status_fails",
-      "community": 52
+      "community": 51
     },
     {
       "label": ".test_invalid_governance_status_fails()",
@@ -7705,7 +7769,7 @@
       "source_file": "scripts/overlord/test_validate_governed_repos.py",
       "source_location": "L105",
       "id": "test_validate_governed_repos_governedreposvalidationtests_test_invalid_governance_status_fails",
-      "community": 52
+      "community": 51
     },
     {
       "label": ".test_empty_issue_refs_fails()",
@@ -7713,7 +7777,7 @@
       "source_file": "scripts/overlord/test_validate_governed_repos.py",
       "source_location": "L110",
       "id": "test_validate_governed_repos_governedreposvalidationtests_test_empty_issue_refs_fails",
-      "community": 52
+      "community": 51
     },
     {
       "label": ".test_bad_review_date_fails()",
@@ -7721,7 +7785,7 @@
       "source_file": "scripts/overlord/test_validate_governed_repos.py",
       "source_location": "L115",
       "id": "test_validate_governed_repos_governedreposvalidationtests_test_bad_review_date_fails",
-      "community": 52
+      "community": 51
     },
     {
       "label": ".test_non_boolean_subsystem_value_fails()",
@@ -7729,12 +7793,12 @@
       "source_file": "scripts/overlord/test_validate_governed_repos.py",
       "source_location": "L120",
       "id": "test_validate_governed_repos_governedreposvalidationtests_test_non_boolean_subsystem_value_fails",
-      "community": 52
+      "community": 51
     },
     {
       "label": "test_validate_handoff_package.py",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_handoff_package.py",
+      "source_file": "scripts/overlord/test_validate_handoff_package.py",
       "source_location": "L1",
       "id": "test_validate_handoff_package",
       "community": 28
@@ -7742,7 +7806,7 @@
     {
       "label": "_plan()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_handoff_package.py",
+      "source_file": "scripts/overlord/test_validate_handoff_package.py",
       "source_location": "L24",
       "id": "test_validate_handoff_package_plan",
       "community": 28
@@ -7750,7 +7814,7 @@
     {
       "label": "_scope()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_handoff_package.py",
+      "source_file": "scripts/overlord/test_validate_handoff_package.py",
       "source_location": "L75",
       "id": "test_validate_handoff_package_scope",
       "community": 28
@@ -7758,7 +7822,7 @@
     {
       "label": "_consumer_scope()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_handoff_package.py",
+      "source_file": "scripts/overlord/test_validate_handoff_package.py",
       "source_location": "L100",
       "id": "test_validate_handoff_package_consumer_scope",
       "community": 28
@@ -7766,7 +7830,7 @@
     {
       "label": "_handoff()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_handoff_package.py",
+      "source_file": "scripts/overlord/test_validate_handoff_package.py",
       "source_location": "L109",
       "id": "test_validate_handoff_package_handoff",
       "community": 28
@@ -7774,7 +7838,7 @@
     {
       "label": "_write_json()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_handoff_package.py",
+      "source_file": "scripts/overlord/test_validate_handoff_package.py",
       "source_location": "L141",
       "id": "test_validate_handoff_package_write_json",
       "community": 28
@@ -7782,7 +7846,7 @@
     {
       "label": "_write_supporting_files()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_handoff_package.py",
+      "source_file": "scripts/overlord/test_validate_handoff_package.py",
       "source_location": "L148",
       "id": "test_validate_handoff_package_write_supporting_files",
       "community": 28
@@ -7790,7 +7854,7 @@
     {
       "label": "TestValidateHandoffPackage",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_handoff_package.py",
+      "source_file": "scripts/overlord/test_validate_handoff_package.py",
       "source_location": "L163",
       "id": "test_validate_handoff_package_testvalidatehandoffpackage",
       "community": 28
@@ -7798,7 +7862,7 @@
     {
       "label": "._run_main()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_handoff_package.py",
+      "source_file": "scripts/overlord/test_validate_handoff_package.py",
       "source_location": "L164",
       "id": "test_validate_handoff_package_testvalidatehandoffpackage_run_main",
       "community": 28
@@ -7806,7 +7870,7 @@
     {
       "label": ".test_valid_package_passes()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_handoff_package.py",
+      "source_file": "scripts/overlord/test_validate_handoff_package.py",
       "source_location": "L171",
       "id": "test_validate_handoff_package_testvalidatehandoffpackage_test_valid_package_passes",
       "community": 28
@@ -7814,7 +7878,7 @@
     {
       "label": ".test_missing_execution_scope_fails_for_implementation_ready()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_handoff_package.py",
+      "source_file": "scripts/overlord/test_validate_handoff_package.py",
       "source_location": "L179",
       "id": "test_validate_handoff_package_testvalidatehandoffpackage_test_missing_execution_scope_fails_for_implementation_ready",
       "community": 28
@@ -7822,7 +7886,7 @@
     {
       "label": ".test_structured_plan_issue_mismatch_fails()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_handoff_package.py",
+      "source_file": "scripts/overlord/test_validate_handoff_package.py",
       "source_location": "L189",
       "id": "test_validate_handoff_package_testvalidatehandoffpackage_test_structured_plan_issue_mismatch_fails",
       "community": 28
@@ -7830,7 +7894,7 @@
     {
       "label": ".test_execution_scope_lane_claim_mismatch_fails()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_handoff_package.py",
+      "source_file": "scripts/overlord/test_validate_handoff_package.py",
       "source_location": "L198",
       "id": "test_validate_handoff_package_testvalidatehandoffpackage_test_execution_scope_lane_claim_mismatch_fails",
       "community": 28
@@ -7838,7 +7902,7 @@
     {
       "label": ".test_accepted_package_requires_closeout_ref()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_handoff_package.py",
+      "source_file": "scripts/overlord/test_validate_handoff_package.py",
       "source_location": "L207",
       "id": "test_validate_handoff_package_testvalidatehandoffpackage_test_accepted_package_requires_closeout_ref",
       "community": 28
@@ -7846,7 +7910,7 @@
     {
       "label": ".test_validation_ready_package_requires_packet_ref()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_handoff_package.py",
+      "source_file": "scripts/overlord/test_validate_handoff_package.py",
       "source_location": "L219",
       "id": "test_validate_handoff_package_testvalidatehandoffpackage_test_validation_ready_package_requires_packet_ref",
       "community": 28
@@ -7854,7 +7918,7 @@
     {
       "label": ".test_implementation_ready_requires_non_empty_review_artifact_refs()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_handoff_package.py",
+      "source_file": "scripts/overlord/test_validate_handoff_package.py",
       "source_location": "L230",
       "id": "test_validate_handoff_package_testvalidatehandoffpackage_test_implementation_ready_requires_non_empty_review_artifact_refs",
       "community": 28
@@ -7862,7 +7926,7 @@
     {
       "label": ".test_in_progress_requires_non_empty_gate_artifact_refs()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_handoff_package.py",
+      "source_file": "scripts/overlord/test_validate_handoff_package.py",
       "source_location": "L241",
       "id": "test_validate_handoff_package_testvalidatehandoffpackage_test_in_progress_requires_non_empty_gate_artifact_refs",
       "community": 28
@@ -7870,7 +7934,7 @@
     {
       "label": ".test_historical_implementation_ready_package_is_grandfathered_without_new_evidence_refs()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_handoff_package.py",
+      "source_file": "scripts/overlord/test_validate_handoff_package.py",
       "source_location": "L253",
       "id": "test_validate_handoff_package_testvalidatehandoffpackage_test_historical_implementation_ready_package_is_grandfathered_without_new_evidence_refs",
       "community": 28
@@ -7878,7 +7942,7 @@
     {
       "label": ".test_validation_ready_requires_non_empty_review_and_gate_artifact_refs()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_handoff_package.py",
+      "source_file": "scripts/overlord/test_validate_handoff_package.py",
       "source_location": "L264",
       "id": "test_validate_handoff_package_testvalidatehandoffpackage_test_validation_ready_requires_non_empty_review_and_gate_artifact_refs",
       "community": 28
@@ -7886,7 +7950,7 @@
     {
       "label": ".test_accepted_requires_non_empty_review_and_gate_artifact_refs()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_handoff_package.py",
+      "source_file": "scripts/overlord/test_validate_handoff_package.py",
       "source_location": "L282",
       "id": "test_validate_handoff_package_testvalidatehandoffpackage_test_accepted_requires_non_empty_review_and_gate_artifact_refs",
       "community": 28
@@ -7894,7 +7958,7 @@
     {
       "label": ".test_missing_structured_plan_ref_fails()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_handoff_package.py",
+      "source_file": "scripts/overlord/test_validate_handoff_package.py",
       "source_location": "L304",
       "id": "test_validate_handoff_package_testvalidatehandoffpackage_test_missing_structured_plan_ref_fails",
       "community": 28
@@ -7902,7 +7966,7 @@
     {
       "label": ".test_empty_acceptance_criteria_fails()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_handoff_package.py",
+      "source_file": "scripts/overlord/test_validate_handoff_package.py",
       "source_location": "L314",
       "id": "test_validate_handoff_package_testvalidatehandoffpackage_test_empty_acceptance_criteria_fails",
       "community": 28
@@ -7910,7 +7974,7 @@
     {
       "label": ".test_unsafe_handoff_ref_fails_without_traceback()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_handoff_package.py",
+      "source_file": "scripts/overlord/test_validate_handoff_package.py",
       "source_location": "L326",
       "id": "test_validate_handoff_package_testvalidatehandoffpackage_test_unsafe_handoff_ref_fails_without_traceback",
       "community": 28
@@ -7918,7 +7982,7 @@
     {
       "label": ".test_invalid_handoff_id_fails()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_handoff_package.py",
+      "source_file": "scripts/overlord/test_validate_handoff_package.py",
       "source_location": "L338",
       "id": "test_validate_handoff_package_testvalidatehandoffpackage_test_invalid_handoff_id_fails",
       "community": 28
@@ -7926,7 +7990,7 @@
     {
       "label": ".test_accepted_consumer_managed_handoff_requires_consumer_verifier_command()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_handoff_package.py",
+      "source_file": "scripts/overlord/test_validate_handoff_package.py",
       "source_location": "L350",
       "id": "test_validate_handoff_package_testvalidatehandoffpackage_test_accepted_consumer_managed_handoff_requires_consumer_verifier_command",
       "community": 28
@@ -7934,7 +7998,7 @@
     {
       "label": ".test_accepted_consumer_managed_handoff_requires_verifier_evidence_refs()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_handoff_package.py",
+      "source_file": "scripts/overlord/test_validate_handoff_package.py",
       "source_location": "L368",
       "id": "test_validate_handoff_package_testvalidatehandoffpackage_test_accepted_consumer_managed_handoff_requires_verifier_evidence_refs",
       "community": 28
@@ -7942,7 +8006,7 @@
     {
       "label": ".test_accepted_consumer_managed_handoff_passes_with_verifier_command_and_evidence()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_handoff_package.py",
+      "source_file": "scripts/overlord/test_validate_handoff_package.py",
       "source_location": "L386",
       "id": "test_validate_handoff_package_testvalidatehandoffpackage_test_accepted_consumer_managed_handoff_passes_with_verifier_command_and_evidence",
       "community": 28
@@ -8062,7 +8126,7 @@
     {
       "label": "test_validate_session_contract_surfaces.py",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_session_contract_surfaces.py",
+      "source_file": "scripts/overlord/test_validate_session_contract_surfaces.py",
       "source_location": "L1",
       "id": "test_validate_session_contract_surfaces",
       "community": 74
@@ -8070,7 +8134,7 @@
     {
       "label": "_write()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_session_contract_surfaces.py",
+      "source_file": "scripts/overlord/test_validate_session_contract_surfaces.py",
       "source_location": "L12",
       "id": "test_validate_session_contract_surfaces_write",
       "community": 74
@@ -8078,7 +8142,7 @@
     {
       "label": "_settings()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_session_contract_surfaces.py",
+      "source_file": "scripts/overlord/test_validate_session_contract_surfaces.py",
       "source_location": "L18",
       "id": "test_validate_session_contract_surfaces_settings",
       "community": 74
@@ -8086,7 +8150,7 @@
     {
       "label": "ValidateSessionContractSurfacesTests",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_session_contract_surfaces.py",
+      "source_file": "scripts/overlord/test_validate_session_contract_surfaces.py",
       "source_location": "L48",
       "id": "test_validate_session_contract_surfaces_validatesessioncontractsurfacestests",
       "community": 74
@@ -8094,7 +8158,7 @@
     {
       "label": ".test_valid_surfaces_pass()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_session_contract_surfaces.py",
+      "source_file": "scripts/overlord/test_validate_session_contract_surfaces.py",
       "source_location": "L49",
       "id": "test_validate_session_contract_surfaces_validatesessioncontractsurfacestests_test_valid_surfaces_pass",
       "community": 74
@@ -8102,7 +8166,7 @@
     {
       "label": ".test_missing_wrapper_fails()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_session_contract_surfaces.py",
+      "source_file": "scripts/overlord/test_validate_session_contract_surfaces.py",
       "source_location": "L65",
       "id": "test_validate_session_contract_surfaces_validatesessioncontractsurfacestests_test_missing_wrapper_fails",
       "community": 74
@@ -8110,7 +8174,7 @@
     {
       "label": ".test_missing_user_prompt_submit_command_fails()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_session_contract_surfaces.py",
+      "source_file": "scripts/overlord/test_validate_session_contract_surfaces.py",
       "source_location": "L81",
       "id": "test_validate_session_contract_surfaces_validatesessioncontractsurfacestests_test_missing_user_prompt_submit_command_fails",
       "community": 74
@@ -8262,247 +8326,311 @@
     {
       "label": "test_validate_structured_agent_cycle_plan.py",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_structured_agent_cycle_plan.py",
+      "source_file": "scripts/overlord/test_validate_structured_agent_cycle_plan.py",
       "source_location": "L1",
       "id": "test_validate_structured_agent_cycle_plan",
-      "community": 22
+      "community": 18
     },
     {
       "label": "_plan()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_structured_agent_cycle_plan.py",
+      "source_file": "scripts/overlord/test_validate_structured_agent_cycle_plan.py",
       "source_location": "L15",
       "id": "test_validate_structured_agent_cycle_plan_plan",
-      "community": 22
+      "community": 18
     },
     {
       "label": "TestGovernanceSurfacePlanGate",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_structured_agent_cycle_plan.py",
-      "source_location": "L74",
+      "source_file": "scripts/overlord/test_validate_structured_agent_cycle_plan.py",
+      "source_location": "L103",
       "id": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate",
-      "community": 22
+      "community": 18
     },
     {
       "label": "._run()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_structured_agent_cycle_plan.py",
-      "source_location": "L75",
+      "source_file": "scripts/overlord/test_validate_structured_agent_cycle_plan.py",
+      "source_location": "L104",
       "id": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate_run",
-      "community": 22
+      "community": 18
     },
     {
       "label": "._run_with_scope_gate()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_structured_agent_cycle_plan.py",
-      "source_location": "L95",
+      "source_file": "scripts/overlord/test_validate_structured_agent_cycle_plan.py",
+      "source_location": "L124",
       "id": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate_run_with_scope_gate",
-      "community": 22
+      "community": 18
     },
     {
       "label": "._write_scope()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_structured_agent_cycle_plan.py",
-      "source_location": "L116",
+      "source_file": "scripts/overlord/test_validate_structured_agent_cycle_plan.py",
+      "source_location": "L145",
       "id": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate_write_scope",
-      "community": 22
+      "community": 18
     },
     {
       "label": ".test_non_issue_branch_with_governance_surface_change_fails()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_structured_agent_cycle_plan.py",
-      "source_location": "L132",
+      "source_file": "scripts/overlord/test_validate_structured_agent_cycle_plan.py",
+      "source_location": "L161",
       "id": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate_test_non_issue_branch_with_governance_surface_change_fails",
-      "community": 22
+      "community": 18
     },
     {
       "label": ".test_non_issue_branch_does_not_validate_unmatched_plans_for_readiness()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_structured_agent_cycle_plan.py",
-      "source_location": "L138",
+      "source_file": "scripts/overlord/test_validate_structured_agent_cycle_plan.py",
+      "source_location": "L167",
       "id": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate_test_non_issue_branch_does_not_validate_unmatched_plans_for_readiness",
-      "community": 22
+      "community": 18
     },
     {
       "label": ".test_github_scripts_are_governance_surface()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_structured_agent_cycle_plan.py",
-      "source_location": "L149",
+      "source_file": "scripts/overlord/test_validate_structured_agent_cycle_plan.py",
+      "source_location": "L178",
       "id": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate_test_github_scripts_are_governance_surface",
-      "community": 22
+      "community": 18
     },
     {
       "label": ".test_github_workflows_with_leading_dot_are_governance_surface()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_structured_agent_cycle_plan.py",
-      "source_location": "L155",
+      "source_file": "scripts/overlord/test_validate_structured_agent_cycle_plan.py",
+      "source_location": "L184",
       "id": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate_test_github_workflows_with_leading_dot_are_governance_surface",
-      "community": 22
+      "community": 18
     },
     {
       "label": ".test_launchd_and_orchestrator_paths_are_governance_surface()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_structured_agent_cycle_plan.py",
-      "source_location": "L161",
+      "source_file": "scripts/overlord/test_validate_structured_agent_cycle_plan.py",
+      "source_location": "L190",
       "id": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate_test_launchd_and_orchestrator_paths_are_governance_surface",
-      "community": 22
+      "community": 18
     },
     {
       "label": ".test_lam_runtime_paths_are_governance_surface()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_structured_agent_cycle_plan.py",
-      "source_location": "L168",
+      "source_file": "scripts/overlord/test_validate_structured_agent_cycle_plan.py",
+      "source_location": "L197",
       "id": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate_test_lam_runtime_paths_are_governance_surface",
-      "community": 22
+      "community": 18
     },
     {
       "label": ".test_packet_paths_are_governance_surface()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_structured_agent_cycle_plan.py",
-      "source_location": "L174",
+      "source_file": "scripts/overlord/test_validate_structured_agent_cycle_plan.py",
+      "source_location": "L203",
       "id": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate_test_packet_paths_are_governance_surface",
-      "community": 22
+      "community": 18
     },
     {
       "label": ".test_self_learning_paths_are_governance_surface()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_structured_agent_cycle_plan.py",
-      "source_location": "L190",
+      "source_file": "scripts/overlord/test_validate_structured_agent_cycle_plan.py",
+      "source_location": "L219",
       "id": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate_test_self_learning_paths_are_governance_surface",
-      "community": 22
+      "community": 18
     },
     {
       "label": ".test_pilot_gate_and_metrics_paths_are_governance_surface()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_structured_agent_cycle_plan.py",
-      "source_location": "L204",
+      "source_file": "scripts/overlord/test_validate_structured_agent_cycle_plan.py",
+      "source_location": "L233",
       "id": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate_test_pilot_gate_and_metrics_paths_are_governance_surface",
-      "community": 22
+      "community": 18
     },
     {
       "label": ".test_riskfix_branch_without_issue_number_gets_specific_issue_hint()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_structured_agent_cycle_plan.py",
-      "source_location": "L218",
+      "source_file": "scripts/overlord/test_validate_structured_agent_cycle_plan.py",
+      "source_location": "L247",
       "id": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate_test_riskfix_branch_without_issue_number_gets_specific_issue_hint",
-      "community": 22
+      "community": 18
     },
     {
       "label": ".test_non_governance_surface_change_without_plan_passes()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_structured_agent_cycle_plan.py",
-      "source_location": "L224",
+      "source_file": "scripts/overlord/test_validate_structured_agent_cycle_plan.py",
+      "source_location": "L253",
       "id": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate_test_non_governance_surface_change_without_plan_passes",
-      "community": 22
+      "community": 18
     },
     {
       "label": ".test_issue_branch_requires_matching_plan()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_structured_agent_cycle_plan.py",
-      "source_location": "L229",
+      "source_file": "scripts/overlord/test_validate_structured_agent_cycle_plan.py",
+      "source_location": "L258",
       "id": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate_test_issue_branch_requires_matching_plan",
-      "community": 22
+      "community": 18
     },
     {
       "label": ".test_issue_branch_matching_approved_plan_passes()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_structured_agent_cycle_plan.py",
-      "source_location": "L235",
+      "source_file": "scripts/overlord/test_validate_structured_agent_cycle_plan.py",
+      "source_location": "L264",
       "id": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate_test_issue_branch_matching_approved_plan_passes",
-      "community": 22
+      "community": 18
     },
     {
       "label": ".test_planner_boundary_scope_gate_requires_issue_specific_scope()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_structured_agent_cycle_plan.py",
-      "source_location": "L244",
+      "source_file": "scripts/overlord/test_validate_structured_agent_cycle_plan.py",
+      "source_location": "L273",
       "id": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate_test_planner_boundary_scope_gate_requires_issue_specific_scope",
-      "community": 22
+      "community": 18
     },
     {
       "label": ".test_planner_boundary_scope_gate_accepts_matching_scope()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_structured_agent_cycle_plan.py",
-      "source_location": "L262",
+      "source_file": "scripts/overlord/test_validate_structured_agent_cycle_plan.py",
+      "source_location": "L291",
       "id": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate_test_planner_boundary_scope_gate_accepts_matching_scope",
-      "community": 22
+      "community": 18
     },
     {
       "label": ".test_matching_plan_must_be_implementation_ready()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_structured_agent_cycle_plan.py",
-      "source_location": "L280",
+      "source_file": "scripts/overlord/test_validate_structured_agent_cycle_plan.py",
+      "source_location": "L309",
       "id": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate_test_matching_plan_must_be_implementation_ready",
-      "community": 22
+      "community": 18
+    },
+    {
+      "label": ".test_planning_evidence_only_changes_allow_planning_only_mode()",
+      "file_type": "code",
+      "source_file": "scripts/overlord/test_validate_structured_agent_cycle_plan.py",
+      "source_location": "L319",
+      "id": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate_test_planning_evidence_only_changes_allow_planning_only_mode",
+      "community": 18
     },
     {
       "label": ".test_required_alternate_review_must_be_accepted()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_structured_agent_cycle_plan.py",
-      "source_location": "L290",
+      "source_file": "scripts/overlord/test_validate_structured_agent_cycle_plan.py",
+      "source_location": "L337",
       "id": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate_test_required_alternate_review_must_be_accepted",
-      "community": 22
+      "community": 18
     },
     {
       "label": ".test_active_issue_branch_validates_matching_plan_review_gate_without_governance_surface_flag()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_structured_agent_cycle_plan.py",
-      "source_location": "L300",
+      "source_file": "scripts/overlord/test_validate_structured_agent_cycle_plan.py",
+      "source_location": "L347",
       "id": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate_test_active_issue_branch_validates_matching_plan_review_gate_without_governance_surface_flag",
-      "community": 22
+      "community": 18
     },
     {
       "label": ".test_active_issue_branch_requires_review_gate_to_be_marked_required()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_structured_agent_cycle_plan.py",
-      "source_location": "L323",
+      "source_file": "scripts/overlord/test_validate_structured_agent_cycle_plan.py",
+      "source_location": "L370",
       "id": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate_test_active_issue_branch_requires_review_gate_to_be_marked_required",
-      "community": 22
+      "community": 18
+    },
+    {
+      "label": ".test_active_issue_branch_requires_plan_author_identity()",
+      "file_type": "code",
+      "source_file": "scripts/overlord/test_validate_structured_agent_cycle_plan.py",
+      "source_location": "L393",
+      "id": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate_test_active_issue_branch_requires_plan_author_identity",
+      "community": 18
+    },
+    {
+      "label": ".test_active_issue_branch_rejects_same_model_self_review()",
+      "file_type": "code",
+      "source_file": "scripts/overlord/test_validate_structured_agent_cycle_plan.py",
+      "source_location": "L419",
+      "id": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate_test_active_issue_branch_rejects_same_model_self_review",
+      "community": 18
+    },
+    {
+      "label": ".test_active_issue_branch_requires_review_refs_once_specialist_review_is_accepted()",
+      "file_type": "code",
+      "source_file": "scripts/overlord/test_validate_structured_agent_cycle_plan.py",
+      "source_location": "L445",
+      "id": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate_test_active_issue_branch_requires_review_refs_once_specialist_review_is_accepted",
+      "community": 18
+    },
+    {
+      "label": ".test_active_issue_branch_requires_handoff_package_ref()",
+      "file_type": "code",
+      "source_file": "scripts/overlord/test_validate_structured_agent_cycle_plan.py",
+      "source_location": "L471",
+      "id": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate_test_active_issue_branch_requires_handoff_package_ref",
+      "community": 18
+    },
+    {
+      "label": ".test_planning_only_active_issue_branch_requires_legal_alternate_review_exemption()",
+      "file_type": "code",
+      "source_file": "scripts/overlord/test_validate_structured_agent_cycle_plan.py",
+      "source_location": "L497",
+      "id": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate_test_planning_only_active_issue_branch_requires_legal_alternate_review_exemption",
+      "community": 18
+    },
+    {
+      "label": ".test_planning_only_active_issue_branch_accepts_bounded_historical_exemption()",
+      "file_type": "code",
+      "source_file": "scripts/overlord/test_validate_structured_agent_cycle_plan.py",
+      "source_location": "L531",
+      "id": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate_test_planning_only_active_issue_branch_accepts_bounded_historical_exemption",
+      "community": 18
+    },
+    {
+      "label": ".test_stampede_issue_184_failure_shape_is_rejected()",
+      "file_type": "code",
+      "source_file": "scripts/overlord/test_validate_structured_agent_cycle_plan.py",
+      "source_location": "L570",
+      "id": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate_test_stampede_issue_184_failure_shape_is_rejected",
+      "community": 18
     },
     {
       "label": ".test_historical_implementation_ready_plan_does_not_fail_without_matching_issue_branch()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_structured_agent_cycle_plan.py",
-      "source_location": "L346",
+      "source_file": "scripts/overlord/test_validate_structured_agent_cycle_plan.py",
+      "source_location": "L611",
       "id": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate_test_historical_implementation_ready_plan_does_not_fail_without_matching_issue_branch",
-      "community": 22
+      "community": 18
     },
     {
-      "label": ".test_historical_issue_branch_plan_is_grandfathered_before_review_gate_cutover()",
+      "label": ".test_active_issue_branch_is_not_grandfathered_out_of_new_identity_gate()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_structured_agent_cycle_plan.py",
-      "source_location": "L366",
-      "id": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate_test_historical_issue_branch_plan_is_grandfathered_before_review_gate_cutover",
-      "community": 22
+      "source_file": "scripts/overlord/test_validate_structured_agent_cycle_plan.py",
+      "source_location": "L631",
+      "id": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate_test_active_issue_branch_is_not_grandfathered_out_of_new_identity_gate",
+      "community": 18
     },
     {
       "label": ".test_malformed_json_reports_structured_fail_without_traceback()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_structured_agent_cycle_plan.py",
-      "source_location": "L398",
+      "source_file": "scripts/overlord/test_validate_structured_agent_cycle_plan.py",
+      "source_location": "L668",
       "id": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate_test_malformed_json_reports_structured_fail_without_traceback",
-      "community": 22
+      "community": 18
     },
     {
       "label": ".test_malformed_matching_plan_does_not_crash_governance_surface_gate()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_structured_agent_cycle_plan.py",
-      "source_location": "L414",
+      "source_file": "scripts/overlord/test_validate_structured_agent_cycle_plan.py",
+      "source_location": "L684",
       "id": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate_test_malformed_matching_plan_does_not_crash_governance_surface_gate",
-      "community": 22
+      "community": 18
     },
     {
       "label": ".test_plan_read_error_reports_structured_fail_without_traceback()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_structured_agent_cycle_plan.py",
-      "source_location": "L427",
+      "source_file": "scripts/overlord/test_validate_structured_agent_cycle_plan.py",
+      "source_location": "L697",
       "id": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate_test_plan_read_error_reports_structured_fail_without_traceback",
-      "community": 22
+      "community": 18
     },
     {
       "label": "test_verify_governance_consumer.py",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L1",
       "id": "test_verify_governance_consumer",
       "community": 6
@@ -8510,7 +8638,7 @@
     {
       "label": "TestVerifyGovernanceConsumer",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L36",
       "id": "test_verify_governance_consumer_testverifygovernanceconsumer",
       "community": 6
@@ -8518,7 +8646,7 @@
     {
       "label": ".setUp()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L37",
       "id": "test_verify_governance_consumer_testverifygovernanceconsumer_setup",
       "community": 6
@@ -8526,7 +8654,7 @@
     {
       "label": ".tearDown()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L50",
       "id": "test_verify_governance_consumer_testverifygovernanceconsumer_teardown",
       "community": 6
@@ -8534,7 +8662,7 @@
     {
       "label": "._deploy()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L53",
       "id": "test_verify_governance_consumer_testverifygovernanceconsumer_deploy",
       "community": 6
@@ -8542,7 +8670,7 @@
     {
       "label": "._invoke()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L71",
       "id": "test_verify_governance_consumer_testverifygovernanceconsumer_invoke",
       "community": 6
@@ -8550,7 +8678,7 @@
     {
       "label": "._base_args()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L78",
       "id": "test_verify_governance_consumer_testverifygovernanceconsumer_base_args",
       "community": 6
@@ -8558,7 +8686,7 @@
     {
       "label": "._record()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L90",
       "id": "test_verify_governance_consumer_testverifygovernanceconsumer_record",
       "community": 6
@@ -8566,7 +8694,7 @@
     {
       "label": "._shim()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L93",
       "id": "test_verify_governance_consumer_testverifygovernanceconsumer_shim",
       "community": 6
@@ -8574,7 +8702,7 @@
     {
       "label": "._read_record()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L96",
       "id": "test_verify_governance_consumer_testverifygovernanceconsumer_read_record",
       "community": 6
@@ -8582,7 +8710,7 @@
     {
       "label": "._write_record()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L99",
       "id": "test_verify_governance_consumer_testverifygovernanceconsumer_write_record",
       "community": 6
@@ -8590,7 +8718,7 @@
     {
       "label": "._valid_override()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L102",
       "id": "test_verify_governance_consumer_testverifygovernanceconsumer_valid_override",
       "community": 6
@@ -8598,7 +8726,7 @@
     {
       "label": "._next_package_version()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L110",
       "id": "test_verify_governance_consumer_testverifygovernanceconsumer_next_package_version",
       "community": 6
@@ -8606,7 +8734,7 @@
     {
       "label": "._required_constraints()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L114",
       "id": "test_verify_governance_consumer_testverifygovernanceconsumer_required_constraints",
       "community": 6
@@ -8614,7 +8742,7 @@
     {
       "label": ".test_verify_passes_for_deployed_pinned_consumer_record()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L118",
       "id": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_passes_for_deployed_pinned_consumer_record",
       "community": 6
@@ -8622,7 +8750,7 @@
     {
       "label": ".test_verify_fails_when_record_missing()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L130",
       "id": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_when_record_missing",
       "community": 6
@@ -8630,7 +8758,7 @@
     {
       "label": ".test_verify_fails_when_governance_root_is_typoed()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L137",
       "id": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_when_governance_root_is_typoed",
       "community": 6
@@ -8638,7 +8766,7 @@
     {
       "label": ".test_verify_fails_when_record_is_malformed_shape()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L156",
       "id": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_when_record_is_malformed_shape",
       "community": 6
@@ -8646,7 +8774,7 @@
     {
       "label": ".test_verify_fails_when_governance_ref_is_not_sha()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L167",
       "id": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_when_governance_ref_is_not_sha",
       "community": 6
@@ -8654,7 +8782,7 @@
     {
       "label": ".test_verify_fails_when_shim_missing_marker()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L184",
       "id": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_when_shim_missing_marker",
       "community": 6
@@ -8662,7 +8790,7 @@
     {
       "label": ".test_verify_fails_when_expected_profile_mismatches()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L194",
       "id": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_when_expected_profile_mismatches",
       "community": 6
@@ -8670,7 +8798,7 @@
     {
       "label": ".test_verify_fails_when_managed_file_record_omits_expected_path()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L210",
       "id": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_when_managed_file_record_omits_expected_path",
       "community": 6
@@ -8678,7 +8806,7 @@
     {
       "label": ".test_verify_fails_when_profile_is_unknown()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L222",
       "id": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_when_profile_is_unknown",
       "community": 6
@@ -8686,7 +8814,7 @@
     {
       "label": ".test_verify_fails_when_profile_is_missing()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L239",
       "id": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_when_profile_is_missing",
       "community": 6
@@ -8694,7 +8822,7 @@
     {
       "label": ".test_verify_fails_for_mutable_governance_workflow_ref()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L252",
       "id": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_for_mutable_governance_workflow_ref",
       "community": 6
@@ -8702,7 +8830,7 @@
     {
       "label": ".test_verify_fails_workflow_ref_is_tag()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L267",
       "id": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_workflow_ref_is_tag",
       "community": 6
@@ -8710,7 +8838,7 @@
     {
       "label": ".test_verify_fails_workflow_ref_is_short_sha()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L284",
       "id": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_workflow_ref_is_short_sha",
       "community": 6
@@ -8718,7 +8846,7 @@
     {
       "label": ".test_verify_fails_workflow_ref_sha_mismatch()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L301",
       "id": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_workflow_ref_sha_mismatch",
       "community": 6
@@ -8726,7 +8854,7 @@
     {
       "label": ".test_verify_fails_stale_workflow_ref_before_acceptance()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L319",
       "id": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_stale_workflow_ref_before_acceptance",
       "community": 6
@@ -8734,7 +8862,7 @@
     {
       "label": ".test_verify_fails_for_managed_hook_checksum_drift()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L340",
       "id": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_for_managed_hook_checksum_drift",
       "community": 6
@@ -8742,7 +8870,7 @@
     {
       "label": ".test_verify_fails_for_managed_hook_missing_marker()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L361",
       "id": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_for_managed_hook_missing_marker",
       "community": 6
@@ -8750,7 +8878,7 @@
     {
       "label": ".test_verify_fails_for_invalid_override_metadata_and_reports_observed_override()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L376",
       "id": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_for_invalid_override_metadata_and_reports_observed_override",
       "community": 6
@@ -8758,7 +8886,7 @@
     {
       "label": ".test_verify_fails_for_malformed_local_overrides()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L390",
       "id": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_for_malformed_local_overrides",
       "community": 6
@@ -8766,7 +8894,7 @@
     {
       "label": ".test_verify_fails_override_empty_owner()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L405",
       "id": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_override_empty_owner",
       "community": 6
@@ -8774,7 +8902,7 @@
     {
       "label": ".test_verify_fails_override_non_string_reason()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L420",
       "id": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_override_non_string_reason",
       "community": 6
@@ -8782,7 +8910,7 @@
     {
       "label": ".test_verify_fails_override_empty_expires_at()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L435",
       "id": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_override_empty_expires_at",
       "community": 6
@@ -8790,7 +8918,7 @@
     {
       "label": ".test_verify_fails_override_weakens_healthcareplatform_hipaa()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L454",
       "id": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_override_weakens_healthcareplatform_hipaa",
       "community": 6
@@ -8798,7 +8926,7 @@
     {
       "label": ".test_verify_fails_override_disables_seek_plan_mode()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L468",
       "id": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_override_disables_seek_plan_mode",
       "community": 6
@@ -8806,7 +8934,7 @@
     {
       "label": ".test_verify_fails_override_routes_pii_away_from_lam()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L482",
       "id": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_override_routes_pii_away_from_lam",
       "community": 6
@@ -8814,7 +8942,7 @@
     {
       "label": ".test_verify_fails_override_core_fork_without_exception()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L496",
       "id": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_override_core_fork_without_exception",
       "community": 6
@@ -8822,7 +8950,7 @@
     {
       "label": ".test_verify_fails_override_disables_ci_required_gate()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L510",
       "id": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_override_disables_ci_required_gate",
       "community": 6
@@ -8830,7 +8958,7 @@
     {
       "label": ".test_verify_fails_override_dry_run_as_live_evidence()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L524",
       "id": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_override_dry_run_as_live_evidence",
       "community": 6
@@ -8838,7 +8966,7 @@
     {
       "label": ".test_verify_fails_when_healthcareplatform_v2_profile_weakens_constraints()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L538",
       "id": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_when_healthcareplatform_v2_profile_weakens_constraints",
       "community": 6
@@ -8846,32 +8974,48 @@
     {
       "label": ".test_verify_passes_for_valid_v2_managed_consumer()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L564",
       "id": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_passes_for_valid_v2_managed_consumer",
       "community": 6
     },
     {
+      "label": ".test_verify_fails_when_consumer_profile_omits_required_session_contract_entries()",
+      "file_type": "code",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
+      "source_location": "L623",
+      "id": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_when_consumer_profile_omits_required_session_contract_entries",
+      "community": 6
+    },
+    {
+      "label": ".test_verify_fails_when_consumer_profile_session_contract_content_is_stale()",
+      "file_type": "code",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
+      "source_location": "L646",
+      "id": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_when_consumer_profile_session_contract_content_is_stale",
+      "community": 6
+    },
+    {
       "label": ".test_verify_fails_for_tracked_session_contract_missing_required_content()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
-      "source_location": "L615",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
+      "source_location": "L677",
       "id": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_for_tracked_session_contract_missing_required_content",
       "community": 6
     },
     {
       "label": ".test_verify_fails_for_hook_settings_contract_missing_post_tool_use_matcher()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
-      "source_location": "L637",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
+      "source_location": "L699",
       "id": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_for_hook_settings_contract_missing_post_tool_use_matcher",
       "community": 6
     },
     {
       "label": ".test_verify_passes_for_session_contract_and_hook_settings_contract_entries()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
-      "source_location": "L670",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
+      "source_location": "L732",
       "id": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_passes_for_session_contract_and_hook_settings_contract_entries",
       "community": 6
     },
@@ -8881,7 +9025,7 @@
       "source_file": "scripts/overlord/test_workflow_local_coverage.py",
       "source_location": "L1",
       "id": "test_workflow_local_coverage",
-      "community": 36
+      "community": 35
     },
     {
       "label": "_write()",
@@ -8889,7 +9033,7 @@
       "source_file": "scripts/overlord/test_workflow_local_coverage.py",
       "source_location": "L12",
       "id": "test_workflow_local_coverage_write",
-      "community": 36
+      "community": 35
     },
     {
       "label": "_inventory()",
@@ -8897,7 +9041,7 @@
       "source_file": "scripts/overlord/test_workflow_local_coverage.py",
       "source_location": "L17",
       "id": "test_workflow_local_coverage_inventory",
-      "community": 36
+      "community": 35
     },
     {
       "label": "_entry()",
@@ -8905,7 +9049,7 @@
       "source_file": "scripts/overlord/test_workflow_local_coverage.py",
       "source_location": "L27",
       "id": "test_workflow_local_coverage_entry",
-      "community": 36
+      "community": 35
     },
     {
       "label": "TestWorkflowLocalCoverage",
@@ -8913,7 +9057,7 @@
       "source_file": "scripts/overlord/test_workflow_local_coverage.py",
       "source_location": "L39",
       "id": "test_workflow_local_coverage_testworkflowlocalcoverage",
-      "community": 36
+      "community": 35
     },
     {
       "label": ".test_repository_inventory_passes()",
@@ -8921,7 +9065,7 @@
       "source_file": "scripts/overlord/test_workflow_local_coverage.py",
       "source_location": "L40",
       "id": "test_workflow_local_coverage_testworkflowlocalcoverage_test_repository_inventory_passes",
-      "community": 36
+      "community": 35
     },
     {
       "label": ".test_rejects_workflow_missing_from_inventory()",
@@ -8929,7 +9073,7 @@
       "source_file": "scripts/overlord/test_workflow_local_coverage.py",
       "source_location": "L45",
       "id": "test_workflow_local_coverage_testworkflowlocalcoverage_test_rejects_workflow_missing_from_inventory",
-      "community": 36
+      "community": 35
     },
     {
       "label": ".test_rejects_inventory_entry_without_workflow_file()",
@@ -8937,7 +9081,7 @@
       "source_file": "scripts/overlord/test_workflow_local_coverage.py",
       "source_location": "L60",
       "id": "test_workflow_local_coverage_testworkflowlocalcoverage_test_rejects_inventory_entry_without_workflow_file",
-      "community": 36
+      "community": 35
     },
     {
       "label": ".test_rejects_deterministic_workflow_without_local_first_coverage()",
@@ -8945,7 +9089,7 @@
       "source_file": "scripts/overlord/test_workflow_local_coverage.py",
       "source_location": "L72",
       "id": "test_workflow_local_coverage_testworkflowlocalcoverage_test_rejects_deterministic_workflow_without_local_first_coverage",
-      "community": 36
+      "community": 35
     },
     {
       "label": ".test_rejects_missing_command_path()",
@@ -8953,7 +9097,7 @@
       "source_file": "scripts/overlord/test_workflow_local_coverage.py",
       "source_location": "L90",
       "id": "test_workflow_local_coverage_testworkflowlocalcoverage_test_rejects_missing_command_path",
-      "community": 36
+      "community": 35
     },
     {
       "label": ".test_rejects_missing_required_snippet()",
@@ -8961,7 +9105,7 @@
       "source_file": "scripts/overlord/test_workflow_local_coverage.py",
       "source_location": "L108",
       "id": "test_workflow_local_coverage_testworkflowlocalcoverage_test_rejects_missing_required_snippet",
-      "community": 36
+      "community": 35
     },
     {
       "label": ".test_accepts_github_only_with_rationale()",
@@ -8969,7 +9113,7 @@
       "source_file": "scripts/overlord/test_workflow_local_coverage.py",
       "source_location": "L123",
       "id": "test_workflow_local_coverage_testworkflowlocalcoverage_test_accepts_github_only_with_rationale",
-      "community": 36
+      "community": 35
     },
     {
       "label": "validate_backlog_gh_sync.py",
@@ -8993,7 +9137,7 @@
       "source_file": "scripts/overlord/validate_closeout.py",
       "source_location": "L1",
       "id": "validate_closeout",
-      "community": 11
+      "community": 12
     },
     {
       "label": "_repo_rel()",
@@ -9001,7 +9145,7 @@
       "source_file": "scripts/overlord/validate_closeout.py",
       "source_location": "L44",
       "id": "validate_closeout_repo_rel",
-      "community": 11
+      "community": 12
     },
     {
       "label": "_sections()",
@@ -9009,7 +9153,7 @@
       "source_file": "scripts/overlord/validate_closeout.py",
       "source_location": "L51",
       "id": "validate_closeout_sections",
-      "community": 11
+      "community": 12
     },
     {
       "label": "_extract_repo_refs()",
@@ -9017,7 +9161,7 @@
       "source_file": "scripts/overlord/validate_closeout.py",
       "source_location": "L64",
       "id": "validate_closeout_extract_repo_refs",
-      "community": 11
+      "community": 12
     },
     {
       "label": "_load_json()",
@@ -9025,55 +9169,71 @@
       "source_file": "scripts/overlord/validate_closeout.py",
       "source_location": "L75",
       "id": "validate_closeout_load_json",
-      "community": 11
+      "community": 12
+    },
+    {
+      "label": "_execution_scope_refs()",
+      "file_type": "code",
+      "source_file": "scripts/overlord/validate_closeout.py",
+      "source_location": "L83",
+      "id": "validate_closeout_execution_scope_refs",
+      "community": 12
     },
     {
       "label": "_validate_residuals()",
       "file_type": "code",
       "source_file": "scripts/overlord/validate_closeout.py",
-      "source_location": "L83",
+      "source_location": "L87",
       "id": "validate_closeout_validate_residuals",
-      "community": 11
+      "community": 12
     },
     {
       "label": "_validate_refs()",
       "file_type": "code",
       "source_file": "scripts/overlord/validate_closeout.py",
-      "source_location": "L98",
+      "source_location": "L102",
       "id": "validate_closeout_validate_refs",
-      "community": 11
+      "community": 12
     },
     {
       "label": "_validate_handoff_refs()",
       "file_type": "code",
       "source_file": "scripts/overlord/validate_closeout.py",
-      "source_location": "L125",
+      "source_location": "L129",
       "id": "validate_closeout_validate_handoff_refs",
-      "community": 11
+      "community": 12
+    },
+    {
+      "label": "resolve_closeout_execution_mode()",
+      "file_type": "code",
+      "source_file": "scripts/overlord/validate_closeout.py",
+      "source_location": "L158",
+      "id": "validate_closeout_resolve_closeout_execution_mode",
+      "community": 12
     },
     {
       "label": "validate_closeout()",
       "file_type": "code",
       "source_file": "scripts/overlord/validate_closeout.py",
-      "source_location": "L154",
+      "source_location": "L180",
       "id": "validate_closeout_validate_closeout",
-      "community": 11
+      "community": 12
     },
     {
       "label": "build_parser()",
       "file_type": "code",
       "source_file": "scripts/overlord/validate_closeout.py",
-      "source_location": "L177",
+      "source_location": "L203",
       "id": "validate_closeout_build_parser",
-      "community": 11
+      "community": 12
     },
     {
       "label": "main()",
       "file_type": "code",
       "source_file": "scripts/overlord/validate_closeout.py",
-      "source_location": "L184",
+      "source_location": "L210",
       "id": "validate_closeout_main",
-      "community": 11
+      "community": 12
     },
     {
       "label": "validate_governed_repos.py",
@@ -9134,138 +9294,138 @@
     {
       "label": "validate_handoff_package.py",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/validate_handoff_package.py",
+      "source_file": "scripts/overlord/validate_handoff_package.py",
       "source_location": "L1",
       "id": "validate_handoff_package",
-      "community": 11
+      "community": 12
     },
     {
       "label": "_is_url()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/validate_handoff_package.py",
+      "source_file": "scripts/overlord/validate_handoff_package.py",
       "source_location": "L78",
       "id": "validate_handoff_package_is_url",
-      "community": 11
+      "community": 12
     },
     {
       "label": "_normalize_repo_path()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/validate_handoff_package.py",
+      "source_file": "scripts/overlord/validate_handoff_package.py",
       "source_location": "L82",
       "id": "validate_handoff_package_normalize_repo_path",
-      "community": 11
+      "community": 12
     },
     {
       "label": "_repo_file_exists()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/validate_handoff_package.py",
+      "source_file": "scripts/overlord/validate_handoff_package.py",
       "source_location": "L94",
       "id": "validate_handoff_package_repo_file_exists",
-      "community": 11
+      "community": 12
     },
     {
       "label": "_load_json()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/validate_handoff_package.py",
+      "source_file": "scripts/overlord/validate_handoff_package.py",
       "source_location": "L100",
       "id": "validate_handoff_package_load_json",
-      "community": 11
+      "community": 12
     },
     {
       "label": "_read_json_ref()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/validate_handoff_package.py",
+      "source_file": "scripts/overlord/validate_handoff_package.py",
       "source_location": "L104",
       "id": "validate_handoff_package_read_json_ref",
-      "community": 11
+      "community": 12
     },
     {
       "label": "_validate_ref_array()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/validate_handoff_package.py",
+      "source_file": "scripts/overlord/validate_handoff_package.py",
       "source_location": "L119",
       "id": "validate_handoff_package_validate_ref_array",
-      "community": 11
+      "community": 12
     },
     {
       "label": "_validate_non_empty_ref_array_for_state()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/validate_handoff_package.py",
+      "source_file": "scripts/overlord/validate_handoff_package.py",
       "source_location": "L140",
       "id": "validate_handoff_package_validate_non_empty_ref_array_for_state",
-      "community": 11
+      "community": 12
     },
     {
       "label": "_evidence_ref_gate_applies()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/validate_handoff_package.py",
+      "source_file": "scripts/overlord/validate_handoff_package.py",
       "source_location": "L154",
       "id": "validate_handoff_package_evidence_ref_gate_applies",
-      "community": 11
+      "community": 12
     },
     {
       "label": "_validate_acceptance_criteria()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/validate_handoff_package.py",
+      "source_file": "scripts/overlord/validate_handoff_package.py",
       "source_location": "L161",
       "id": "validate_handoff_package_validate_acceptance_criteria",
-      "community": 11
+      "community": 12
     },
     {
       "label": "_consumer_managed_paths()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/validate_handoff_package.py",
+      "source_file": "scripts/overlord/validate_handoff_package.py",
       "source_location": "L204",
       "id": "validate_handoff_package_consumer_managed_paths",
-      "community": 11
+      "community": 12
     },
     {
       "label": "_criteria_verification_refs()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/validate_handoff_package.py",
+      "source_file": "scripts/overlord/validate_handoff_package.py",
       "source_location": "L220",
       "id": "validate_handoff_package_criteria_verification_refs",
-      "community": 11
+      "community": 12
     },
     {
       "label": "_consumer_verifier_acceptance_gate_applies()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/validate_handoff_package.py",
+      "source_file": "scripts/overlord/validate_handoff_package.py",
       "source_location": "L234",
       "id": "validate_handoff_package_consumer_verifier_acceptance_gate_applies",
-      "community": 11
+      "community": 12
     },
     {
       "label": "_validate_consumer_verifier_acceptance()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/validate_handoff_package.py",
+      "source_file": "scripts/overlord/validate_handoff_package.py",
       "source_location": "L241",
       "id": "validate_handoff_package_validate_consumer_verifier_acceptance",
-      "community": 11
+      "community": 12
     },
     {
       "label": "validate_package()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/validate_handoff_package.py",
+      "source_file": "scripts/overlord/validate_handoff_package.py",
       "source_location": "L277",
       "id": "validate_handoff_package_validate_package",
-      "community": 11
+      "community": 12
     },
     {
       "label": "_discover_package_files()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/validate_handoff_package.py",
+      "source_file": "scripts/overlord/validate_handoff_package.py",
       "source_location": "L377",
       "id": "validate_handoff_package_discover_package_files",
-      "community": 11
+      "community": 12
     },
     {
       "label": "main()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/validate_handoff_package.py",
+      "source_file": "scripts/overlord/validate_handoff_package.py",
       "source_location": "L386",
       "id": "validate_handoff_package_main",
-      "community": 11
+      "community": 12
     },
     {
       "label": "validate_provisioning_evidence.py",
@@ -9446,7 +9606,7 @@
     {
       "label": "validate_session_contract_surfaces.py",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/validate_session_contract_surfaces.py",
+      "source_file": "scripts/overlord/validate_session_contract_surfaces.py",
       "source_location": "L1",
       "id": "validate_session_contract_surfaces",
       "community": 83
@@ -9454,7 +9614,7 @@
     {
       "label": "_find_hook_command()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/validate_session_contract_surfaces.py",
+      "source_file": "scripts/overlord/validate_session_contract_surfaces.py",
       "source_location": "L18",
       "id": "validate_session_contract_surfaces_find_hook_command",
       "community": 83
@@ -9462,7 +9622,7 @@
     {
       "label": "validate()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/validate_session_contract_surfaces.py",
+      "source_file": "scripts/overlord/validate_session_contract_surfaces.py",
       "source_location": "L38",
       "id": "validate_session_contract_surfaces_validate",
       "community": 83
@@ -9470,7 +9630,7 @@
     {
       "label": "main()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/validate_session_contract_surfaces.py",
+      "source_file": "scripts/overlord/validate_session_contract_surfaces.py",
       "source_location": "L77",
       "id": "validate_session_contract_surfaces_main",
       "community": 83
@@ -9654,442 +9814,514 @@
     {
       "label": "validate_structured_agent_cycle_plan.py",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/validate_structured_agent_cycle_plan.py",
+      "source_file": "scripts/overlord/validate_structured_agent_cycle_plan.py",
       "source_location": "L1",
       "id": "validate_structured_agent_cycle_plan",
-      "community": 48
+      "community": 37
     },
     {
       "label": "_display_path()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/validate_structured_agent_cycle_plan.py",
-      "source_location": "L54",
+      "source_file": "scripts/overlord/validate_structured_agent_cycle_plan.py",
+      "source_location": "L71",
       "id": "validate_structured_agent_cycle_plan_display_path",
-      "community": 48
+      "community": 37
     },
     {
       "label": "_load_json_safe()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/validate_structured_agent_cycle_plan.py",
-      "source_location": "L61",
+      "source_file": "scripts/overlord/validate_structured_agent_cycle_plan.py",
+      "source_location": "L78",
       "id": "validate_structured_agent_cycle_plan_load_json_safe",
-      "community": 48
+      "community": 37
     },
     {
       "label": "_find_plan_files()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/validate_structured_agent_cycle_plan.py",
-      "source_location": "L69",
+      "source_file": "scripts/overlord/validate_structured_agent_cycle_plan.py",
+      "source_location": "L86",
       "id": "validate_structured_agent_cycle_plan_find_plan_files",
-      "community": 48
+      "community": 37
     },
     {
       "label": "_require()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/validate_structured_agent_cycle_plan.py",
-      "source_location": "L73",
+      "source_file": "scripts/overlord/validate_structured_agent_cycle_plan.py",
+      "source_location": "L90",
       "id": "validate_structured_agent_cycle_plan_require",
-      "community": 48
+      "community": 37
     },
     {
       "label": "_branch_issue_number()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/validate_structured_agent_cycle_plan.py",
-      "source_location": "L78",
+      "source_file": "scripts/overlord/validate_structured_agent_cycle_plan.py",
+      "source_location": "L95",
       "id": "validate_structured_agent_cycle_plan_branch_issue_number",
-      "community": 48
+      "community": 37
     },
     {
       "label": "_is_governance_surface()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/validate_structured_agent_cycle_plan.py",
-      "source_location": "L83",
+      "source_file": "scripts/overlord/validate_structured_agent_cycle_plan.py",
+      "source_location": "L100",
       "id": "validate_structured_agent_cycle_plan_is_governance_surface",
-      "community": 48
+      "community": 37
     },
     {
       "label": "_read_changed_files()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/validate_structured_agent_cycle_plan.py",
-      "source_location": "L92",
+      "source_file": "scripts/overlord/validate_structured_agent_cycle_plan.py",
+      "source_location": "L109",
       "id": "validate_structured_agent_cycle_plan_read_changed_files",
-      "community": 48
+      "community": 37
+    },
+    {
+      "label": "_is_planning_evidence_surface()",
+      "file_type": "code",
+      "source_file": "scripts/overlord/validate_structured_agent_cycle_plan.py",
+      "source_location": "L115",
+      "id": "validate_structured_agent_cycle_plan_is_planning_evidence_surface",
+      "community": 37
     },
     {
       "label": "_matching_plan_payloads()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/validate_structured_agent_cycle_plan.py",
-      "source_location": "L98",
+      "source_file": "scripts/overlord/validate_structured_agent_cycle_plan.py",
+      "source_location": "L124",
       "id": "validate_structured_agent_cycle_plan_matching_plan_payloads",
-      "community": 48
+      "community": 37
     },
     {
       "label": "_matching_execution_scopes()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/validate_structured_agent_cycle_plan.py",
-      "source_location": "L112",
+      "source_file": "scripts/overlord/validate_structured_agent_cycle_plan.py",
+      "source_location": "L138",
       "id": "validate_structured_agent_cycle_plan_matching_execution_scopes",
-      "community": 48
+      "community": 37
+    },
+    {
+      "label": "_require_identity()",
+      "file_type": "code",
+      "source_file": "scripts/overlord/validate_structured_agent_cycle_plan.py",
+      "source_location": "L147",
+      "id": "validate_structured_agent_cycle_plan_require_identity",
+      "community": 37
+    },
+    {
+      "label": "_require_repo_ref_array()",
+      "file_type": "code",
+      "source_file": "scripts/overlord/validate_structured_agent_cycle_plan.py",
+      "source_location": "L169",
+      "id": "validate_structured_agent_cycle_plan_require_repo_ref_array",
+      "community": 37
+    },
+    {
+      "label": "_validate_alternate_review_exemption()",
+      "file_type": "code",
+      "source_file": "scripts/overlord/validate_structured_agent_cycle_plan.py",
+      "source_location": "L197",
+      "id": "validate_structured_agent_cycle_plan_validate_alternate_review_exemption",
+      "community": 37
+    },
+    {
+      "label": "_validate_active_issue_branch_contract()",
+      "file_type": "code",
+      "source_file": "scripts/overlord/validate_structured_agent_cycle_plan.py",
+      "source_location": "L227",
+      "id": "validate_structured_agent_cycle_plan_validate_active_issue_branch_contract",
+      "community": 37
     },
     {
       "label": "_validate_planner_boundary_scope_presence()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/validate_structured_agent_cycle_plan.py",
-      "source_location": "L121",
+      "source_file": "scripts/overlord/validate_structured_agent_cycle_plan.py",
+      "source_location": "L284",
       "id": "validate_structured_agent_cycle_plan_validate_planner_boundary_scope_presence",
-      "community": 48
+      "community": 37
     },
     {
       "label": "_validate_implementation_ready_plan()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/validate_structured_agent_cycle_plan.py",
-      "source_location": "L153",
+      "source_file": "scripts/overlord/validate_structured_agent_cycle_plan.py",
+      "source_location": "L316",
       "id": "validate_structured_agent_cycle_plan_validate_implementation_ready_plan",
-      "community": 48
+      "community": 37
+    },
+    {
+      "label": "_validate_planning_evidence_plan()",
+      "file_type": "code",
+      "source_file": "scripts/overlord/validate_structured_agent_cycle_plan.py",
+      "source_location": "L334",
+      "id": "validate_structured_agent_cycle_plan_validate_planning_evidence_plan",
+      "community": 37
     },
     {
       "label": "_validate_implementation_ready_alternate_review()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/validate_structured_agent_cycle_plan.py",
-      "source_location": "L171",
+      "source_file": "scripts/overlord/validate_structured_agent_cycle_plan.py",
+      "source_location": "L359",
       "id": "validate_structured_agent_cycle_plan_validate_implementation_ready_alternate_review",
-      "community": 48
+      "community": 37
     },
     {
       "label": "_validate_file()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/validate_structured_agent_cycle_plan.py",
-      "source_location": "L206",
+      "source_file": "scripts/overlord/validate_structured_agent_cycle_plan.py",
+      "source_location": "L394",
       "id": "validate_structured_agent_cycle_plan_validate_file",
-      "community": 48
+      "community": 37
     },
     {
       "label": "main()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/validate_structured_agent_cycle_plan.py",
-      "source_location": "L283",
+      "source_file": "scripts/overlord/validate_structured_agent_cycle_plan.py",
+      "source_location": "L471",
       "id": "validate_structured_agent_cycle_plan_main",
-      "community": 48
+      "community": 37
     },
     {
       "label": "verify_governance_consumer.py",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/verify_governance_consumer.py",
+      "source_file": "scripts/overlord/verify_governance_consumer.py",
       "source_location": "L1",
       "id": "verify_governance_consumer",
-      "community": 12
+      "community": 9
     },
     {
       "label": "ConsumerVerifyError",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/verify_governance_consumer.py",
+      "source_file": "scripts/overlord/verify_governance_consumer.py",
       "source_location": "L76",
       "id": "verify_governance_consumer_consumerverifyerror",
-      "community": 12
+      "community": 9
     },
     {
       "label": "ConsumerRecord",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/verify_governance_consumer.py",
+      "source_file": "scripts/overlord/verify_governance_consumer.py",
       "source_location": "L81",
       "id": "verify_governance_consumer_consumerrecord",
-      "community": 12
+      "community": 9
     },
     {
       "label": "_fail()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/verify_governance_consumer.py",
+      "source_file": "scripts/overlord/verify_governance_consumer.py",
       "source_location": "L86",
       "id": "verify_governance_consumer_fail",
-      "community": 12
+      "community": 9
     },
     {
       "label": "_run_git()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/verify_governance_consumer.py",
+      "source_file": "scripts/overlord/verify_governance_consumer.py",
       "source_location": "L90",
       "id": "verify_governance_consumer_run_git",
-      "community": 12
+      "community": 9
     },
     {
       "label": "_git_root()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/verify_governance_consumer.py",
+      "source_file": "scripts/overlord/verify_governance_consumer.py",
       "source_location": "L94",
       "id": "verify_governance_consumer_git_root",
-      "community": 12
+      "community": 9
     },
     {
       "label": "_load_json()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/verify_governance_consumer.py",
+      "source_file": "scripts/overlord/verify_governance_consumer.py",
       "source_location": "L101",
       "id": "verify_governance_consumer_load_json",
-      "community": 12
+      "community": 9
     },
     {
       "label": "_consumer_record_relpath()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/verify_governance_consumer.py",
+      "source_file": "scripts/overlord/verify_governance_consumer.py",
       "source_location": "L113",
       "id": "verify_governance_consumer_consumer_record_relpath",
-      "community": 12
+      "community": 9
     },
     {
       "label": "_required_record_fields()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/verify_governance_consumer.py",
+      "source_file": "scripts/overlord/verify_governance_consumer.py",
       "source_location": "L122",
       "id": "verify_governance_consumer_required_record_fields",
-      "community": 12
+      "community": 9
     },
     {
       "label": "_initial_package_version()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/verify_governance_consumer.py",
+      "source_file": "scripts/overlord/verify_governance_consumer.py",
       "source_location": "L143",
       "id": "verify_governance_consumer_initial_package_version",
-      "community": 12
+      "community": 9
     },
     {
       "label": "_profile_desired_state()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/verify_governance_consumer.py",
+      "source_file": "scripts/overlord/verify_governance_consumer.py",
       "source_location": "L152",
       "id": "verify_governance_consumer_profile_desired_state",
-      "community": 12
+      "community": 9
+    },
+    {
+      "label": "_profile_package_version()",
+      "file_type": "code",
+      "source_file": "scripts/overlord/verify_governance_consumer.py",
+      "source_location": "L160",
+      "id": "verify_governance_consumer_profile_package_version",
+      "community": 9
     },
     {
       "label": "_profile_contract()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/verify_governance_consumer.py",
-      "source_location": "L160",
+      "source_file": "scripts/overlord/verify_governance_consumer.py",
+      "source_location": "L165",
       "id": "verify_governance_consumer_profile_contract",
-      "community": 12
+      "community": 9
     },
     {
       "label": "_manifest_profiles()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/verify_governance_consumer.py",
-      "source_location": "L165",
+      "source_file": "scripts/overlord/verify_governance_consumer.py",
+      "source_location": "L170",
       "id": "verify_governance_consumer_manifest_profiles",
-      "community": 12
+      "community": 9
     },
     {
       "label": "_known_profiles()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/verify_governance_consumer.py",
-      "source_location": "L170",
+      "source_file": "scripts/overlord/verify_governance_consumer.py",
+      "source_location": "L175",
       "id": "verify_governance_consumer_known_profiles",
-      "community": 12
+      "community": 9
     },
     {
       "label": "_next_package_version()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/verify_governance_consumer.py",
-      "source_location": "L178",
+      "source_file": "scripts/overlord/verify_governance_consumer.py",
+      "source_location": "L183",
       "id": "verify_governance_consumer_next_package_version",
-      "community": 12
+      "community": 9
     },
     {
       "label": "_is_v2_record()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/verify_governance_consumer.py",
-      "source_location": "L187",
+      "source_file": "scripts/overlord/verify_governance_consumer.py",
+      "source_location": "L192",
       "id": "verify_governance_consumer_is_v2_record",
-      "community": 12
+      "community": 9
     },
     {
       "label": "_profile_required_constraints()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/verify_governance_consumer.py",
-      "source_location": "L197",
+      "source_file": "scripts/overlord/verify_governance_consumer.py",
+      "source_location": "L202",
       "id": "verify_governance_consumer_profile_required_constraints",
-      "community": 12
+      "community": 9
     },
     {
       "label": "_record_constraints()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/verify_governance_consumer.py",
-      "source_location": "L207",
+      "source_file": "scripts/overlord/verify_governance_consumer.py",
+      "source_location": "L212",
       "id": "verify_governance_consumer_record_constraints",
-      "community": 12
+      "community": 9
     },
     {
-      "label": "_expected_managed_paths()",
+      "label": "_expected_managed_entries()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/verify_governance_consumer.py",
-      "source_location": "L219",
-      "id": "verify_governance_consumer_expected_managed_paths",
-      "community": 12
+      "source_file": "scripts/overlord/verify_governance_consumer.py",
+      "source_location": "L224",
+      "id": "verify_governance_consumer_expected_managed_entries",
+      "community": 9
     },
     {
       "label": "_managed_paths()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/verify_governance_consumer.py",
-      "source_location": "L226",
+      "source_file": "scripts/overlord/verify_governance_consumer.py",
+      "source_location": "L245",
       "id": "verify_governance_consumer_managed_paths",
-      "community": 12
+      "community": 9
+    },
+    {
+      "label": "_string_list_or_none()",
+      "file_type": "code",
+      "source_file": "scripts/overlord/verify_governance_consumer.py",
+      "source_location": "L256",
+      "id": "verify_governance_consumer_string_list_or_none",
+      "community": 9
     },
     {
       "label": "_managed_file_type()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/verify_governance_consumer.py",
-      "source_location": "L237",
+      "source_file": "scripts/overlord/verify_governance_consumer.py",
+      "source_location": "L264",
       "id": "verify_governance_consumer_managed_file_type",
-      "community": 12
+      "community": 9
     },
     {
       "label": "_managed_file_entry()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/verify_governance_consumer.py",
-      "source_location": "L247",
+      "source_file": "scripts/overlord/verify_governance_consumer.py",
+      "source_location": "L274",
       "id": "verify_governance_consumer_managed_file_entry",
-      "community": 12
+      "community": 9
+    },
+    {
+      "label": "_expected_entry_failures()",
+      "file_type": "code",
+      "source_file": "scripts/overlord/verify_governance_consumer.py",
+      "source_location": "L284",
+      "id": "verify_governance_consumer_expected_entry_failures",
+      "community": 9
     },
     {
       "label": "_string_list()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/verify_governance_consumer.py",
-      "source_location": "L257",
+      "source_file": "scripts/overlord/verify_governance_consumer.py",
+      "source_location": "L303",
       "id": "verify_governance_consumer_string_list",
-      "community": 12
+      "community": 9
     },
     {
       "label": "_managed_markers()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/verify_governance_consumer.py",
-      "source_location": "L263",
+      "source_file": "scripts/overlord/verify_governance_consumer.py",
+      "source_location": "L309",
       "id": "verify_governance_consumer_managed_markers",
-      "community": 12
+      "community": 9
     },
     {
       "label": "_managed_settings_matchers()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/verify_governance_consumer.py",
-      "source_location": "L272",
+      "source_file": "scripts/overlord/verify_governance_consumer.py",
+      "source_location": "L318",
       "id": "verify_governance_consumer_managed_settings_matchers",
-      "community": 12
+      "community": 9
     },
     {
       "label": "_managed_file_content_failures()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/verify_governance_consumer.py",
-      "source_location": "L288",
+      "source_file": "scripts/overlord/verify_governance_consumer.py",
+      "source_location": "L334",
       "id": "verify_governance_consumer_managed_file_content_failures",
-      "community": 12
+      "community": 9
     },
     {
       "label": "_expected_checksum()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/verify_governance_consumer.py",
-      "source_location": "L317",
+      "source_file": "scripts/overlord/verify_governance_consumer.py",
+      "source_location": "L363",
       "id": "verify_governance_consumer_expected_checksum",
-      "community": 12
+      "community": 9
     },
     {
       "label": "_non_empty_string()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/verify_governance_consumer.py",
-      "source_location": "L325",
+      "source_file": "scripts/overlord/verify_governance_consumer.py",
+      "source_location": "L371",
       "id": "verify_governance_consumer_non_empty_string",
-      "community": 12
+      "community": 9
     },
     {
       "label": "_override_text()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/verify_governance_consumer.py",
-      "source_location": "L329",
+      "source_file": "scripts/overlord/verify_governance_consumer.py",
+      "source_location": "L375",
       "id": "verify_governance_consumer_override_text",
-      "community": 12
+      "community": 9
     },
     {
       "label": "_contains_negated_forbidden_action()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/verify_governance_consumer.py",
-      "source_location": "L333",
+      "source_file": "scripts/overlord/verify_governance_consumer.py",
+      "source_location": "L379",
       "id": "verify_governance_consumer_contains_negated_forbidden_action",
-      "community": 12
+      "community": 9
     },
     {
       "label": "_forbidden_override_failures()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/verify_governance_consumer.py",
-      "source_location": "L345",
+      "source_file": "scripts/overlord/verify_governance_consumer.py",
+      "source_location": "L391",
       "id": "verify_governance_consumer_forbidden_override_failures",
-      "community": 12
+      "community": 9
     },
     {
       "label": "_is_relative_to()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/verify_governance_consumer.py",
-      "source_location": "L360",
+      "source_file": "scripts/overlord/verify_governance_consumer.py",
+      "source_location": "L406",
       "id": "verify_governance_consumer_is_relative_to",
-      "community": 12
+      "community": 9
     },
     {
       "label": "_load_consumer_record()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/verify_governance_consumer.py",
-      "source_location": "L368",
+      "source_file": "scripts/overlord/verify_governance_consumer.py",
+      "source_location": "L414",
       "id": "verify_governance_consumer_load_consumer_record",
-      "community": 12
+      "community": 9
     },
     {
       "label": "_override_records()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/verify_governance_consumer.py",
-      "source_location": "L377",
+      "source_file": "scripts/overlord/verify_governance_consumer.py",
+      "source_location": "L423",
       "id": "verify_governance_consumer_override_records",
-      "community": 12
+      "community": 9
     },
     {
       "label": "_workflow_ref_failures()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/verify_governance_consumer.py",
-      "source_location": "L408",
+      "source_file": "scripts/overlord/verify_governance_consumer.py",
+      "source_location": "L454",
       "id": "verify_governance_consumer_workflow_ref_failures",
-      "community": 12
+      "community": 9
     },
     {
       "label": "_validate_record()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/verify_governance_consumer.py",
-      "source_location": "L428",
+      "source_file": "scripts/overlord/verify_governance_consumer.py",
+      "source_location": "L474",
       "id": "verify_governance_consumer_validate_record",
-      "community": 12
+      "community": 9
     },
     {
       "label": "verify()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/verify_governance_consumer.py",
-      "source_location": "L538",
+      "source_file": "scripts/overlord/verify_governance_consumer.py",
+      "source_location": "L592",
       "id": "verify_governance_consumer_verify",
-      "community": 12
+      "community": 9
     },
     {
       "label": "print_json()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/verify_governance_consumer.py",
-      "source_location": "L584",
+      "source_file": "scripts/overlord/verify_governance_consumer.py",
+      "source_location": "L638",
       "id": "verify_governance_consumer_print_json",
-      "community": 12
+      "community": 9
     },
     {
       "label": "build_parser()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/verify_governance_consumer.py",
-      "source_location": "L589",
+      "source_file": "scripts/overlord/verify_governance_consumer.py",
+      "source_location": "L643",
       "id": "verify_governance_consumer_build_parser",
-      "community": 12
+      "community": 9
     },
     {
       "label": "main()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/verify_governance_consumer.py",
-      "source_location": "L603",
+      "source_file": "scripts/overlord/verify_governance_consumer.py",
+      "source_location": "L657",
       "id": "verify_governance_consumer_main",
-      "community": 12
+      "community": 9
     },
     {
       "label": "emit.py",
@@ -10097,7 +10329,7 @@
       "source_file": "scripts/packet/emit.py",
       "source_location": "L1",
       "id": "emit",
-      "community": 53
+      "community": 52
     },
     {
       "label": "emit_packet()",
@@ -10105,7 +10337,7 @@
       "source_file": "scripts/packet/emit.py",
       "source_location": "L14",
       "id": "emit_emit_packet",
-      "community": 53
+      "community": 52
     },
     {
       "label": "build_governance()",
@@ -10113,7 +10345,7 @@
       "source_file": "scripts/packet/emit.py",
       "source_location": "L73",
       "id": "emit_build_governance",
-      "community": 53
+      "community": 52
     },
     {
       "label": "emit_dispatch_packet()",
@@ -10121,7 +10353,7 @@
       "source_file": "scripts/packet/emit.py",
       "source_location": "L100",
       "id": "emit_emit_dispatch_packet",
-      "community": 53
+      "community": 52
     },
     {
       "label": "main()",
@@ -10129,7 +10361,7 @@
       "source_file": "scripts/packet/emit.py",
       "source_location": "L150",
       "id": "emit_main",
-      "community": 53
+      "community": 52
     },
     {
       "label": "Emit a minimal or dispatch-ready packet YAML file. Returns path to written file.",
@@ -10137,7 +10369,7 @@
       "source_file": "scripts/packet/emit.py",
       "source_location": "L28",
       "id": "emit_rationale_28",
-      "community": 53
+      "community": 52
     },
     {
       "label": "Build a governance block dict for inclusion in a dispatch-ready packet.",
@@ -10145,7 +10377,7 @@
       "source_file": "scripts/packet/emit.py",
       "source_location": "L84",
       "id": "emit_rationale_84",
-      "community": 53
+      "community": 52
     },
     {
       "label": "Emit a dispatch-ready packet that includes a complete governance block.",
@@ -10153,7 +10385,7 @@
       "source_file": "scripts/packet/emit.py",
       "source_location": "L122",
       "id": "emit_rationale_122",
-      "community": 53
+      "community": 52
     },
     {
       "label": "test_emit.py",
@@ -10161,7 +10393,7 @@
       "source_file": "scripts/packet/test_emit.py",
       "source_location": "L1",
       "id": "test_emit",
-      "community": 53
+      "community": 52
     },
     {
       "label": "TestPacketEmitter",
@@ -10169,7 +10401,7 @@
       "source_file": "scripts/packet/test_emit.py",
       "source_location": "L16",
       "id": "test_emit_testpacketemitter",
-      "community": 53
+      "community": 52
     },
     {
       "label": ".test_emit_dispatch_packet_writes_complete_governance_block()",
@@ -10177,7 +10409,7 @@
       "source_file": "scripts/packet/test_emit.py",
       "source_location": "L17",
       "id": "test_emit_testpacketemitter_test_emit_dispatch_packet_writes_complete_governance_block",
-      "community": 53
+      "community": 52
     },
     {
       "label": ".test_emit_packet_without_governance_preserves_historical_shape()",
@@ -10185,7 +10417,7 @@
       "source_file": "scripts/packet/test_emit.py",
       "source_location": "L50",
       "id": "test_emit_testpacketemitter_test_emit_packet_without_governance_preserves_historical_shape",
-      "community": 53
+      "community": 52
     },
     {
       "label": ".test_cli_rejects_partial_governance_flags()",
@@ -10193,7 +10425,7 @@
       "source_file": "scripts/packet/test_emit.py",
       "source_location": "L66",
       "id": "test_emit_testpacketemitter_test_cli_rejects_partial_governance_flags",
-      "community": 53
+      "community": 52
     },
     {
       "label": ".test_cli_passes_full_governance_block_to_emitter()",
@@ -10201,7 +10433,7 @@
       "source_file": "scripts/packet/test_emit.py",
       "source_location": "L91",
       "id": "test_emit_testpacketemitter_test_cli_passes_full_governance_block_to_emitter",
-      "community": 53
+      "community": 52
     },
     {
       "label": "test_hitl_relay_schema.py",
@@ -10769,7 +11001,7 @@
       "source_file": "scripts/packet/test_validate_hitl_relay.py",
       "source_location": "L1",
       "id": "test_validate_hitl_relay",
-      "community": 5
+      "community": 7
     },
     {
       "label": "_load()",
@@ -10777,7 +11009,7 @@
       "source_file": "scripts/packet/test_validate_hitl_relay.py",
       "source_location": "L19",
       "id": "test_validate_hitl_relay_load",
-      "community": 5
+      "community": 7
     },
     {
       "label": "test_valid_examples_pass_policy_validation()",
@@ -10785,7 +11017,7 @@
       "source_file": "scripts/packet/test_validate_hitl_relay.py",
       "source_location": "L23",
       "id": "test_validate_hitl_relay_test_valid_examples_pass_policy_validation",
-      "community": 5
+      "community": 7
     },
     {
       "label": "test_invalid_examples_fail_policy_validation()",
@@ -10793,7 +11025,7 @@
       "source_file": "scripts/packet/test_validate_hitl_relay.py",
       "source_location": "L30",
       "id": "test_validate_hitl_relay_test_invalid_examples_fail_policy_validation",
-      "community": 5
+      "community": 7
     },
     {
       "label": "test_session_instruction_requires_matching_target_session()",
@@ -10801,7 +11033,7 @@
       "source_file": "scripts/packet/test_validate_hitl_relay.py",
       "source_location": "L38",
       "id": "test_validate_hitl_relay_test_session_instruction_requires_matching_target_session",
-      "community": 5
+      "community": 7
     },
     {
       "label": "test_low_confidence_non_clarify_decision_fails_closed()",
@@ -10809,7 +11041,7 @@
       "source_file": "scripts/packet/test_validate_hitl_relay.py",
       "source_location": "L46",
       "id": "test_validate_hitl_relay_test_low_confidence_non_clarify_decision_fails_closed",
-      "community": 5
+      "community": 7
     },
     {
       "label": "test_low_confidence_clarify_decision_passes_without_instruction()",
@@ -10817,7 +11049,7 @@
       "source_file": "scripts/packet/test_validate_hitl_relay.py",
       "source_location": "L54",
       "id": "test_validate_hitl_relay_test_low_confidence_clarify_decision_passes_without_instruction",
-      "community": 5
+      "community": 7
     },
     {
       "label": "test_duplicate_reply_cannot_produce_instruction()",
@@ -10825,7 +11057,7 @@
       "source_file": "scripts/packet/test_validate_hitl_relay.py",
       "source_location": "L64",
       "id": "test_validate_hitl_relay_test_duplicate_reply_cannot_produce_instruction",
-      "community": 5
+      "community": 7
     },
     {
       "label": "test_expired_reply_cannot_produce_instruction()",
@@ -10833,7 +11065,7 @@
       "source_file": "scripts/packet/test_validate_hitl_relay.py",
       "source_location": "L72",
       "id": "test_validate_hitl_relay_test_expired_reply_cannot_produce_instruction",
-      "community": 5
+      "community": 7
     },
     {
       "label": "test_pii_external_channel_fails_closed()",
@@ -10841,7 +11073,7 @@
       "source_file": "scripts/packet/test_validate_hitl_relay.py",
       "source_location": "L80",
       "id": "test_validate_hitl_relay_test_pii_external_channel_fails_closed",
-      "community": 5
+      "community": 7
     },
     {
       "label": "test_stale_session_requires_resume_packet()",
@@ -10849,7 +11081,7 @@
       "source_file": "scripts/packet/test_validate_hitl_relay.py",
       "source_location": "L90",
       "id": "test_validate_hitl_relay_test_stale_session_requires_resume_packet",
-      "community": 5
+      "community": 7
     },
     {
       "label": "test_response_requires_notification_and_response_ids()",
@@ -10857,7 +11089,7 @@
       "source_file": "scripts/packet/test_validate_hitl_relay.py",
       "source_location": "L98",
       "id": "test_validate_hitl_relay_test_response_requires_notification_and_response_ids",
-      "community": 5
+      "community": 7
     },
     {
       "label": "validate.py",
@@ -10865,7 +11097,7 @@
       "source_file": "scripts/packet/validate.py",
       "source_location": "L1",
       "id": "validate",
-      "community": 21
+      "community": 23
     },
     {
       "label": "_load_packet()",
@@ -10873,7 +11105,7 @@
       "source_file": "scripts/packet/validate.py",
       "source_location": "L57",
       "id": "validate_load_packet",
-      "community": 21
+      "community": 23
     },
     {
       "label": "_load_schema()",
@@ -10881,7 +11113,7 @@
       "source_file": "scripts/packet/validate.py",
       "source_location": "L65",
       "id": "validate_load_schema",
-      "community": 21
+      "community": 23
     },
     {
       "label": "_find_packet_file()",
@@ -10889,7 +11121,7 @@
       "source_file": "scripts/packet/validate.py",
       "source_location": "L79",
       "id": "validate_find_packet_file",
-      "community": 21
+      "community": 23
     },
     {
       "label": "_resolve_chain()",
@@ -10897,7 +11129,7 @@
       "source_file": "scripts/packet/validate.py",
       "source_location": "L89",
       "id": "validate_resolve_chain",
-      "community": 21
+      "community": 23
     },
     {
       "label": "load_pii_patterns()",
@@ -10905,7 +11137,7 @@
       "source_file": "scripts/packet/validate.py",
       "source_location": "L115",
       "id": "validate_load_pii_patterns",
-      "community": 21
+      "community": 23
     },
     {
       "label": "validate_dual_planner()",
@@ -10913,7 +11145,7 @@
       "source_file": "scripts/packet/validate.py",
       "source_location": "L137",
       "id": "validate_validate_dual_planner",
-      "community": 21
+      "community": 23
     },
     {
       "label": "validate_no_self_approval()",
@@ -10921,7 +11153,7 @@
       "source_file": "scripts/packet/validate.py",
       "source_location": "L180",
       "id": "validate_validate_no_self_approval",
-      "community": 21
+      "community": 23
     },
     {
       "label": "validate_tier_escalation_valid()",
@@ -10929,7 +11161,7 @@
       "source_file": "scripts/packet/validate.py",
       "source_location": "L213",
       "id": "validate_validate_tier_escalation_valid",
-      "community": 21
+      "community": 23
     },
     {
       "label": "validate_local_family_diversity()",
@@ -10937,7 +11169,7 @@
       "source_file": "scripts/packet/validate.py",
       "source_location": "L231",
       "id": "validate_validate_local_family_diversity",
-      "community": 21
+      "community": 23
     },
     {
       "label": "validate_fallback_logged()",
@@ -10945,7 +11177,7 @@
       "source_file": "scripts/packet/validate.py",
       "source_location": "L257",
       "id": "validate_validate_fallback_logged",
-      "community": 21
+      "community": 23
     },
     {
       "label": "validate_schema()",
@@ -10953,7 +11185,7 @@
       "source_file": "scripts/packet/validate.py",
       "source_location": "L294",
       "id": "validate_validate_schema",
-      "community": 21
+      "community": 23
     },
     {
       "label": "validate_planning_floor()",
@@ -10961,7 +11193,7 @@
       "source_file": "scripts/packet/validate.py",
       "source_location": "L309",
       "id": "validate_validate_planning_floor",
-      "community": 21
+      "community": 23
     },
     {
       "label": "validate_pii_floor()",
@@ -10969,7 +11201,7 @@
       "source_file": "scripts/packet/validate.py",
       "source_location": "L325",
       "id": "validate_validate_pii_floor",
-      "community": 21
+      "community": 23
     },
     {
       "label": "validate_packet()",
@@ -10977,7 +11209,7 @@
       "source_file": "scripts/packet/validate.py",
       "source_location": "L362",
       "id": "validate_validate_packet",
-      "community": 21
+      "community": 23
     },
     {
       "label": "_run_cli()",
@@ -10985,7 +11217,7 @@
       "source_file": "scripts/packet/validate.py",
       "source_location": "L393",
       "id": "validate_run_cli",
-      "community": 21
+      "community": 23
     },
     {
       "label": "Load a YAML packet; return None if missing or malformed.",
@@ -10993,7 +11225,7 @@
       "source_file": "scripts/packet/validate.py",
       "source_location": "L58",
       "id": "validate_rationale_58",
-      "community": 21
+      "community": 23
     },
     {
       "label": "Load the packet schema from docs/schemas/som-packet.schema.yml.",
@@ -11001,7 +11233,7 @@
       "source_file": "scripts/packet/validate.py",
       "source_location": "L66",
       "id": "validate_rationale_66",
-      "community": 21
+      "community": 23
     },
     {
       "label": "Locate a packet file by ID (supports YYYY-MM-DD-<id>.yml naming).",
@@ -11009,7 +11241,7 @@
       "source_file": "scripts/packet/validate.py",
       "source_location": "L80",
       "id": "validate_rationale_80",
-      "community": 21
+      "community": 23
     },
     {
       "label": "Walk parent_packet_id links backwards; return ordered list [packet, parent, ...]",
@@ -11017,7 +11249,7 @@
       "source_file": "scripts/packet/validate.py",
       "source_location": "L90",
       "id": "validate_rationale_90",
-      "community": 21
+      "community": 23
     },
     {
       "label": "Load and compile PII patterns from pii-patterns.yml.",
@@ -11025,7 +11257,7 @@
       "source_file": "scripts/packet/validate.py",
       "source_location": "L116",
       "id": "validate_rationale_116",
-      "community": 21
+      "community": 23
     },
     {
       "label": "Enforce cross-family independence for tier-1 dual-planner packets.      When pri",
@@ -11033,7 +11265,7 @@
       "source_file": "scripts/packet/validate.py",
       "source_location": "L141",
       "id": "validate_rationale_141",
-      "community": 21
+      "community": 23
     },
     {
       "label": "Refuse if any consecutive pair in the parent chain shares model_id across differ",
@@ -11041,7 +11273,7 @@
       "source_file": "scripts/packet/validate.py",
       "source_location": "L184",
       "id": "validate_rationale_184",
-      "community": 21
+      "community": 23
     },
     {
       "label": "Enforce expected handoff sequence with no tier jumps.",
@@ -11049,7 +11281,7 @@
       "source_file": "scripts/packet/validate.py",
       "source_location": "L214",
       "id": "validate_rationale_214",
-      "community": 21
+      "community": 23
     },
     {
       "label": "Enforce LAM family diversity for LAM-only handoffs.",
@@ -11057,7 +11289,7 @@
       "source_file": "scripts/packet/validate.py",
       "source_location": "L235",
       "id": "validate_rationale_235",
-      "community": 21
+      "community": 23
     },
     {
       "label": "Require explicit fallback references to resolve in raw/model-fallbacks.",
@@ -11065,7 +11297,7 @@
       "source_file": "scripts/packet/validate.py",
       "source_location": "L258",
       "id": "validate_rationale_258",
-      "community": 21
+      "community": 23
     },
     {
       "label": "Validate packet shape against docs/schemas/som-packet.schema.yml.",
@@ -11073,7 +11305,7 @@
       "source_file": "scripts/packet/validate.py",
       "source_location": "L295",
       "id": "validate_rationale_295",
-      "community": 21
+      "community": 23
     },
     {
       "label": "Refuse tier-1 packets whose model is below the planning floor.",
@@ -11081,7 +11313,7 @@
       "source_file": "scripts/packet/validate.py",
       "source_location": "L310",
       "id": "validate_rationale_310",
-      "community": 21
+      "community": 23
     },
     {
       "label": "Refuse if PII artifacts appear outside LAM-role packets, or if the pattern file",
@@ -11089,7 +11321,7 @@
       "source_file": "scripts/packet/validate.py",
       "source_location": "L326",
       "id": "validate_rationale_326",
-      "community": 21
+      "community": 23
     },
     {
       "label": "Run all validators against a packet dict.      Returns (all_passed, list_of_fail",
@@ -11097,7 +11329,7 @@
       "source_file": "scripts/packet/validate.py",
       "source_location": "L366",
       "id": "validate_rationale_366",
-      "community": 21
+      "community": 23
     },
     {
       "label": "CLI entrypoint for validating packet files.",
@@ -11105,7 +11337,7 @@
       "source_file": "scripts/packet/validate.py",
       "source_location": "L394",
       "id": "validate_rationale_394",
-      "community": 21
+      "community": 23
     },
     {
       "label": "validate_hitl_relay.py",
@@ -11113,7 +11345,7 @@
       "source_file": "scripts/packet/validate_hitl_relay.py",
       "source_location": "L1",
       "id": "validate_hitl_relay",
-      "community": 5
+      "community": 7
     },
     {
       "label": "load_packet()",
@@ -11121,7 +11353,7 @@
       "source_file": "scripts/packet/validate_hitl_relay.py",
       "source_location": "L22",
       "id": "validate_hitl_relay_load_packet",
-      "community": 5
+      "community": 7
     },
     {
       "label": "_schema_validator()",
@@ -11129,7 +11361,7 @@
       "source_file": "scripts/packet/validate_hitl_relay.py",
       "source_location": "L26",
       "id": "validate_hitl_relay_schema_validator",
-      "community": 5
+      "community": 7
     },
     {
       "label": "validate_schema()",
@@ -11137,7 +11369,7 @@
       "source_file": "scripts/packet/validate_hitl_relay.py",
       "source_location": "L32",
       "id": "validate_hitl_relay_validate_schema",
-      "community": 5
+      "community": 7
     },
     {
       "label": "_packet_type()",
@@ -11145,7 +11377,7 @@
       "source_file": "scripts/packet/validate_hitl_relay.py",
       "source_location": "L37",
       "id": "validate_hitl_relay_packet_type",
-      "community": 5
+      "community": 7
     },
     {
       "label": "_correlation()",
@@ -11153,7 +11385,7 @@
       "source_file": "scripts/packet/validate_hitl_relay.py",
       "source_location": "L41",
       "id": "validate_hitl_relay_correlation",
-      "community": 5
+      "community": 7
     },
     {
       "label": "_session()",
@@ -11161,7 +11393,7 @@
       "source_file": "scripts/packet/validate_hitl_relay.py",
       "source_location": "L46",
       "id": "validate_hitl_relay_session",
-      "community": 5
+      "community": 7
     },
     {
       "label": "_policy()",
@@ -11169,7 +11401,7 @@
       "source_file": "scripts/packet/validate_hitl_relay.py",
       "source_location": "L51",
       "id": "validate_hitl_relay_policy",
-      "community": 5
+      "community": 7
     },
     {
       "label": "_operator_reply()",
@@ -11177,7 +11409,7 @@
       "source_file": "scripts/packet/validate_hitl_relay.py",
       "source_location": "L56",
       "id": "validate_hitl_relay_operator_reply",
-      "community": 5
+      "community": 7
     },
     {
       "label": "_decision()",
@@ -11185,7 +11417,7 @@
       "source_file": "scripts/packet/validate_hitl_relay.py",
       "source_location": "L61",
       "id": "validate_hitl_relay_decision",
-      "community": 5
+      "community": 7
     },
     {
       "label": "_instruction()",
@@ -11193,7 +11425,7 @@
       "source_file": "scripts/packet/validate_hitl_relay.py",
       "source_location": "L66",
       "id": "validate_hitl_relay_instruction",
-      "community": 5
+      "community": 7
     },
     {
       "label": "validate_policy_refs()",
@@ -11201,7 +11433,7 @@
       "source_file": "scripts/packet/validate_hitl_relay.py",
       "source_location": "L71",
       "id": "validate_hitl_relay_validate_policy_refs",
-      "community": 5
+      "community": 7
     },
     {
       "label": "validate_correlation()",
@@ -11209,7 +11441,7 @@
       "source_file": "scripts/packet/validate_hitl_relay.py",
       "source_location": "L83",
       "id": "validate_hitl_relay_validate_correlation",
-      "community": 5
+      "community": 7
     },
     {
       "label": "validate_operator_reply()",
@@ -11217,7 +11449,7 @@
       "source_file": "scripts/packet/validate_hitl_relay.py",
       "source_location": "L96",
       "id": "validate_hitl_relay_validate_operator_reply",
-      "community": 5
+      "community": 7
     },
     {
       "label": "validate_pii_channel_policy()",
@@ -11225,7 +11457,7 @@
       "source_file": "scripts/packet/validate_hitl_relay.py",
       "source_location": "L113",
       "id": "validate_hitl_relay_validate_pii_channel_policy",
-      "community": 5
+      "community": 7
     },
     {
       "label": "validate_normalized_decision()",
@@ -11233,7 +11465,7 @@
       "source_file": "scripts/packet/validate_hitl_relay.py",
       "source_location": "L124",
       "id": "validate_hitl_relay_validate_normalized_decision",
-      "community": 5
+      "community": 7
     },
     {
       "label": "validate_instruction()",
@@ -11241,7 +11473,7 @@
       "source_file": "scripts/packet/validate_hitl_relay.py",
       "source_location": "L142",
       "id": "validate_hitl_relay_validate_instruction",
-      "community": 5
+      "community": 7
     },
     {
       "label": "validate_resume()",
@@ -11249,7 +11481,7 @@
       "source_file": "scripts/packet/validate_hitl_relay.py",
       "source_location": "L161",
       "id": "validate_hitl_relay_validate_resume",
-      "community": 5
+      "community": 7
     },
     {
       "label": "validate_hitl_packet()",
@@ -11257,7 +11489,7 @@
       "source_file": "scripts/packet/validate_hitl_relay.py",
       "source_location": "L170",
       "id": "validate_hitl_relay_validate_hitl_packet",
-      "community": 5
+      "community": 7
     },
     {
       "label": "_run_cli()",
@@ -11265,7 +11497,7 @@
       "source_file": "scripts/packet/validate_hitl_relay.py",
       "source_location": "L187",
       "id": "validate_hitl_relay_run_cli",
-      "community": 5
+      "community": 7
     },
     {
       "label": "inventory_direct_upload_projects.py",
@@ -11369,7 +11601,7 @@
       "source_file": "scripts/pages-deploy/pages_deploy_gate.py",
       "source_location": "L1",
       "id": "pages_deploy_gate",
-      "community": 13
+      "community": 14
     },
     {
       "label": "_load_verifier()",
@@ -11377,7 +11609,7 @@
       "source_file": "scripts/pages-deploy/pages_deploy_gate.py",
       "source_location": "L24",
       "id": "pages_deploy_gate_load_verifier",
-      "community": 13
+      "community": 14
     },
     {
       "label": "GateError",
@@ -11385,7 +11617,7 @@
       "source_file": "scripts/pages-deploy/pages_deploy_gate.py",
       "source_location": "L57",
       "id": "pages_deploy_gate_gateerror",
-      "community": 13
+      "community": 14
     },
     {
       "label": "Exception",
@@ -11401,7 +11633,7 @@
       "source_file": "scripts/pages-deploy/pages_deploy_gate.py",
       "source_location": "L60",
       "id": "pages_deploy_gate_gateerror_init",
-      "community": 13
+      "community": 14
     },
     {
       "label": "ArtifactStats",
@@ -11409,7 +11641,7 @@
       "source_file": "scripts/pages-deploy/pages_deploy_gate.py",
       "source_location": "L66",
       "id": "pages_deploy_gate_artifactstats",
-      "community": 13
+      "community": 14
     },
     {
       "label": "repo_root()",
@@ -11417,7 +11649,7 @@
       "source_file": "scripts/pages-deploy/pages_deploy_gate.py",
       "source_location": "L73",
       "id": "pages_deploy_gate_repo_root",
-      "community": 13
+      "community": 14
     },
     {
       "label": "redact()",
@@ -11425,7 +11657,7 @@
       "source_file": "scripts/pages-deploy/pages_deploy_gate.py",
       "source_location": "L77",
       "id": "pages_deploy_gate_redact",
-      "community": 13
+      "community": 14
     },
     {
       "label": "log()",
@@ -11433,7 +11665,7 @@
       "source_file": "scripts/pages-deploy/pages_deploy_gate.py",
       "source_location": "L89",
       "id": "pages_deploy_gate_log",
-      "community": 13
+      "community": 14
     },
     {
       "label": "fail()",
@@ -11441,7 +11673,7 @@
       "source_file": "scripts/pages-deploy/pages_deploy_gate.py",
       "source_location": "L93",
       "id": "pages_deploy_gate_fail",
-      "community": 13
+      "community": 14
     },
     {
       "label": "fail_error()",
@@ -11449,7 +11681,7 @@
       "source_file": "scripts/pages-deploy/pages_deploy_gate.py",
       "source_location": "L98",
       "id": "pages_deploy_gate_fail_error",
-      "community": 13
+      "community": 14
     },
     {
       "label": "load_json()",
@@ -11457,7 +11689,7 @@
       "source_file": "scripts/pages-deploy/pages_deploy_gate.py",
       "source_location": "L102",
       "id": "pages_deploy_gate_load_json",
-      "community": 13
+      "community": 14
     },
     {
       "label": "json_type_matches()",
@@ -11465,7 +11697,7 @@
       "source_file": "scripts/pages-deploy/pages_deploy_gate.py",
       "source_location": "L111",
       "id": "pages_deploy_gate_json_type_matches",
-      "community": 13
+      "community": 14
     },
     {
       "label": "validate_with_schema()",
@@ -11473,7 +11705,7 @@
       "source_file": "scripts/pages-deploy/pages_deploy_gate.py",
       "source_location": "L125",
       "id": "pages_deploy_gate_validate_with_schema",
-      "community": 13
+      "community": 14
     },
     {
       "label": "_validate_config_or_raise()",
@@ -11481,7 +11713,7 @@
       "source_file": "scripts/pages-deploy/pages_deploy_gate.py",
       "source_location": "L156",
       "id": "pages_deploy_gate_validate_config_or_raise",
-      "community": 13
+      "community": 14
     },
     {
       "label": "validate_config()",
@@ -11489,7 +11721,7 @@
       "source_file": "scripts/pages-deploy/pages_deploy_gate.py",
       "source_location": "L164",
       "id": "pages_deploy_gate_validate_config",
-      "community": 13
+      "community": 14
     },
     {
       "label": "validate_schema()",
@@ -11497,7 +11729,7 @@
       "source_file": "scripts/pages-deploy/pages_deploy_gate.py",
       "source_location": "L173",
       "id": "pages_deploy_gate_validate_schema",
-      "community": 13
+      "community": 14
     },
     {
       "label": "load_config()",
@@ -11505,7 +11737,7 @@
       "source_file": "scripts/pages-deploy/pages_deploy_gate.py",
       "source_location": "L189",
       "id": "pages_deploy_gate_load_config",
-      "community": 13
+      "community": 14
     },
     {
       "label": "resolve_app_root()",
@@ -11513,7 +11745,7 @@
       "source_file": "scripts/pages-deploy/pages_deploy_gate.py",
       "source_location": "L196",
       "id": "pages_deploy_gate_resolve_app_root",
-      "community": 13
+      "community": 14
     },
     {
       "label": "resolve_output_dir()",
@@ -11521,7 +11753,7 @@
       "source_file": "scripts/pages-deploy/pages_deploy_gate.py",
       "source_location": "L203",
       "id": "pages_deploy_gate_resolve_output_dir",
-      "community": 13
+      "community": 14
     },
     {
       "label": "run_command()",
@@ -11529,7 +11761,7 @@
       "source_file": "scripts/pages-deploy/pages_deploy_gate.py",
       "source_location": "L210",
       "id": "pages_deploy_gate_run_command",
-      "community": 13
+      "community": 14
     },
     {
       "label": "preflight_env()",
@@ -11537,7 +11769,7 @@
       "source_file": "scripts/pages-deploy/pages_deploy_gate.py",
       "source_location": "L232",
       "id": "pages_deploy_gate_preflight_env",
-      "community": 13
+      "community": 14
     },
     {
       "label": "preflight_tools()",
@@ -11545,7 +11777,7 @@
       "source_file": "scripts/pages-deploy/pages_deploy_gate.py",
       "source_location": "L257",
       "id": "pages_deploy_gate_preflight_tools",
-      "community": 13
+      "community": 14
     },
     {
       "label": "branch_binding_preflight()",
@@ -11553,7 +11785,7 @@
       "source_file": "scripts/pages-deploy/pages_deploy_gate.py",
       "source_location": "L264",
       "id": "pages_deploy_gate_branch_binding_preflight",
-      "community": 13
+      "community": 14
     },
     {
       "label": "get_wrangler_version()",
@@ -11561,7 +11793,7 @@
       "source_file": "scripts/pages-deploy/pages_deploy_gate.py",
       "source_location": "L297",
       "id": "pages_deploy_gate_get_wrangler_version",
-      "community": 13
+      "community": 14
     },
     {
       "label": "run_pre_deploy()",
@@ -11569,7 +11801,7 @@
       "source_file": "scripts/pages-deploy/pages_deploy_gate.py",
       "source_location": "L306",
       "id": "pages_deploy_gate_run_pre_deploy",
-      "community": 13
+      "community": 14
     },
     {
       "label": "count_files()",
@@ -11577,7 +11809,7 @@
       "source_file": "scripts/pages-deploy/pages_deploy_gate.py",
       "source_location": "L319",
       "id": "pages_deploy_gate_count_files",
-      "community": 13
+      "community": 14
     },
     {
       "label": "run_build()",
@@ -11585,7 +11817,7 @@
       "source_file": "scripts/pages-deploy/pages_deploy_gate.py",
       "source_location": "L323",
       "id": "pages_deploy_gate_run_build",
-      "community": 13
+      "community": 14
     },
     {
       "label": "_inspect_files()",
@@ -11593,7 +11825,7 @@
       "source_file": "scripts/pages-deploy/pages_deploy_gate.py",
       "source_location": "L350",
       "id": "pages_deploy_gate_inspect_files",
-      "community": 13
+      "community": 14
     },
     {
       "label": "_check_pages_limits()",
@@ -11601,7 +11833,7 @@
       "source_file": "scripts/pages-deploy/pages_deploy_gate.py",
       "source_location": "L367",
       "id": "pages_deploy_gate_check_pages_limits",
-      "community": 13
+      "community": 14
     },
     {
       "label": "enforce_pages_limits()",
@@ -11609,7 +11841,7 @@
       "source_file": "scripts/pages-deploy/pages_deploy_gate.py",
       "source_location": "L390",
       "id": "pages_deploy_gate_enforce_pages_limits",
-      "community": 13
+      "community": 14
     },
     {
       "label": "git_head()",
@@ -11617,7 +11849,7 @@
       "source_file": "scripts/pages-deploy/pages_deploy_gate.py",
       "source_location": "L399",
       "id": "pages_deploy_gate_git_head",
-      "community": 13
+      "community": 14
     },
     {
       "label": "deploy()",
@@ -11625,7 +11857,7 @@
       "source_file": "scripts/pages-deploy/pages_deploy_gate.py",
       "source_location": "L411",
       "id": "pages_deploy_gate_deploy",
-      "community": 13
+      "community": 14
     },
     {
       "label": "extract_deployment_url()",
@@ -11633,7 +11865,7 @@
       "source_file": "scripts/pages-deploy/pages_deploy_gate.py",
       "source_location": "L435",
       "id": "pages_deploy_gate_extract_deployment_url",
-      "community": 13
+      "community": 14
     },
     {
       "label": "_run_post_deploy_verification()",
@@ -11641,7 +11873,7 @@
       "source_file": "scripts/pages-deploy/pages_deploy_gate.py",
       "source_location": "L445",
       "id": "pages_deploy_gate_run_post_deploy_verification",
-      "community": 13
+      "community": 14
     },
     {
       "label": "emit_evidence()",
@@ -11649,7 +11881,7 @@
       "source_file": "scripts/pages-deploy/pages_deploy_gate.py",
       "source_location": "L459",
       "id": "pages_deploy_gate_emit_evidence",
-      "community": 13
+      "community": 14
     },
     {
       "label": "run_gate()",
@@ -11657,7 +11889,7 @@
       "source_file": "scripts/pages-deploy/pages_deploy_gate.py",
       "source_location": "L483",
       "id": "pages_deploy_gate_run_gate",
-      "community": 13
+      "community": 14
     },
     {
       "label": "main()",
@@ -11665,7 +11897,7 @@
       "source_file": "scripts/pages-deploy/pages_deploy_gate.py",
       "source_location": "L529",
       "id": "pages_deploy_gate_main",
-      "community": 13
+      "community": 14
     },
     {
       "label": "Expected gate failure with deterministic operator output.",
@@ -11673,7 +11905,7 @@
       "source_file": "scripts/pages-deploy/pages_deploy_gate.py",
       "source_location": "L58",
       "id": "pages_deploy_gate_rationale_58",
-      "community": 13
+      "community": 14
     },
     {
       "label": "Public test-facing config validator.",
@@ -11681,7 +11913,7 @@
       "source_file": "scripts/pages-deploy/pages_deploy_gate.py",
       "source_location": "L165",
       "id": "pages_deploy_gate_rationale_165",
-      "community": 13
+      "community": 14
     },
     {
       "label": "Public test-facing Pages limits checker.",
@@ -11689,7 +11921,7 @@
       "source_file": "scripts/pages-deploy/pages_deploy_gate.py",
       "source_location": "L391",
       "id": "pages_deploy_gate_rationale_391",
-      "community": 13
+      "community": 14
     },
     {
       "label": "pages_deploy_verifier.py",
@@ -11697,7 +11929,7 @@
       "source_file": "scripts/pages-deploy/pages_deploy_verifier.py",
       "source_location": "L1",
       "id": "pages_deploy_verifier",
-      "community": 20
+      "community": 22
     },
     {
       "label": "PagesDeployVerifierError",
@@ -11705,7 +11937,7 @@
       "source_file": "scripts/pages-deploy/pages_deploy_verifier.py",
       "source_location": "L39",
       "id": "pages_deploy_verifier_pagesdeployverifiererror",
-      "community": 20
+      "community": 22
     },
     {
       "label": "HttpResponse",
@@ -11713,7 +11945,7 @@
       "source_file": "scripts/pages-deploy/pages_deploy_verifier.py",
       "source_location": "L44",
       "id": "pages_deploy_verifier_httpresponse",
-      "community": 20
+      "community": 22
     },
     {
       "label": "_NoRedirectHandler",
@@ -11721,7 +11953,7 @@
       "source_file": "scripts/pages-deploy/pages_deploy_verifier.py",
       "source_location": "L54",
       "id": "pages_deploy_verifier_noredirecthandler",
-      "community": 20
+      "community": 22
     },
     {
       "label": ".redirect_request()",
@@ -11729,7 +11961,7 @@
       "source_file": "scripts/pages-deploy/pages_deploy_verifier.py",
       "source_location": "L55",
       "id": "pages_deploy_verifier_noredirecthandler_redirect_request",
-      "community": 20
+      "community": 22
     },
     {
       "label": "_headers_dict()",
@@ -11737,7 +11969,7 @@
       "source_file": "scripts/pages-deploy/pages_deploy_verifier.py",
       "source_location": "L59",
       "id": "pages_deploy_verifier_headers_dict",
-      "community": 20
+      "community": 22
     },
     {
       "label": "_header()",
@@ -11745,7 +11977,7 @@
       "source_file": "scripts/pages-deploy/pages_deploy_verifier.py",
       "source_location": "L63",
       "id": "pages_deploy_verifier_header",
-      "community": 20
+      "community": 22
     },
     {
       "label": "_sanitize_url()",
@@ -11753,7 +11985,7 @@
       "source_file": "scripts/pages-deploy/pages_deploy_verifier.py",
       "source_location": "L71",
       "id": "pages_deploy_verifier_sanitize_url",
-      "community": 20
+      "community": 22
     },
     {
       "label": "_sanitize_text()",
@@ -11761,7 +11993,7 @@
       "source_file": "scripts/pages-deploy/pages_deploy_verifier.py",
       "source_location": "L84",
       "id": "pages_deploy_verifier_sanitize_text",
-      "community": 20
+      "community": 22
     },
     {
       "label": "_load_config()",
@@ -11769,7 +12001,7 @@
       "source_file": "scripts/pages-deploy/pages_deploy_verifier.py",
       "source_location": "L102",
       "id": "pages_deploy_verifier_load_config",
-      "community": 20
+      "community": 22
     },
     {
       "label": "_branch()",
@@ -11777,7 +12009,7 @@
       "source_file": "scripts/pages-deploy/pages_deploy_verifier.py",
       "source_location": "L114",
       "id": "pages_deploy_verifier_branch",
-      "community": 20
+      "community": 22
     },
     {
       "label": "_domains()",
@@ -11785,7 +12017,7 @@
       "source_file": "scripts/pages-deploy/pages_deploy_verifier.py",
       "source_location": "L121",
       "id": "pages_deploy_verifier_domains",
-      "community": 20
+      "community": 22
     },
     {
       "label": "_domain_label()",
@@ -11793,7 +12025,7 @@
       "source_file": "scripts/pages-deploy/pages_deploy_verifier.py",
       "source_location": "L148",
       "id": "pages_deploy_verifier_domain_label",
-      "community": 20
+      "community": 22
     },
     {
       "label": "_deployment_url()",
@@ -11801,7 +12033,7 @@
       "source_file": "scripts/pages-deploy/pages_deploy_verifier.py",
       "source_location": "L153",
       "id": "pages_deploy_verifier_deployment_url",
-      "community": 20
+      "community": 22
     },
     {
       "label": "_query_value()",
@@ -11809,7 +12041,7 @@
       "source_file": "scripts/pages-deploy/pages_deploy_verifier.py",
       "source_location": "L161",
       "id": "pages_deploy_verifier_query_value",
-      "community": 20
+      "community": 22
     },
     {
       "label": "_with_query_value()",
@@ -11817,7 +12049,7 @@
       "source_file": "scripts/pages-deploy/pages_deploy_verifier.py",
       "source_location": "L169",
       "id": "pages_deploy_verifier_with_query_value",
-      "community": 20
+      "community": 22
     },
     {
       "label": "_urllib_get()",
@@ -11825,7 +12057,7 @@
       "source_file": "scripts/pages-deploy/pages_deploy_verifier.py",
       "source_location": "L182",
       "id": "pages_deploy_verifier_urllib_get",
-      "community": 20
+      "community": 22
     },
     {
       "label": "_fetch_with_redirects()",
@@ -11833,7 +12065,7 @@
       "source_file": "scripts/pages-deploy/pages_deploy_verifier.py",
       "source_location": "L202",
       "id": "pages_deploy_verifier_fetch_with_redirects",
-      "community": 20
+      "community": 22
     },
     {
       "label": "_extract_deployment_id()",
@@ -11841,7 +12073,7 @@
       "source_file": "scripts/pages-deploy/pages_deploy_verifier.py",
       "source_location": "L220",
       "id": "pages_deploy_verifier_extract_deployment_id",
-      "community": 20
+      "community": 22
     },
     {
       "label": "_cname_note()",
@@ -11849,7 +12081,7 @@
       "source_file": "scripts/pages-deploy/pages_deploy_verifier.py",
       "source_location": "L249",
       "id": "pages_deploy_verifier_cname_note",
-      "community": 20
+      "community": 22
     },
     {
       "label": "_domain_result()",
@@ -11857,7 +12089,7 @@
       "source_file": "scripts/pages-deploy/pages_deploy_verifier.py",
       "source_location": "L262",
       "id": "pages_deploy_verifier_domain_result",
-      "community": 20
+      "community": 22
     },
     {
       "label": "_error_domain_result()",
@@ -11865,7 +12097,7 @@
       "source_file": "scripts/pages-deploy/pages_deploy_verifier.py",
       "source_location": "L293",
       "id": "pages_deploy_verifier_error_domain_result",
-      "community": 20
+      "community": 22
     },
     {
       "label": "_should_retry_response()",
@@ -11873,7 +12105,7 @@
       "source_file": "scripts/pages-deploy/pages_deploy_verifier.py",
       "source_location": "L307",
       "id": "pages_deploy_verifier_should_retry_response",
-      "community": 20
+      "community": 22
     },
     {
       "label": "_sleep_for_retry()",
@@ -11881,7 +12113,7 @@
       "source_file": "scripts/pages-deploy/pages_deploy_verifier.py",
       "source_location": "L313",
       "id": "pages_deploy_verifier_sleep_for_retry",
-      "community": 20
+      "community": 22
     },
     {
       "label": "probe_domain()",
@@ -11889,7 +12121,7 @@
       "source_file": "scripts/pages-deploy/pages_deploy_verifier.py",
       "source_location": "L326",
       "id": "pages_deploy_verifier_probe_domain",
-      "community": 20
+      "community": 22
     },
     {
       "label": "_extract_title()",
@@ -11897,7 +12129,7 @@
       "source_file": "scripts/pages-deploy/pages_deploy_verifier.py",
       "source_location": "L368",
       "id": "pages_deploy_verifier_extract_title",
-      "community": 20
+      "community": 22
     },
     {
       "label": "_probe_title()",
@@ -11905,7 +12137,7 @@
       "source_file": "scripts/pages-deploy/pages_deploy_verifier.py",
       "source_location": "L374",
       "id": "pages_deploy_verifier_probe_title",
-      "community": 20
+      "community": 22
     },
     {
       "label": "stale_checkout_guard()",
@@ -11913,7 +12145,7 @@
       "source_file": "scripts/pages-deploy/pages_deploy_verifier.py",
       "source_location": "L396",
       "id": "pages_deploy_verifier_stale_checkout_guard",
-      "community": 20
+      "community": 22
     },
     {
       "label": "build_report()",
@@ -11921,7 +12153,7 @@
       "source_file": "scripts/pages-deploy/pages_deploy_verifier.py",
       "source_location": "L425",
       "id": "pages_deploy_verifier_build_report",
-      "community": 20
+      "community": 22
     },
     {
       "label": "run_verification()",
@@ -11929,7 +12161,7 @@
       "source_file": "scripts/pages-deploy/pages_deploy_verifier.py",
       "source_location": "L485",
       "id": "pages_deploy_verifier_run_verification",
-      "community": 20
+      "community": 22
     },
     {
       "label": "emit_summary()",
@@ -11937,7 +12169,7 @@
       "source_file": "scripts/pages-deploy/pages_deploy_verifier.py",
       "source_location": "L502",
       "id": "pages_deploy_verifier_emit_summary",
-      "community": 20
+      "community": 22
     },
     {
       "label": "main()",
@@ -11945,7 +12177,7 @@
       "source_file": "scripts/pages-deploy/pages_deploy_verifier.py",
       "source_location": "L522",
       "id": "pages_deploy_verifier_main",
-      "community": 20
+      "community": 22
     },
     {
       "label": "test_inventory_direct_upload_projects.py",
@@ -11985,7 +12217,7 @@
       "source_file": "scripts/pages-deploy/tests/test_pages_deploy_gate.py",
       "source_location": "L1",
       "id": "test_pages_deploy_gate",
-      "community": 18
+      "community": 20
     },
     {
       "label": "FakeCompleted",
@@ -11993,7 +12225,7 @@
       "source_file": "scripts/pages-deploy/tests/test_pages_deploy_gate.py",
       "source_location": "L20",
       "id": "test_pages_deploy_gate_fakecompleted",
-      "community": 18
+      "community": 20
     },
     {
       "label": ".__init__()",
@@ -12001,7 +12233,7 @@
       "source_file": "scripts/pages-deploy/tests/test_pages_deploy_gate.py",
       "source_location": "L21",
       "id": "test_pages_deploy_gate_fakecompleted_init",
-      "community": 18
+      "community": 20
     },
     {
       "label": "write_config()",
@@ -12009,7 +12241,7 @@
       "source_file": "scripts/pages-deploy/tests/test_pages_deploy_gate.py",
       "source_location": "L27",
       "id": "test_pages_deploy_gate_write_config",
-      "community": 18
+      "community": 20
     },
     {
       "label": "default_env()",
@@ -12017,7 +12249,7 @@
       "source_file": "scripts/pages-deploy/tests/test_pages_deploy_gate.py",
       "source_location": "L43",
       "id": "test_pages_deploy_gate_default_env",
-      "community": 18
+      "community": 20
     },
     {
       "label": "make_runner()",
@@ -12025,7 +12257,7 @@
       "source_file": "scripts/pages-deploy/tests/test_pages_deploy_gate.py",
       "source_location": "L52",
       "id": "test_pages_deploy_gate_make_runner",
-      "community": 18
+      "community": 20
     },
     {
       "label": "run_gate()",
@@ -12033,7 +12265,7 @@
       "source_file": "scripts/pages-deploy/tests/test_pages_deploy_gate.py",
       "source_location": "L82",
       "id": "test_pages_deploy_gate_run_gate",
-      "community": 18
+      "community": 20
     },
     {
       "label": "run_gate_expect_error()",
@@ -12041,7 +12273,7 @@
       "source_file": "scripts/pages-deploy/tests/test_pages_deploy_gate.py",
       "source_location": "L93",
       "id": "test_pages_deploy_gate_run_gate_expect_error",
-      "community": 18
+      "community": 20
     },
     {
       "label": "deploy_calls()",
@@ -12049,7 +12281,7 @@
       "source_file": "scripts/pages-deploy/tests/test_pages_deploy_gate.py",
       "source_location": "L113",
       "id": "test_pages_deploy_gate_deploy_calls",
-      "community": 18
+      "community": 20
     },
     {
       "label": "test_two_phase_order_pre_deploy_success()",
@@ -12057,7 +12289,7 @@
       "source_file": "scripts/pages-deploy/tests/test_pages_deploy_gate.py",
       "source_location": "L117",
       "id": "test_pages_deploy_gate_test_two_phase_order_pre_deploy_success",
-      "community": 18
+      "community": 20
     },
     {
       "label": "test_two_phase_order_pre_deploy_failure()",
@@ -12065,7 +12297,7 @@
       "source_file": "scripts/pages-deploy/tests/test_pages_deploy_gate.py",
       "source_location": "L127",
       "id": "test_pages_deploy_gate_test_two_phase_order_pre_deploy_failure",
-      "community": 18
+      "community": 20
     },
     {
       "label": "test_missing_cloudflare_api_token()",
@@ -12073,7 +12305,7 @@
       "source_file": "scripts/pages-deploy/tests/test_pages_deploy_gate.py",
       "source_location": "L135",
       "id": "test_pages_deploy_gate_test_missing_cloudflare_api_token",
-      "community": 18
+      "community": 20
     },
     {
       "label": "test_missing_cloudflare_api_token_public_message_is_name_only()",
@@ -12081,7 +12313,7 @@
       "source_file": "scripts/pages-deploy/tests/test_pages_deploy_gate.py",
       "source_location": "L146",
       "id": "test_pages_deploy_gate_test_missing_cloudflare_api_token_public_message_is_name_only",
-      "community": 18
+      "community": 20
     },
     {
       "label": "test_missing_cloudflare_account_id()",
@@ -12089,7 +12321,7 @@
       "source_file": "scripts/pages-deploy/tests/test_pages_deploy_gate.py",
       "source_location": "L170",
       "id": "test_pages_deploy_gate_test_missing_cloudflare_account_id",
-      "community": 18
+      "community": 20
     },
     {
       "label": "test_missing_cloudflare_account_id_public_message_is_name_only()",
@@ -12097,7 +12329,7 @@
       "source_file": "scripts/pages-deploy/tests/test_pages_deploy_gate.py",
       "source_location": "L182",
       "id": "test_pages_deploy_gate_test_missing_cloudflare_account_id_public_message_is_name_only",
-      "community": 18
+      "community": 20
     },
     {
       "label": "test_missing_both_cloudflare_env_vars_lists_names_only()",
@@ -12105,7 +12337,7 @@
       "source_file": "scripts/pages-deploy/tests/test_pages_deploy_gate.py",
       "source_location": "L202",
       "id": "test_pages_deploy_gate_test_missing_both_cloudflare_env_vars_lists_names_only",
-      "community": 18
+      "community": 20
     },
     {
       "label": "test_deploy_requires_approved_flag()",
@@ -12113,7 +12345,7 @@
       "source_file": "scripts/pages-deploy/tests/test_pages_deploy_gate.py",
       "source_location": "L221",
       "id": "test_pages_deploy_gate_test_deploy_requires_approved_flag",
-      "community": 18
+      "community": 20
     },
     {
       "label": "test_dry_run_skips_deploy()",
@@ -12121,7 +12353,7 @@
       "source_file": "scripts/pages-deploy/tests/test_pages_deploy_gate.py",
       "source_location": "L232",
       "id": "test_pages_deploy_gate_test_dry_run_skips_deploy",
-      "community": 18
+      "community": 20
     },
     {
       "label": "test_build_failure()",
@@ -12129,7 +12361,7 @@
       "source_file": "scripts/pages-deploy/tests/test_pages_deploy_gate.py",
       "source_location": "L245",
       "id": "test_pages_deploy_gate_test_build_failure",
-      "community": 18
+      "community": 20
     },
     {
       "label": "test_output_dir_missing()",
@@ -12137,7 +12369,7 @@
       "source_file": "scripts/pages-deploy/tests/test_pages_deploy_gate.py",
       "source_location": "L254",
       "id": "test_pages_deploy_gate_test_output_dir_missing",
-      "community": 18
+      "community": 20
     },
     {
       "label": "test_output_dir_empty()",
@@ -12145,7 +12377,7 @@
       "source_file": "scripts/pages-deploy/tests/test_pages_deploy_gate.py",
       "source_location": "L263",
       "id": "test_pages_deploy_gate_test_output_dir_empty",
-      "community": 18
+      "community": 20
     },
     {
       "label": "test_stale_artifact()",
@@ -12153,7 +12385,7 @@
       "source_file": "scripts/pages-deploy/tests/test_pages_deploy_gate.py",
       "source_location": "L273",
       "id": "test_pages_deploy_gate_test_stale_artifact",
-      "community": 18
+      "community": 20
     },
     {
       "label": "test_pages_limit_file_count()",
@@ -12161,7 +12393,7 @@
       "source_file": "scripts/pages-deploy/tests/test_pages_deploy_gate.py",
       "source_location": "L286",
       "id": "test_pages_deploy_gate_test_pages_limit_file_count",
-      "community": 18
+      "community": 20
     },
     {
       "label": "test_pages_limit_file_size()",
@@ -12169,7 +12401,7 @@
       "source_file": "scripts/pages-deploy/tests/test_pages_deploy_gate.py",
       "source_location": "L295",
       "id": "test_pages_deploy_gate_test_pages_limit_file_size",
-      "community": 18
+      "community": 20
     },
     {
       "label": "test_secret_redaction()",
@@ -12177,7 +12409,7 @@
       "source_file": "scripts/pages-deploy/tests/test_pages_deploy_gate.py",
       "source_location": "L307",
       "id": "test_pages_deploy_gate_test_secret_redaction",
-      "community": 18
+      "community": 20
     },
     {
       "label": "test_wrangler_missing()",
@@ -12185,7 +12417,7 @@
       "source_file": "scripts/pages-deploy/tests/test_pages_deploy_gate.py",
       "source_location": "L318",
       "id": "test_pages_deploy_gate_test_wrangler_missing",
-      "community": 18
+      "community": 20
     },
     {
       "label": "test_wrangler_uses_ci_without_removed_noninteractive_flag()",
@@ -12193,7 +12425,7 @@
       "source_file": "scripts/pages-deploy/tests/test_pages_deploy_gate.py",
       "source_location": "L345",
       "id": "test_pages_deploy_gate_test_wrangler_uses_ci_without_removed_noninteractive_flag",
-      "community": 18
+      "community": 20
     },
     {
       "label": "_make_cf_response()",
@@ -12201,7 +12433,7 @@
       "source_file": "scripts/pages-deploy/tests/test_pages_deploy_gate.py",
       "source_location": "L357",
       "id": "test_pages_deploy_gate_make_cf_response",
-      "community": 18
+      "community": 20
     },
     {
       "label": "test_branch_binding_preflight_passes_on_match()",
@@ -12209,7 +12441,7 @@
       "source_file": "scripts/pages-deploy/tests/test_pages_deploy_gate.py",
       "source_location": "L377",
       "id": "test_pages_deploy_gate_test_branch_binding_preflight_passes_on_match",
-      "community": 18
+      "community": 20
     },
     {
       "label": "test_branch_binding_preflight_fails_on_mismatch()",
@@ -12217,7 +12449,7 @@
       "source_file": "scripts/pages-deploy/tests/test_pages_deploy_gate.py",
       "source_location": "L385",
       "id": "test_pages_deploy_gate_test_branch_binding_preflight_fails_on_mismatch",
-      "community": 18
+      "community": 20
     },
     {
       "label": "test_branch_binding_preflight_skips_without_token()",
@@ -12225,7 +12457,7 @@
       "source_file": "scripts/pages-deploy/tests/test_pages_deploy_gate.py",
       "source_location": "L397",
       "id": "test_pages_deploy_gate_test_branch_binding_preflight_skips_without_token",
-      "community": 18
+      "community": 20
     },
     {
       "label": "test_branch_binding_preflight_skips_via_env_flag()",
@@ -12233,7 +12465,7 @@
       "source_file": "scripts/pages-deploy/tests/test_pages_deploy_gate.py",
       "source_location": "L405",
       "id": "test_pages_deploy_gate_test_branch_binding_preflight_skips_via_env_flag",
-      "community": 18
+      "community": 20
     },
     {
       "label": "test_branch_binding_preflight_skips_on_api_error()",
@@ -12241,7 +12473,7 @@
       "source_file": "scripts/pages-deploy/tests/test_pages_deploy_gate.py",
       "source_location": "L413",
       "id": "test_pages_deploy_gate_test_branch_binding_preflight_skips_on_api_error",
-      "community": 18
+      "community": 20
     },
     {
       "label": "test_post_deploy_verify_called_with_source_sha()",
@@ -12249,7 +12481,7 @@
       "source_file": "scripts/pages-deploy/tests/test_pages_deploy_gate.py",
       "source_location": "L421",
       "id": "test_pages_deploy_gate_test_post_deploy_verify_called_with_source_sha",
-      "community": 18
+      "community": 20
     },
     {
       "label": "test_post_deploy_verify_failure_propagates()",
@@ -12257,7 +12489,7 @@
       "source_file": "scripts/pages-deploy/tests/test_pages_deploy_gate.py",
       "source_location": "L439",
       "id": "test_pages_deploy_gate_test_post_deploy_verify_failure_propagates",
-      "community": 18
+      "community": 20
     },
     {
       "label": "test_post_deploy_verify_not_called_on_dry_run()",
@@ -12265,7 +12497,7 @@
       "source_file": "scripts/pages-deploy/tests/test_pages_deploy_gate.py",
       "source_location": "L455",
       "id": "test_pages_deploy_gate_test_post_deploy_verify_not_called_on_dry_run",
-      "community": 18
+      "community": 20
     },
     {
       "label": "test_pages_deploy_verifier.py",
@@ -12273,7 +12505,7 @@
       "source_file": "scripts/pages-deploy/tests/test_pages_deploy_verifier.py",
       "source_location": "L1",
       "id": "test_pages_deploy_verifier",
-      "community": 33
+      "community": 32
     },
     {
       "label": "FakeTransport",
@@ -12281,7 +12513,7 @@
       "source_file": "scripts/pages-deploy/tests/test_pages_deploy_verifier.py",
       "source_location": "L29",
       "id": "test_pages_deploy_verifier_faketransport",
-      "community": 33
+      "community": 32
     },
     {
       "label": ".__init__()",
@@ -12289,7 +12521,7 @@
       "source_file": "scripts/pages-deploy/tests/test_pages_deploy_verifier.py",
       "source_location": "L30",
       "id": "test_pages_deploy_verifier_faketransport_init",
-      "community": 33
+      "community": 32
     },
     {
       "label": ".__call__()",
@@ -12297,7 +12529,7 @@
       "source_file": "scripts/pages-deploy/tests/test_pages_deploy_verifier.py",
       "source_location": "L34",
       "id": "test_pages_deploy_verifier_faketransport_call",
-      "community": 33
+      "community": 32
     },
     {
       "label": "response()",
@@ -12305,7 +12537,7 @@
       "source_file": "scripts/pages-deploy/tests/test_pages_deploy_verifier.py",
       "source_location": "L46",
       "id": "test_pages_deploy_verifier_response",
-      "community": 33
+      "community": 32
     },
     {
       "label": "write_config()",
@@ -12313,7 +12545,7 @@
       "source_file": "scripts/pages-deploy/tests/test_pages_deploy_verifier.py",
       "source_location": "L50",
       "id": "test_pages_deploy_verifier_write_config",
-      "community": 33
+      "community": 32
     },
     {
       "label": "run_report()",
@@ -12321,7 +12553,7 @@
       "source_file": "scripts/pages-deploy/tests/test_pages_deploy_verifier.py",
       "source_location": "L57",
       "id": "test_pages_deploy_verifier_run_report",
-      "community": 33
+      "community": 32
     },
     {
       "label": "test_matching_deployment_id()",
@@ -12329,7 +12561,7 @@
       "source_file": "scripts/pages-deploy/tests/test_pages_deploy_verifier.py",
       "source_location": "L71",
       "id": "test_pages_deploy_verifier_test_matching_deployment_id",
-      "community": 33
+      "community": 32
     },
     {
       "label": "test_stale_source_sha()",
@@ -12337,7 +12569,7 @@
       "source_file": "scripts/pages-deploy/tests/test_pages_deploy_verifier.py",
       "source_location": "L88",
       "id": "test_pages_deploy_verifier_test_stale_source_sha",
-      "community": 33
+      "community": 32
     },
     {
       "label": "test_domain_not_200()",
@@ -12345,7 +12577,7 @@
       "source_file": "scripts/pages-deploy/tests/test_pages_deploy_verifier.py",
       "source_location": "L98",
       "id": "test_pages_deploy_verifier_test_domain_not_200",
-      "community": 33
+      "community": 32
     },
     {
       "label": "test_different_deployment_ids()",
@@ -12353,7 +12585,7 @@
       "source_file": "scripts/pages-deploy/tests/test_pages_deploy_verifier.py",
       "source_location": "L108",
       "id": "test_pages_deploy_verifier_test_different_deployment_ids",
-      "community": 33
+      "community": 32
     },
     {
       "label": "test_redacted_output()",
@@ -12361,7 +12593,7 @@
       "source_file": "scripts/pages-deploy/tests/test_pages_deploy_verifier.py",
       "source_location": "L125",
       "id": "test_pages_deploy_verifier_test_redacted_output",
-      "community": 33
+      "community": 32
     },
     {
       "label": "test_retry_backoff()",
@@ -12369,7 +12601,7 @@
       "source_file": "scripts/pages-deploy/tests/test_pages_deploy_verifier.py",
       "source_location": "L162",
       "id": "test_pages_deploy_verifier_test_retry_backoff",
-      "community": 33
+      "community": 32
     },
     {
       "label": "test_redirect_chain_recorded()",
@@ -12377,7 +12609,7 @@
       "source_file": "scripts/pages-deploy/tests/test_pages_deploy_verifier.py",
       "source_location": "L190",
       "id": "test_pages_deploy_verifier_test_redirect_chain_recorded",
-      "community": 33
+      "community": 32
     },
     {
       "label": "test_cache_busting_headers()",
@@ -12385,7 +12617,7 @@
       "source_file": "scripts/pages-deploy/tests/test_pages_deploy_verifier.py",
       "source_location": "L209",
       "id": "test_pages_deploy_verifier_test_cache_busting_headers",
-      "community": 33
+      "community": 32
     },
     {
       "label": "test_stable_endpoint_not_html()",
@@ -12393,7 +12625,7 @@
       "source_file": "scripts/pages-deploy/tests/test_pages_deploy_verifier.py",
       "source_location": "L228",
       "id": "test_pages_deploy_verifier_test_stable_endpoint_not_html",
-      "community": 33
+      "community": 32
     },
     {
       "label": "test_cname_mismatch_not_blocking()",
@@ -12401,7 +12633,7 @@
       "source_file": "scripts/pages-deploy/tests/test_pages_deploy_verifier.py",
       "source_location": "L244",
       "id": "test_pages_deploy_verifier_test_cname_mismatch_not_blocking",
-      "community": 33
+      "community": 32
     },
     {
       "label": "test_stale_checkout_refused()",
@@ -12409,7 +12641,7 @@
       "source_file": "scripts/pages-deploy/tests/test_pages_deploy_verifier.py",
       "source_location": "L262",
       "id": "test_pages_deploy_verifier_test_stale_checkout_refused",
-      "community": 33
+      "community": 32
     },
     {
       "label": "test_per_domain_report_fields()",
@@ -12417,7 +12649,7 @@
       "source_file": "scripts/pages-deploy/tests/test_pages_deploy_verifier.py",
       "source_location": "L283",
       "id": "test_pages_deploy_verifier_test_per_domain_report_fields",
-      "community": 33
+      "community": 32
     },
     {
       "label": "title_response()",
@@ -12425,7 +12657,7 @@
       "source_file": "scripts/pages-deploy/tests/test_pages_deploy_verifier.py",
       "source_location": "L293",
       "id": "test_pages_deploy_verifier_title_response",
-      "community": 33
+      "community": 32
     },
     {
       "label": "test_expected_title_matches()",
@@ -12433,7 +12665,7 @@
       "source_file": "scripts/pages-deploy/tests/test_pages_deploy_verifier.py",
       "source_location": "L298",
       "id": "test_pages_deploy_verifier_test_expected_title_matches",
-      "community": 33
+      "community": 32
     },
     {
       "label": "test_expected_title_mismatch_fails()",
@@ -12441,7 +12673,7 @@
       "source_file": "scripts/pages-deploy/tests/test_pages_deploy_verifier.py",
       "source_location": "L314",
       "id": "test_pages_deploy_verifier_test_expected_title_mismatch_fails",
-      "community": 33
+      "community": 32
     },
     {
       "label": "test_no_expected_title_skips_probe()",
@@ -12449,7 +12681,7 @@
       "source_file": "scripts/pages-deploy/tests/test_pages_deploy_verifier.py",
       "source_location": "L330",
       "id": "test_pages_deploy_verifier_test_no_expected_title_skips_probe",
-      "community": 33
+      "community": 32
     },
     {
       "label": "live_health_monitor.py",
@@ -12521,7 +12753,7 @@
       "source_file": "scripts/remote-mcp/monitor_alert.py",
       "source_location": "L1",
       "id": "monitor_alert",
-      "community": 44
+      "community": 43
     },
     {
       "label": "_now()",
@@ -12529,7 +12761,7 @@
       "source_file": "scripts/remote-mcp/monitor_alert.py",
       "source_location": "L23",
       "id": "monitor_alert_now",
-      "community": 44
+      "community": 43
     },
     {
       "label": "_contains_sensitive()",
@@ -12537,7 +12769,7 @@
       "source_file": "scripts/remote-mcp/monitor_alert.py",
       "source_location": "L27",
       "id": "monitor_alert_contains_sensitive",
-      "community": 44
+      "community": 43
     },
     {
       "label": "_safe_text()",
@@ -12545,7 +12777,7 @@
       "source_file": "scripts/remote-mcp/monitor_alert.py",
       "source_location": "L31",
       "id": "monitor_alert_safe_text",
-      "community": 44
+      "community": 43
     },
     {
       "label": "_load_payload()",
@@ -12553,7 +12785,7 @@
       "source_file": "scripts/remote-mcp/monitor_alert.py",
       "source_location": "L39",
       "id": "monitor_alert_load_payload",
-      "community": 44
+      "community": 43
     },
     {
       "label": "build_alert()",
@@ -12561,7 +12793,7 @@
       "source_file": "scripts/remote-mcp/monitor_alert.py",
       "source_location": "L50",
       "id": "monitor_alert_build_alert",
-      "community": 44
+      "community": 43
     },
     {
       "label": "render_markdown()",
@@ -12569,7 +12801,7 @@
       "source_file": "scripts/remote-mcp/monitor_alert.py",
       "source_location": "L106",
       "id": "monitor_alert_render_markdown",
-      "community": 44
+      "community": 43
     },
     {
       "label": "build_parser()",
@@ -12577,7 +12809,7 @@
       "source_file": "scripts/remote-mcp/monitor_alert.py",
       "source_location": "L138",
       "id": "monitor_alert_build_parser",
-      "community": 44
+      "community": 43
     },
     {
       "label": "main()",
@@ -12585,7 +12817,7 @@
       "source_file": "scripts/remote-mcp/monitor_alert.py",
       "source_location": "L147",
       "id": "monitor_alert_main",
-      "community": 44
+      "community": 43
     },
     {
       "label": "operator_connectivity.py",
@@ -12729,7 +12961,7 @@
       "source_file": "scripts/remote-mcp/operator_inbound_preflight.py",
       "source_location": "L1",
       "id": "operator_inbound_preflight",
-      "community": 5
+      "community": 7
     },
     {
       "label": "Check",
@@ -12737,7 +12969,7 @@
       "source_file": "scripts/remote-mcp/operator_inbound_preflight.py",
       "source_location": "L32",
       "id": "operator_inbound_preflight_check",
-      "community": 5
+      "community": 7
     },
     {
       "label": ".to_dict()",
@@ -12745,7 +12977,7 @@
       "source_file": "scripts/remote-mcp/operator_inbound_preflight.py",
       "source_location": "L37",
       "id": "operator_inbound_preflight_check_to_dict",
-      "community": 5
+      "community": 7
     },
     {
       "label": "_missing_groups()",
@@ -12753,7 +12985,7 @@
       "source_file": "scripts/remote-mcp/operator_inbound_preflight.py",
       "source_location": "L41",
       "id": "operator_inbound_preflight_missing_groups",
-      "community": 5
+      "community": 7
     },
     {
       "label": "_fixture_request()",
@@ -12761,7 +12993,7 @@
       "source_file": "scripts/remote-mcp/operator_inbound_preflight.py",
       "source_location": "L49",
       "id": "operator_inbound_preflight_fixture_request",
-      "community": 5
+      "community": 7
     },
     {
       "label": "_packet_summary()",
@@ -12769,7 +13001,7 @@
       "source_file": "scripts/remote-mcp/operator_inbound_preflight.py",
       "source_location": "L68",
       "id": "operator_inbound_preflight_packet_summary",
-      "community": 5
+      "community": 7
     },
     {
       "label": "_call_fixture()",
@@ -12777,7 +13009,7 @@
       "source_file": "scripts/remote-mcp/operator_inbound_preflight.py",
       "source_location": "L81",
       "id": "operator_inbound_preflight_call_fixture",
-      "community": 5
+      "community": 7
     },
     {
       "label": "_latest_live_instruction()",
@@ -12785,7 +13017,7 @@
       "source_file": "scripts/remote-mcp/operator_inbound_preflight.py",
       "source_location": "L121",
       "id": "operator_inbound_preflight_latest_live_instruction",
-      "community": 5
+      "community": 7
     },
     {
       "label": "_call_live()",
@@ -12793,7 +13025,7 @@
       "source_file": "scripts/remote-mcp/operator_inbound_preflight.py",
       "source_location": "L143",
       "id": "operator_inbound_preflight_call_live",
-      "community": 5
+      "community": 7
     },
     {
       "label": "build_payload()",
@@ -12801,7 +13033,7 @@
       "source_file": "scripts/remote-mcp/operator_inbound_preflight.py",
       "source_location": "L154",
       "id": "operator_inbound_preflight_build_payload",
-      "community": 5
+      "community": 7
     },
     {
       "label": "build_parser()",
@@ -12809,7 +13041,7 @@
       "source_file": "scripts/remote-mcp/operator_inbound_preflight.py",
       "source_location": "L200",
       "id": "operator_inbound_preflight_build_parser",
-      "community": 5
+      "community": 7
     },
     {
       "label": "main()",
@@ -12817,7 +13049,7 @@
       "source_file": "scripts/remote-mcp/operator_inbound_preflight.py",
       "source_location": "L207",
       "id": "operator_inbound_preflight_main",
-      "community": 5
+      "community": 7
     },
     {
       "label": "stage_d_smoke.py",
@@ -13009,7 +13241,7 @@
       "source_file": "scripts/remote-mcp/tests/test_monitor_alert.py",
       "source_location": "L1",
       "id": "test_monitor_alert",
-      "community": 44
+      "community": 43
     },
     {
       "label": "_payload()",
@@ -13017,7 +13249,7 @@
       "source_file": "scripts/remote-mcp/tests/test_monitor_alert.py",
       "source_location": "L17",
       "id": "test_monitor_alert_payload",
-      "community": 44
+      "community": 43
     },
     {
       "label": "test_build_alert_marks_healthy_payload()",
@@ -13025,7 +13257,7 @@
       "source_file": "scripts/remote-mcp/tests/test_monitor_alert.py",
       "source_location": "L28",
       "id": "test_monitor_alert_test_build_alert_marks_healthy_payload",
-      "community": 44
+      "community": 43
     },
     {
       "label": "test_build_alert_marks_degraded_failures()",
@@ -13033,7 +13265,7 @@
       "source_file": "scripts/remote-mcp/tests/test_monitor_alert.py",
       "source_location": "L37",
       "id": "test_monitor_alert_test_build_alert_marks_degraded_failures",
-      "community": 44
+      "community": 43
     },
     {
       "label": "test_sensitive_material_is_redacted_and_degraded()",
@@ -13041,7 +13273,7 @@
       "source_file": "scripts/remote-mcp/tests/test_monitor_alert.py",
       "source_location": "L46",
       "id": "test_monitor_alert_test_sensitive_material_is_redacted_and_degraded",
-      "community": 44
+      "community": 43
     },
     {
       "label": "test_cli_writes_json_and_markdown()",
@@ -13049,7 +13281,7 @@
       "source_file": "scripts/remote-mcp/tests/test_monitor_alert.py",
       "source_location": "L61",
       "id": "test_monitor_alert_test_cli_writes_json_and_markdown",
-      "community": 44
+      "community": 43
     },
     {
       "label": "test_cli_fail_on_degraded_returns_one_without_secret_echo()",
@@ -13057,7 +13289,7 @@
       "source_file": "scripts/remote-mcp/tests/test_monitor_alert.py",
       "source_location": "L88",
       "id": "test_monitor_alert_test_cli_fail_on_degraded_returns_one_without_secret_echo",
-      "community": 44
+      "community": 43
     },
     {
       "label": "test_operator_connectivity.py",
@@ -13105,7 +13337,7 @@
       "source_file": "scripts/remote-mcp/tests/test_operator_inbound_preflight.py",
       "source_location": "L1",
       "id": "test_operator_inbound_preflight",
-      "community": 5
+      "community": 7
     },
     {
       "label": "test_fixture_preflight_proves_session_inbox_receive_path()",
@@ -13113,7 +13345,7 @@
       "source_file": "scripts/remote-mcp/tests/test_operator_inbound_preflight.py",
       "source_location": "L18",
       "id": "test_operator_inbound_preflight_test_fixture_preflight_proves_session_inbox_receive_path",
-      "community": 5
+      "community": 7
     },
     {
       "label": "test_live_preflight_fails_closed_when_config_missing()",
@@ -13121,7 +13353,7 @@
       "source_file": "scripts/remote-mcp/tests/test_operator_inbound_preflight.py",
       "source_location": "L31",
       "id": "test_operator_inbound_preflight_test_live_preflight_fails_closed_when_config_missing",
-      "community": 5
+      "community": 7
     },
     {
       "label": "test_live_preflight_fails_when_session_inbox_has_no_instruction()",
@@ -13129,7 +13361,7 @@
       "source_file": "scripts/remote-mcp/tests/test_operator_inbound_preflight.py",
       "source_location": "L47",
       "id": "test_operator_inbound_preflight_test_live_preflight_fails_when_session_inbox_has_no_instruction",
-      "community": 5
+      "community": 7
     },
     {
       "label": "test_cli_writes_json_output()",
@@ -13137,7 +13369,7 @@
       "source_file": "scripts/remote-mcp/tests/test_operator_inbound_preflight.py",
       "source_location": "L62",
       "id": "test_operator_inbound_preflight_test_cli_writes_json_output",
-      "community": 5
+      "community": 7
     },
     {
       "label": "test_stage_d_smoke.py",
@@ -13406,122 +13638,122 @@
     {
       "label": "session_bootstrap_contract.py",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/session_bootstrap_contract.py",
+      "source_file": "scripts/session_bootstrap_contract.py",
       "source_location": "L1",
       "id": "session_bootstrap_contract",
-      "community": 49
+      "community": 48
     },
     {
       "label": "RunbookPaths",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/session_bootstrap_contract.py",
+      "source_file": "scripts/session_bootstrap_contract.py",
       "source_location": "L28",
       "id": "session_bootstrap_contract_runbookpaths",
-      "community": 49
+      "community": 48
     },
     {
       "label": "parse_args()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/session_bootstrap_contract.py",
+      "source_file": "scripts/session_bootstrap_contract.py",
       "source_location": "L35",
       "id": "session_bootstrap_contract_parse_args",
-      "community": 49
+      "community": 48
     },
     {
       "label": "resolve_repo_root()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/session_bootstrap_contract.py",
+      "source_file": "scripts/session_bootstrap_contract.py",
       "source_location": "L44",
       "id": "session_bootstrap_contract_resolve_repo_root",
-      "community": 49
+      "community": 48
     },
     {
       "label": "run_git_root()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/session_bootstrap_contract.py",
+      "source_file": "scripts/session_bootstrap_contract.py",
       "source_location": "L52",
       "id": "session_bootstrap_contract_run_git_root",
-      "community": 49
+      "community": 48
     },
     {
       "label": "sentinel_path()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/session_bootstrap_contract.py",
+      "source_file": "scripts/session_bootstrap_contract.py",
       "source_location": "L64",
       "id": "session_bootstrap_contract_sentinel_path",
-      "community": 49
+      "community": 48
     },
     {
       "label": "read_text()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/session_bootstrap_contract.py",
+      "source_file": "scripts/session_bootstrap_contract.py",
       "source_location": "L75",
       "id": "session_bootstrap_contract_read_text",
-      "community": 49
+      "community": 48
     },
     {
       "label": "extract_som_excerpt()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/session_bootstrap_contract.py",
+      "source_file": "scripts/session_bootstrap_contract.py",
       "source_location": "L79",
       "id": "session_bootstrap_contract_extract_som_excerpt",
-      "community": 49
+      "community": 48
     },
     {
       "label": "extract_runbook_paths()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/session_bootstrap_contract.py",
+      "source_file": "scripts/session_bootstrap_contract.py",
       "source_location": "L91",
       "id": "session_bootstrap_contract_extract_runbook_paths",
-      "community": 49
+      "community": 48
     },
     {
       "label": "codex_backlog_status()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/session_bootstrap_contract.py",
+      "source_file": "scripts/session_bootstrap_contract.py",
       "source_location": "L110",
       "id": "session_bootstrap_contract_codex_backlog_status",
-      "community": 49
+      "community": 48
     },
     {
       "label": "build_report()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/session_bootstrap_contract.py",
+      "source_file": "scripts/session_bootstrap_contract.py",
       "source_location": "L121",
       "id": "session_bootstrap_contract_build_report",
-      "community": 49
+      "community": 48
     },
     {
       "label": "git_branch()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/session_bootstrap_contract.py",
+      "source_file": "scripts/session_bootstrap_contract.py",
       "source_location": "L173",
       "id": "session_bootstrap_contract_git_branch",
-      "community": 49
+      "community": 48
     },
     {
       "label": "write_sentinel()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/session_bootstrap_contract.py",
+      "source_file": "scripts/session_bootstrap_contract.py",
       "source_location": "L186",
       "id": "session_bootstrap_contract_write_sentinel",
-      "community": 49
+      "community": 48
     },
     {
       "label": "format_hook_note()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/session_bootstrap_contract.py",
+      "source_file": "scripts/session_bootstrap_contract.py",
       "source_location": "L191",
       "id": "session_bootstrap_contract_format_hook_note",
-      "community": 49
+      "community": 48
     },
     {
       "label": "main()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/session_bootstrap_contract.py",
+      "source_file": "scripts/session_bootstrap_contract.py",
       "source_location": "L235",
       "id": "session_bootstrap_contract_main",
-      "community": 49
+      "community": 48
     },
     {
       "label": "som_client.py",
@@ -13828,26 +14060,26 @@
       "community": 57
     },
     {
-      "label": "run_sibling_worktree_lam_bootstrap()",
+      "label": "run_canonical_root_worktree_lam_bootstrap()",
       "file_type": "code",
       "source_file": "scripts/test_bootstrap_repo_env_contract.py",
-      "source_location": "L168",
-      "id": "test_bootstrap_repo_env_contract_run_sibling_worktree_lam_bootstrap",
+      "source_location": "L172",
+      "id": "test_bootstrap_repo_env_contract_run_canonical_root_worktree_lam_bootstrap",
       "community": 57
     },
     {
-      "label": "run_nested_var_worktree_lam_bootstrap()",
+      "label": "run_noncanonical_root_lam_bootstrap_fails_closed()",
       "file_type": "code",
       "source_file": "scripts/test_bootstrap_repo_env_contract.py",
-      "source_location": "L218",
-      "id": "test_bootstrap_repo_env_contract_run_nested_var_worktree_lam_bootstrap",
+      "source_location": "L224",
+      "id": "test_bootstrap_repo_env_contract_run_noncanonical_root_lam_bootstrap_fails_closed",
       "community": 57
     },
     {
       "label": "run_synthetic_seek_bootstrap()",
       "file_type": "code",
       "source_file": "scripts/test_bootstrap_repo_env_contract.py",
-      "source_location": "L263",
+      "source_location": "L254",
       "id": "test_bootstrap_repo_env_contract_run_synthetic_seek_bootstrap",
       "community": 57
     },
@@ -13855,7 +14087,7 @@
       "label": "run_synthetic_stampede_bootstrap()",
       "file_type": "code",
       "source_file": "scripts/test_bootstrap_repo_env_contract.py",
-      "source_location": "L322",
+      "source_location": "L317",
       "id": "test_bootstrap_repo_env_contract_run_synthetic_stampede_bootstrap",
       "community": 57
     },
@@ -13868,35 +14100,35 @@
       "community": 57
     },
     {
-      "label": "Exercise vault discovery from sibling governance worktrees.",
+      "label": "Exercise worktree invocation while still resolving the canonical governance root",
       "file_type": "rationale",
       "source_file": "scripts/test_bootstrap_repo_env_contract.py",
-      "source_location": "L169",
-      "id": "test_bootstrap_repo_env_contract_rationale_169",
+      "source_location": "L173",
+      "id": "test_bootstrap_repo_env_contract_rationale_173",
       "community": 57
     },
     {
-      "label": "Exercise vault discovery from HLDPRO/var/worktrees/* governance worktrees.",
+      "label": "Exercise failure when the canonical governance root is absent.",
       "file_type": "rationale",
       "source_file": "scripts/test_bootstrap_repo_env_contract.py",
-      "source_location": "L219",
-      "id": "test_bootstrap_repo_env_contract_rationale_219",
+      "source_location": "L225",
+      "id": "test_bootstrap_repo_env_contract_rationale_225",
       "community": 57
     },
     {
       "label": "Exercise Seek/Ponder bootstrap aliases without leaking synthetic values.",
       "file_type": "rationale",
       "source_file": "scripts/test_bootstrap_repo_env_contract.py",
-      "source_location": "L264",
-      "id": "test_bootstrap_repo_env_contract_rationale_264",
+      "source_location": "L255",
+      "id": "test_bootstrap_repo_env_contract_rationale_255",
       "community": 57
     },
     {
       "label": "Exercise Stampede bootstrap with production Tradier mapping and redaction.",
       "file_type": "rationale",
       "source_file": "scripts/test_bootstrap_repo_env_contract.py",
-      "source_location": "L323",
-      "id": "test_bootstrap_repo_env_contract_rationale_323",
+      "source_location": "L318",
+      "id": "test_bootstrap_repo_env_contract_rationale_318",
       "community": 57
     },
     {
@@ -14025,7 +14257,7 @@
       "source_file": "scripts/test_codex_fire.py",
       "source_location": "L1",
       "id": "test_codex_fire",
-      "community": 69
+      "community": 68
     },
     {
       "label": "write_fake_codex()",
@@ -14033,7 +14265,7 @@
       "source_file": "scripts/test_codex_fire.py",
       "source_location": "L13",
       "id": "test_codex_fire_write_fake_codex",
-      "community": 69
+      "community": 68
     },
     {
       "label": "run_fire()",
@@ -14041,7 +14273,7 @@
       "source_file": "scripts/test_codex_fire.py",
       "source_location": "L27",
       "id": "test_codex_fire_run_fire",
-      "community": 69
+      "community": 68
     },
     {
       "label": "test_preflight_failure_logs_and_exits_fast()",
@@ -14049,7 +14281,7 @@
       "source_file": "scripts/test_codex_fire.py",
       "source_location": "L61",
       "id": "test_codex_fire_test_preflight_failure_logs_and_exits_fast",
-      "community": 69
+      "community": 68
     },
     {
       "label": "test_preflight_timeout_logs_and_exits_fast()",
@@ -14057,7 +14289,7 @@
       "source_file": "scripts/test_codex_fire.py",
       "source_location": "L83",
       "id": "test_codex_fire_test_preflight_timeout_logs_and_exits_fast",
-      "community": 69
+      "community": 68
     },
     {
       "label": "test_exec_failure_after_successful_preflight_logs_and_signals()",
@@ -14065,7 +14297,7 @@
       "source_file": "scripts/test_codex_fire.py",
       "source_location": "L105",
       "id": "test_codex_fire_test_exec_failure_after_successful_preflight_logs_and_signals",
-      "community": 69
+      "community": 68
     },
     {
       "label": "test_success_does_not_write_failure_log()",
@@ -14073,7 +14305,7 @@
       "source_file": "scripts/test_codex_fire.py",
       "source_location": "L137",
       "id": "test_codex_fire_test_success_does_not_write_failure_log",
-      "community": 69
+      "community": 68
     },
     {
       "label": "test_review_template_default_persona_reaches_codex_fire()",
@@ -14081,7 +14313,7 @@
       "source_file": "scripts/test_codex_fire.py",
       "source_location": "L155",
       "id": "test_codex_fire_test_review_template_default_persona_reaches_codex_fire",
-      "community": 69
+      "community": 68
     },
     {
       "label": "test_review_template_propagates_wrapper_failure()",
@@ -14089,12 +14321,20 @@
       "source_file": "scripts/test_codex_fire.py",
       "source_location": "L225",
       "id": "test_codex_fire_test_review_template_propagates_wrapper_failure",
-      "community": 69
+      "community": 68
+    },
+    {
+      "label": "test_review_template_claude_dry_run_uses_self_contained_packet_contract()",
+      "file_type": "code",
+      "source_file": "scripts/test_codex_fire.py",
+      "source_location": "L279",
+      "id": "test_codex_fire_test_review_template_claude_dry_run_uses_self_contained_packet_contract",
+      "community": 68
     },
     {
       "label": "test_session_bootstrap_contract.py",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/test_session_bootstrap_contract.py",
+      "source_file": "scripts/test_session_bootstrap_contract.py",
       "source_location": "L1",
       "id": "test_session_bootstrap_contract",
       "community": 76
@@ -14102,7 +14342,7 @@
     {
       "label": "make_repo()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/test_session_bootstrap_contract.py",
+      "source_file": "scripts/test_session_bootstrap_contract.py",
       "source_location": "L14",
       "id": "test_session_bootstrap_contract_make_repo",
       "community": 76
@@ -14110,7 +14350,7 @@
     {
       "label": "run_contract()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/test_session_bootstrap_contract.py",
+      "source_file": "scripts/test_session_bootstrap_contract.py",
       "source_location": "L60",
       "id": "test_session_bootstrap_contract_run_contract",
       "community": 76
@@ -14118,7 +14358,7 @@
     {
       "label": "SessionBootstrapContractTests",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/test_session_bootstrap_contract.py",
+      "source_file": "scripts/test_session_bootstrap_contract.py",
       "source_location": "L69",
       "id": "test_session_bootstrap_contract_sessionbootstrapcontracttests",
       "community": 76
@@ -14126,7 +14366,7 @@
     {
       "label": ".test_emit_hook_note_writes_sentinel_and_surfaces_runbook_paths()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/test_session_bootstrap_contract.py",
+      "source_file": "scripts/test_session_bootstrap_contract.py",
       "source_location": "L70",
       "id": "test_session_bootstrap_contract_sessionbootstrapcontracttests_test_emit_hook_note_writes_sentinel_and_surfaces_runbook_paths",
       "community": 76
@@ -14134,7 +14374,7 @@
     {
       "label": ".test_missing_required_file_is_recorded_as_warning()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/test_session_bootstrap_contract.py",
+      "source_file": "scripts/test_session_bootstrap_contract.py",
       "source_location": "L93",
       "id": "test_session_bootstrap_contract_sessionbootstrapcontracttests_test_missing_required_file_is_recorded_as_warning",
       "community": 76
@@ -14649,7 +14889,7 @@
       "source_file": "scripts/windows-ollama/tests/test_audit.py",
       "source_location": "L1",
       "id": "test_audit",
-      "community": 37
+      "community": 38
     },
     {
       "label": "TestAuditChainIntegrity",
@@ -14657,7 +14897,7 @@
       "source_file": "scripts/windows-ollama/tests/test_audit.py",
       "source_location": "L20",
       "id": "test_audit_testauditchainintegrity",
-      "community": 37
+      "community": 38
     },
     {
       "label": ".test_tamper_line_breaks_chain()",
@@ -14665,7 +14905,7 @@
       "source_file": "scripts/windows-ollama/tests/test_audit.py",
       "source_location": "L23",
       "id": "test_audit_testauditchainintegrity_test_tamper_line_breaks_chain",
-      "community": 37
+      "community": 38
     },
     {
       "label": "TestHmacForgery",
@@ -14673,7 +14913,7 @@
       "source_file": "scripts/windows-ollama/tests/test_audit.py",
       "source_location": "L61",
       "id": "test_audit_testhmacforgery",
-      "community": 37
+      "community": 38
     },
     {
       "label": ".test_hmac_forgery_detected()",
@@ -14681,7 +14921,7 @@
       "source_file": "scripts/windows-ollama/tests/test_audit.py",
       "source_location": "L64",
       "id": "test_audit_testhmacforgery_test_hmac_forgery_detected",
-      "community": 37
+      "community": 38
     },
     {
       "label": "TestManifestMismatch",
@@ -14689,7 +14929,7 @@
       "source_file": "scripts/windows-ollama/tests/test_audit.py",
       "source_location": "L97",
       "id": "test_audit_testmanifestmismatch",
-      "community": 37
+      "community": 38
     },
     {
       "label": ".test_manifest_first_hash_mismatch()",
@@ -14697,7 +14937,7 @@
       "source_file": "scripts/windows-ollama/tests/test_audit.py",
       "source_location": "L100",
       "id": "test_audit_testmanifestmismatch_test_manifest_first_hash_mismatch",
-      "community": 37
+      "community": 38
     },
     {
       "label": "TestFileTruncation",
@@ -14705,7 +14945,7 @@
       "source_file": "scripts/windows-ollama/tests/test_audit.py",
       "source_location": "L130",
       "id": "test_audit_testfiletruncation",
-      "community": 37
+      "community": 38
     },
     {
       "label": ".test_file_truncation_detected()",
@@ -14713,7 +14953,7 @@
       "source_file": "scripts/windows-ollama/tests/test_audit.py",
       "source_location": "L133",
       "id": "test_audit_testfiletruncation_test_file_truncation_detected",
-      "community": 37
+      "community": 38
     },
     {
       "label": "TestReplay",
@@ -14721,7 +14961,7 @@
       "source_file": "scripts/windows-ollama/tests/test_audit.py",
       "source_location": "L164",
       "id": "test_audit_testreplay",
-      "community": 37
+      "community": 38
     },
     {
       "label": ".test_duplicate_line_detected()",
@@ -14729,7 +14969,7 @@
       "source_file": "scripts/windows-ollama/tests/test_audit.py",
       "source_location": "L167",
       "id": "test_audit_testreplay_test_duplicate_line_detected",
-      "community": 37
+      "community": 38
     },
     {
       "label": "Test that tampering with a line breaks the chain.",
@@ -14737,7 +14977,7 @@
       "source_file": "scripts/windows-ollama/tests/test_audit.py",
       "source_location": "L21",
       "id": "test_audit_rationale_21",
-      "community": 37
+      "community": 38
     },
     {
       "label": "Tamper with line N and verify fails at line N+1.",
@@ -14745,7 +14985,7 @@
       "source_file": "scripts/windows-ollama/tests/test_audit.py",
       "source_location": "L24",
       "id": "test_audit_rationale_24",
-      "community": 37
+      "community": 38
     },
     {
       "label": "Test that replacing entry_hmac with wrong value fails verification.",
@@ -14753,7 +14993,7 @@
       "source_file": "scripts/windows-ollama/tests/test_audit.py",
       "source_location": "L62",
       "id": "test_audit_rationale_62",
-      "community": 37
+      "community": 38
     },
     {
       "label": "Replace entry_hmac with wrong value and verify fails.",
@@ -14761,7 +15001,7 @@
       "source_file": "scripts/windows-ollama/tests/test_audit.py",
       "source_location": "L65",
       "id": "test_audit_rationale_65",
-      "community": 37
+      "community": 38
     },
     {
       "label": "Test that modifying manifest fails verification.",
@@ -14769,7 +15009,7 @@
       "source_file": "scripts/windows-ollama/tests/test_audit.py",
       "source_location": "L98",
       "id": "test_audit_rationale_98",
-      "community": 37
+      "community": 38
     },
     {
       "label": "Modify first_hash in manifest and verify fails.",
@@ -14777,7 +15017,7 @@
       "source_file": "scripts/windows-ollama/tests/test_audit.py",
       "source_location": "L101",
       "id": "test_audit_rationale_101",
-      "community": 37
+      "community": 38
     },
     {
       "label": "Test that truncated file (missing last line) breaks manifest.",
@@ -14785,7 +15025,7 @@
       "source_file": "scripts/windows-ollama/tests/test_audit.py",
       "source_location": "L131",
       "id": "test_audit_rationale_131",
-      "community": 37
+      "community": 38
     },
     {
       "label": "Delete last line and verify detects entry_count mismatch.",
@@ -14793,7 +15033,7 @@
       "source_file": "scripts/windows-ollama/tests/test_audit.py",
       "source_location": "L134",
       "id": "test_audit_rationale_134",
-      "community": 37
+      "community": 38
     },
     {
       "label": "Test that duplicate line (replay) breaks seq monotonicity.",
@@ -14801,7 +15041,7 @@
       "source_file": "scripts/windows-ollama/tests/test_audit.py",
       "source_location": "L165",
       "id": "test_audit_rationale_165",
-      "community": 37
+      "community": 38
     },
     {
       "label": "Duplicate a line and verify detects non-monotonic seq.",
@@ -14809,7 +15049,7 @@
       "source_file": "scripts/windows-ollama/tests/test_audit.py",
       "source_location": "L168",
       "id": "test_audit_rationale_168",
-      "community": 37
+      "community": 38
     },
     {
       "label": "test_submit.py",
@@ -15353,7 +15593,7 @@
       "source_file": "tests/test_codex_ingestion.py",
       "source_location": "L1",
       "id": "test_codex_ingestion",
-      "community": 9
+      "community": 13
     },
     {
       "label": "ValidateLocationTests",
@@ -15361,7 +15601,7 @@
       "source_file": "tests/test_codex_ingestion.py",
       "source_location": "L15",
       "id": "test_codex_ingestion_validatelocationtests",
-      "community": 9
+      "community": 13
     },
     {
       "label": ".test_rejects_hallucinated_anchor_on_valid_line()",
@@ -15369,7 +15609,7 @@
       "source_file": "tests/test_codex_ingestion.py",
       "source_location": "L16",
       "id": "test_codex_ingestion_validatelocationtests_test_rejects_hallucinated_anchor_on_valid_line",
-      "community": 9
+      "community": 13
     },
     {
       "label": ".test_accepts_matching_anchor_on_valid_line()",
@@ -15377,7 +15617,7 @@
       "source_file": "tests/test_codex_ingestion.py",
       "source_location": "L38",
       "id": "test_codex_ingestion_validatelocationtests_test_accepts_matching_anchor_on_valid_line",
-      "community": 9
+      "community": 13
     },
     {
       "label": "test_progress_github_issue_staleness.py",
@@ -15385,7 +15625,7 @@
       "source_file": "tests/test_progress_github_issue_staleness.py",
       "source_location": "L1",
       "id": "test_progress_github_issue_staleness",
-      "community": 45
+      "community": 44
     },
     {
       "label": "ProgressGithubIssueStalenessTests",
@@ -15393,7 +15633,7 @@
       "source_file": "tests/test_progress_github_issue_staleness.py",
       "source_location": "L16",
       "id": "test_progress_github_issue_staleness_progressgithubissuestalenesstests",
-      "community": 45
+      "community": 44
     },
     {
       "label": ".test_collects_active_sections_and_ignores_done()",
@@ -15401,7 +15641,7 @@
       "source_file": "tests/test_progress_github_issue_staleness.py",
       "source_location": "L17",
       "id": "test_progress_github_issue_staleness_progressgithubissuestalenesstests_test_collects_active_sections_and_ignores_done",
-      "community": 45
+      "community": 44
     },
     {
       "label": ".test_build_summary_reports_missing_open_and_stale_closed()",
@@ -15409,7 +15649,7 @@
       "source_file": "tests/test_progress_github_issue_staleness.py",
       "source_location": "L46",
       "id": "test_progress_github_issue_staleness_progressgithubissuestalenesstests_test_build_summary_reports_missing_open_and_stale_closed",
-      "community": 45
+      "community": 44
     },
     {
       "label": "local_ci_gate.py",
@@ -15417,7 +15657,7 @@
       "source_file": "tools/local-ci-gate/local_ci_gate.py",
       "source_location": "L1",
       "id": "local_ci_gate",
-      "community": 15
+      "community": 16
     },
     {
       "label": "GateError",
@@ -15425,7 +15665,7 @@
       "source_file": "tools/local-ci-gate/local_ci_gate.py",
       "source_location": "L32",
       "id": "local_ci_gate_gateerror",
-      "community": 15
+      "community": 16
     },
     {
       "label": "ChangedFiles",
@@ -15433,7 +15673,7 @@
       "source_file": "tools/local-ci-gate/local_ci_gate.py",
       "source_location": "L37",
       "id": "local_ci_gate_changedfiles",
-      "community": 15
+      "community": 16
     },
     {
       "label": "CheckSpec",
@@ -15441,7 +15681,7 @@
       "source_file": "tools/local-ci-gate/local_ci_gate.py",
       "source_location": "L45",
       "id": "local_ci_gate_checkspec",
-      "community": 15
+      "community": 16
     },
     {
       "label": "Profile",
@@ -15449,7 +15689,7 @@
       "source_file": "tools/local-ci-gate/local_ci_gate.py",
       "source_location": "L55",
       "id": "local_ci_gate_profile",
-      "community": 15
+      "community": 16
     },
     {
       "label": "CheckResult",
@@ -15457,7 +15697,7 @@
       "source_file": "tools/local-ci-gate/local_ci_gate.py",
       "source_location": "L67",
       "id": "local_ci_gate_checkresult",
-      "community": 15
+      "community": 16
     },
     {
       "label": "RunReport",
@@ -15465,7 +15705,7 @@
       "source_file": "tools/local-ci-gate/local_ci_gate.py",
       "source_location": "L79",
       "id": "local_ci_gate_runreport",
-      "community": 15
+      "community": 16
     },
     {
       "label": "_load_yaml()",
@@ -15473,7 +15713,7 @@
       "source_file": "tools/local-ci-gate/local_ci_gate.py",
       "source_location": "L97",
       "id": "local_ci_gate_load_yaml",
-      "community": 15
+      "community": 16
     },
     {
       "label": "_normalize_path()",
@@ -15481,7 +15721,7 @@
       "source_file": "tools/local-ci-gate/local_ci_gate.py",
       "source_location": "L108",
       "id": "local_ci_gate_normalize_path",
-      "community": 15
+      "community": 16
     },
     {
       "label": "_git()",
@@ -15489,7 +15729,7 @@
       "source_file": "tools/local-ci-gate/local_ci_gate.py",
       "source_location": "L114",
       "id": "local_ci_gate_git",
-      "community": 15
+      "community": 16
     },
     {
       "label": "_repo_root()",
@@ -15497,7 +15737,7 @@
       "source_file": "tools/local-ci-gate/local_ci_gate.py",
       "source_location": "L118",
       "id": "local_ci_gate_repo_root",
-      "community": 15
+      "community": 16
     },
     {
       "label": "_current_branch()",
@@ -15505,7 +15745,7 @@
       "source_file": "tools/local-ci-gate/local_ci_gate.py",
       "source_location": "L125",
       "id": "local_ci_gate_current_branch",
-      "community": 15
+      "community": 16
     },
     {
       "label": "_changed_files_from_git()",
@@ -15513,7 +15753,7 @@
       "source_file": "tools/local-ci-gate/local_ci_gate.py",
       "source_location": "L132",
       "id": "local_ci_gate_changed_files_from_git",
-      "community": 15
+      "community": 16
     },
     {
       "label": "_read_changed_files_file()",
@@ -15521,7 +15761,7 @@
       "source_file": "tools/local-ci-gate/local_ci_gate.py",
       "source_location": "L165",
       "id": "local_ci_gate_read_changed_files_file",
-      "community": 15
+      "community": 16
     },
     {
       "label": "resolve_changed_files()",
@@ -15529,7 +15769,7 @@
       "source_file": "tools/local-ci-gate/local_ci_gate.py",
       "source_location": "L174",
       "id": "local_ci_gate_resolve_changed_files",
-      "community": 15
+      "community": 16
     },
     {
       "label": "_is_glob()",
@@ -15537,7 +15777,7 @@
       "source_file": "tools/local-ci-gate/local_ci_gate.py",
       "source_location": "L208",
       "id": "local_ci_gate_is_glob",
-      "community": 15
+      "community": 16
     },
     {
       "label": "_path_matches()",
@@ -15545,7 +15785,7 @@
       "source_file": "tools/local-ci-gate/local_ci_gate.py",
       "source_location": "L212",
       "id": "local_ci_gate_path_matches",
-      "community": 15
+      "community": 16
     },
     {
       "label": "_check_matches_changed_files()",
@@ -15553,7 +15793,7 @@
       "source_file": "tools/local-ci-gate/local_ci_gate.py",
       "source_location": "L226",
       "id": "local_ci_gate_check_matches_changed_files",
-      "community": 15
+      "community": 16
     },
     {
       "label": "_load_checks()",
@@ -15561,7 +15801,7 @@
       "source_file": "tools/local-ci-gate/local_ci_gate.py",
       "source_location": "L236",
       "id": "local_ci_gate_load_checks",
-      "community": 15
+      "community": 16
     },
     {
       "label": "_load_requires_dependencies()",
@@ -15569,7 +15809,7 @@
       "source_file": "tools/local-ci-gate/local_ci_gate.py",
       "source_location": "L281",
       "id": "local_ci_gate_load_requires_dependencies",
-      "community": 15
+      "community": 16
     },
     {
       "label": "load_profile()",
@@ -15577,7 +15817,7 @@
       "source_file": "tools/local-ci-gate/local_ci_gate.py",
       "source_location": "L290",
       "id": "local_ci_gate_load_profile",
-      "community": 15
+      "community": 16
     },
     {
       "label": "_format_command()",
@@ -15585,7 +15825,7 @@
       "source_file": "tools/local-ci-gate/local_ci_gate.py",
       "source_location": "L336",
       "id": "local_ci_gate_format_command",
-      "community": 15
+      "community": 16
     },
     {
       "label": "_branch_issue_number()",
@@ -15593,7 +15833,7 @@
       "source_file": "tools/local-ci-gate/local_ci_gate.py",
       "source_location": "L340",
       "id": "local_ci_gate_branch_issue_number",
-      "community": 15
+      "community": 16
     },
     {
       "label": "_scope_lane_claim_issue()",
@@ -15601,7 +15841,7 @@
       "source_file": "tools/local-ci-gate/local_ci_gate.py",
       "source_location": "L345",
       "id": "local_ci_gate_scope_lane_claim_issue",
-      "community": 15
+      "community": 16
     },
     {
       "label": "_resolve_execution_scope()",
@@ -15609,7 +15849,7 @@
       "source_file": "tools/local-ci-gate/local_ci_gate.py",
       "source_location": "L361",
       "id": "local_ci_gate_resolve_execution_scope",
-      "community": 15
+      "community": 16
     },
     {
       "label": "_command_context()",
@@ -15617,7 +15857,7 @@
       "source_file": "tools/local-ci-gate/local_ci_gate.py",
       "source_location": "L386",
       "id": "local_ci_gate_command_context",
-      "community": 15
+      "community": 16
     },
     {
       "label": "_exec_command()",
@@ -15625,7 +15865,7 @@
       "source_file": "tools/local-ci-gate/local_ci_gate.py",
       "source_location": "L409",
       "id": "local_ci_gate_exec_command",
-      "community": 15
+      "community": 16
     },
     {
       "label": "run_checks()",
@@ -15633,7 +15873,7 @@
       "source_file": "tools/local-ci-gate/local_ci_gate.py",
       "source_location": "L413",
       "id": "local_ci_gate_run_checks",
-      "community": 15
+      "community": 16
     },
     {
       "label": "_summarize_verdict()",
@@ -15641,7 +15881,7 @@
       "source_file": "tools/local-ci-gate/local_ci_gate.py",
       "source_location": "L500",
       "id": "local_ci_gate_summarize_verdict",
-      "community": 15
+      "community": 16
     },
     {
       "label": "_build_summary()",
@@ -15649,7 +15889,7 @@
       "source_file": "tools/local-ci-gate/local_ci_gate.py",
       "source_location": "L516",
       "id": "local_ci_gate_build_summary",
-      "community": 15
+      "community": 16
     },
     {
       "label": "_report_path()",
@@ -15657,7 +15897,7 @@
       "source_file": "tools/local-ci-gate/local_ci_gate.py",
       "source_location": "L531",
       "id": "local_ci_gate_report_path",
-      "community": 15
+      "community": 16
     },
     {
       "label": "_write_report()",
@@ -15665,7 +15905,7 @@
       "source_file": "tools/local-ci-gate/local_ci_gate.py",
       "source_location": "L536",
       "id": "local_ci_gate_write_report",
-      "community": 15
+      "community": 16
     },
     {
       "label": "render_report()",
@@ -15673,7 +15913,7 @@
       "source_file": "tools/local-ci-gate/local_ci_gate.py",
       "source_location": "L600",
       "id": "local_ci_gate_render_report",
-      "community": 15
+      "community": 16
     },
     {
       "label": "_default_report_dir()",
@@ -15681,7 +15921,7 @@
       "source_file": "tools/local-ci-gate/local_ci_gate.py",
       "source_location": "L634",
       "id": "local_ci_gate_default_report_dir",
-      "community": 15
+      "community": 16
     },
     {
       "label": "_print_report()",
@@ -15689,7 +15929,7 @@
       "source_file": "tools/local-ci-gate/local_ci_gate.py",
       "source_location": "L641",
       "id": "local_ci_gate_print_report",
-      "community": 15
+      "community": 16
     },
     {
       "label": "_check_exit_code()",
@@ -15697,7 +15937,7 @@
       "source_file": "tools/local-ci-gate/local_ci_gate.py",
       "source_location": "L645",
       "id": "local_ci_gate_check_exit_code",
-      "community": 15
+      "community": 16
     },
     {
       "label": "_resolve_profile_path()",
@@ -15705,7 +15945,7 @@
       "source_file": "tools/local-ci-gate/local_ci_gate.py",
       "source_location": "L651",
       "id": "local_ci_gate_resolve_profile_path",
-      "community": 15
+      "community": 16
     },
     {
       "label": "build_argument_parser()",
@@ -15713,7 +15953,7 @@
       "source_file": "tools/local-ci-gate/local_ci_gate.py",
       "source_location": "L659",
       "id": "local_ci_gate_build_argument_parser",
-      "community": 15
+      "community": 16
     },
     {
       "label": "main()",
@@ -15721,12 +15961,12 @@
       "source_file": "tools/local-ci-gate/local_ci_gate.py",
       "source_location": "L680",
       "id": "local_ci_gate_main",
-      "community": 15
+      "community": 16
     },
     {
       "label": "test_local_ci_gate.py",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/tools/local-ci-gate/tests/test_local_ci_gate.py",
+      "source_file": "tools/local-ci-gate/tests/test_local_ci_gate.py",
       "source_location": "L1",
       "id": "test_local_ci_gate",
       "community": 31
@@ -15734,7 +15974,7 @@
     {
       "label": "TestLocalCiGate",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/tools/local-ci-gate/tests/test_local_ci_gate.py",
+      "source_file": "tools/local-ci-gate/tests/test_local_ci_gate.py",
       "source_location": "L19",
       "id": "test_local_ci_gate_testlocalcigate",
       "community": 31
@@ -15742,7 +15982,7 @@
     {
       "label": ".setUp()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/tools/local-ci-gate/tests/test_local_ci_gate.py",
+      "source_file": "tools/local-ci-gate/tests/test_local_ci_gate.py",
       "source_location": "L20",
       "id": "test_local_ci_gate_testlocalcigate_setup",
       "community": 31
@@ -15750,7 +15990,7 @@
     {
       "label": ".tearDown()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/tools/local-ci-gate/tests/test_local_ci_gate.py",
+      "source_file": "tools/local-ci-gate/tests/test_local_ci_gate.py",
       "source_location": "L68",
       "id": "test_local_ci_gate_testlocalcigate_teardown",
       "community": 31
@@ -15758,7 +15998,7 @@
     {
       "label": ".test_resolves_changed_files_from_git_and_writes_report()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/tools/local-ci-gate/tests/test_local_ci_gate.py",
+      "source_file": "tools/local-ci-gate/tests/test_local_ci_gate.py",
       "source_location": "L71",
       "id": "test_local_ci_gate_testlocalcigate_test_resolves_changed_files_from_git_and_writes_report",
       "community": 31
@@ -15766,7 +16006,7 @@
     {
       "label": ".test_base_ref_changed_files_include_unstaged_tracked_edits()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/tools/local-ci-gate/tests/test_local_ci_gate.py",
+      "source_file": "tools/local-ci-gate/tests/test_local_ci_gate.py",
       "source_location": "L89",
       "id": "test_local_ci_gate_testlocalcigate_test_base_ref_changed_files_include_unstaged_tracked_edits",
       "community": 31
@@ -15774,7 +16014,7 @@
     {
       "label": ".test_blocker_and_advisory_statuses_are_distinct()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/tools/local-ci-gate/tests/test_local_ci_gate.py",
+      "source_file": "tools/local-ci-gate/tests/test_local_ci_gate.py",
       "source_location": "L96",
       "id": "test_local_ci_gate_testlocalcigate_test_blocker_and_advisory_statuses_are_distinct",
       "community": 31
@@ -15782,7 +16022,7 @@
     {
       "label": ".test_noop_profile_supports_dry_run_without_side_effects()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/tools/local-ci-gate/tests/test_local_ci_gate.py",
+      "source_file": "tools/local-ci-gate/tests/test_local_ci_gate.py",
       "source_location": "L113",
       "id": "test_local_ci_gate_testlocalcigate_test_noop_profile_supports_dry_run_without_side_effects",
       "community": 31
@@ -15790,7 +16030,7 @@
     {
       "label": ".test_cli_prints_authoritative_note()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/tools/local-ci-gate/tests/test_local_ci_gate.py",
+      "source_file": "tools/local-ci-gate/tests/test_local_ci_gate.py",
       "source_location": "L134",
       "id": "test_local_ci_gate_testlocalcigate_test_cli_prints_authoritative_note",
       "community": 31
@@ -15798,7 +16038,7 @@
     {
       "label": ".test_cli_accepts_managed_shim_run_invocation()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/tools/local-ci-gate/tests/test_local_ci_gate.py",
+      "source_file": "tools/local-ci-gate/tests/test_local_ci_gate.py",
       "source_location": "L156",
       "id": "test_local_ci_gate_testlocalcigate_test_cli_accepts_managed_shim_run_invocation",
       "community": 31
@@ -15806,7 +16046,7 @@
     {
       "label": ".test_report_json_is_machine_readable()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/tools/local-ci-gate/tests/test_local_ci_gate.py",
+      "source_file": "tools/local-ci-gate/tests/test_local_ci_gate.py",
       "source_location": "L203",
       "id": "test_local_ci_gate_testlocalcigate_test_report_json_is_machine_readable",
       "community": 31
@@ -15814,7 +16054,7 @@
     {
       "label": ".test_profile_rejects_duplicate_check_ids()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/tools/local-ci-gate/tests/test_local_ci_gate.py",
+      "source_file": "tools/local-ci-gate/tests/test_local_ci_gate.py",
       "source_location": "L238",
       "id": "test_local_ci_gate_testlocalcigate_test_profile_rejects_duplicate_check_ids",
       "community": 31
@@ -15822,7 +16062,7 @@
     {
       "label": ".test_profile_rejects_malformed_dependency_metadata()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/tools/local-ci-gate/tests/test_local_ci_gate.py",
+      "source_file": "tools/local-ci-gate/tests/test_local_ci_gate.py",
       "source_location": "L268",
       "id": "test_local_ci_gate_testlocalcigate_test_profile_rejects_malformed_dependency_metadata",
       "community": 31
@@ -15830,7 +16070,7 @@
     {
       "label": ".test_changed_files_file_accepts_null_separated_entries()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/tools/local-ci-gate/tests/test_local_ci_gate.py",
+      "source_file": "tools/local-ci-gate/tests/test_local_ci_gate.py",
       "source_location": "L287",
       "id": "test_local_ci_gate_testlocalcigate_test_changed_files_file_accepts_null_separated_entries",
       "community": 31
@@ -15838,7 +16078,7 @@
     {
       "label": ".test_bundled_profiles_load()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/tools/local-ci-gate/tests/test_local_ci_gate.py",
+      "source_file": "tools/local-ci-gate/tests/test_local_ci_gate.py",
       "source_location": "L296",
       "id": "test_local_ci_gate_testlocalcigate_test_bundled_profiles_load",
       "community": 31
@@ -15846,7 +16086,7 @@
     {
       "label": ".test_governance_profile_uses_active_execution_scope_placeholder()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/tools/local-ci-gate/tests/test_local_ci_gate.py",
+      "source_file": "tools/local-ci-gate/tests/test_local_ci_gate.py",
       "source_location": "L313",
       "id": "test_local_ci_gate_testlocalcigate_test_governance_profile_uses_active_execution_scope_placeholder",
       "community": 31
@@ -15854,7 +16094,7 @@
     {
       "label": ".test_governance_profile_runs_handoff_validator_for_handoff_paths()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/tools/local-ci-gate/tests/test_local_ci_gate.py",
+      "source_file": "tools/local-ci-gate/tests/test_local_ci_gate.py",
       "source_location": "L320",
       "id": "test_local_ci_gate_testlocalcigate_test_governance_profile_runs_handoff_validator_for_handoff_paths",
       "community": 31
@@ -15862,7 +16102,7 @@
     {
       "label": ".test_governance_profile_runs_handoff_validator_for_unrelated_paths()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/tools/local-ci-gate/tests/test_local_ci_gate.py",
+      "source_file": "tools/local-ci-gate/tests/test_local_ci_gate.py",
       "source_location": "L336",
       "id": "test_local_ci_gate_testlocalcigate_test_governance_profile_runs_handoff_validator_for_unrelated_paths",
       "community": 31
@@ -15870,7 +16110,7 @@
     {
       "label": ".test_governance_profile_runs_provisioning_evidence_validator_for_runbooks()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/tools/local-ci-gate/tests/test_local_ci_gate.py",
+      "source_file": "tools/local-ci-gate/tests/test_local_ci_gate.py",
       "source_location": "L349",
       "id": "test_local_ci_gate_testlocalcigate_test_governance_profile_runs_provisioning_evidence_validator_for_runbooks",
       "community": 31
@@ -15878,7 +16118,7 @@
     {
       "label": ".test_governance_profile_skips_provisioning_evidence_validator_for_unrelated_paths()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/tools/local-ci-gate/tests/test_local_ci_gate.py",
+      "source_file": "tools/local-ci-gate/tests/test_local_ci_gate.py",
       "source_location": "L364",
       "id": "test_local_ci_gate_testlocalcigate_test_governance_profile_skips_provisioning_evidence_validator_for_unrelated_paths",
       "community": 31
@@ -15886,7 +16126,7 @@
     {
       "label": ".test_governance_profile_runs_sql_schema_drift_probe_contract_for_contract_surfaces()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/tools/local-ci-gate/tests/test_local_ci_gate.py",
+      "source_file": "tools/local-ci-gate/tests/test_local_ci_gate.py",
       "source_location": "L377",
       "id": "test_local_ci_gate_testlocalcigate_test_governance_profile_runs_sql_schema_drift_probe_contract_for_contract_surfaces",
       "community": 31
@@ -15894,7 +16134,7 @@
     {
       "label": ".test_execution_scope_resolution_prefers_active_issue_implementation_scope()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/tools/local-ci-gate/tests/test_local_ci_gate.py",
+      "source_file": "tools/local-ci-gate/tests/test_local_ci_gate.py",
       "source_location": "L391",
       "id": "test_local_ci_gate_testlocalcigate_test_execution_scope_resolution_prefers_active_issue_implementation_scope",
       "community": 31
@@ -15902,7 +16142,7 @@
     {
       "label": ".test_execution_scope_resolution_requires_matching_lane_claim()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/tools/local-ci-gate/tests/test_local_ci_gate.py",
+      "source_file": "tools/local-ci-gate/tests/test_local_ci_gate.py",
       "source_location": "L403",
       "id": "test_local_ci_gate_testlocalcigate_test_execution_scope_resolution_requires_matching_lane_claim",
       "community": 31
@@ -15910,7 +16150,7 @@
     {
       "label": ".test_knocktracker_profile_scopes_heavy_checks_to_matching_files()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/tools/local-ci-gate/tests/test_local_ci_gate.py",
+      "source_file": "tools/local-ci-gate/tests/test_local_ci_gate.py",
       "source_location": "L414",
       "id": "test_local_ci_gate_testlocalcigate_test_knocktracker_profile_scopes_heavy_checks_to_matching_files",
       "community": 31
@@ -15918,7 +16158,7 @@
     {
       "label": ".test_ai_integration_services_profile_scopes_app_builds()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/tools/local-ci-gate/tests/test_local_ci_gate.py",
+      "source_file": "tools/local-ci-gate/tests/test_local_ci_gate.py",
       "source_location": "L436",
       "id": "test_local_ci_gate_testlocalcigate_test_ai_integration_services_profile_scopes_app_builds",
       "community": 31
@@ -15926,7 +16166,7 @@
     {
       "label": ".test_local_ai_machine_profile_scopes_contract_checks()",
       "file_type": "code",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/tools/local-ci-gate/tests/test_local_ci_gate.py",
+      "source_file": "tools/local-ci-gate/tests/test_local_ci_gate.py",
       "source_location": "L457",
       "id": "test_local_ci_gate_testlocalcigate_test_local_ai_machine_profile_scopes_contract_checks",
       "community": 31
@@ -17665,7 +17905,7 @@
       "relation": "inherits",
       "confidence": "EXTRACTED",
       "source_file": "scripts/overlord/deploy_governance_tooling.py",
-      "source_location": "L22",
+      "source_location": "L23",
       "weight": 1.0,
       "_src": "deploy_governance_tooling_governancedeployerror",
       "_tgt": "runtimeerror",
@@ -17688,7 +17928,7 @@
     {
       "relation": "inherits",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/verify_governance_consumer.py",
+      "source_file": "scripts/overlord/verify_governance_consumer.py",
       "source_location": "L76",
       "weight": 1.0,
       "_src": "verify_governance_consumer_consumerverifyerror",
@@ -27733,7 +27973,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/overlord/check_stage6_closeout.py",
-      "source_location": "L50",
+      "source_location": "L53",
       "weight": 1.0,
       "_src": "check_stage6_closeout",
       "_tgt": "check_stage6_closeout_closeoutdecision",
@@ -27745,7 +27985,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/overlord/check_stage6_closeout.py",
-      "source_location": "L58",
+      "source_location": "L61",
       "weight": 1.0,
       "_src": "check_stage6_closeout",
       "_tgt": "check_stage6_closeout_normalize",
@@ -27757,7 +27997,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/overlord/check_stage6_closeout.py",
-      "source_location": "L64",
+      "source_location": "L67",
       "weight": 1.0,
       "_src": "check_stage6_closeout",
       "_tgt": "check_stage6_closeout_read_changed_files",
@@ -27769,7 +28009,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/overlord/check_stage6_closeout.py",
-      "source_location": "L68",
+      "source_location": "L71",
       "weight": 1.0,
       "_src": "check_stage6_closeout",
       "_tgt": "check_stage6_closeout_issue_number",
@@ -27781,7 +28021,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/overlord/check_stage6_closeout.py",
-      "source_location": "L73",
+      "source_location": "L76",
       "weight": 1.0,
       "_src": "check_stage6_closeout",
       "_tgt": "check_stage6_closeout_is_governance_surface",
@@ -27793,7 +28033,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/overlord/check_stage6_closeout.py",
-      "source_location": "L77",
+      "source_location": "L80",
       "weight": 1.0,
       "_src": "check_stage6_closeout",
       "_tgt": "check_stage6_closeout_is_planning_only",
@@ -27805,7 +28045,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/overlord/check_stage6_closeout.py",
-      "source_location": "L81",
+      "source_location": "L84",
       "weight": 1.0,
       "_src": "check_stage6_closeout",
       "_tgt": "check_stage6_closeout_matching_closeouts",
@@ -27817,7 +28057,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/overlord/check_stage6_closeout.py",
-      "source_location": "L90",
+      "source_location": "L93",
       "weight": 1.0,
       "_src": "check_stage6_closeout",
       "_tgt": "check_stage6_closeout_evaluate",
@@ -27829,7 +28069,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/overlord/check_stage6_closeout.py",
-      "source_location": "L136",
+      "source_location": "L139",
       "weight": 1.0,
       "_src": "check_stage6_closeout",
       "_tgt": "check_stage6_closeout_build_parser",
@@ -27841,7 +28081,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/overlord/check_stage6_closeout.py",
-      "source_location": "L144",
+      "source_location": "L147",
       "weight": 1.0,
       "_src": "check_stage6_closeout",
       "_tgt": "check_stage6_closeout_main",
@@ -27850,22 +28090,10 @@
       "confidence_score": 1.0
     },
     {
-      "relation": "imports",
-      "confidence": "EXTRACTED",
-      "source_file": "scripts/overlord/test_check_stage6_closeout.py",
-      "source_location": "L8",
-      "weight": 1.0,
-      "_src": "test_check_stage6_closeout",
-      "_tgt": "check_stage6_closeout",
-      "source": "check_stage6_closeout",
-      "target": "test_check_stage6_closeout",
-      "confidence_score": 1.0
-    },
-    {
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/overlord/check_stage6_closeout.py",
-      "source_location": "L93",
+      "source_location": "L96",
       "weight": 0.8,
       "_src": "check_stage6_closeout_evaluate",
       "_tgt": "check_stage6_closeout_closeoutdecision",
@@ -27877,7 +28105,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/overlord/check_stage6_closeout.py",
-      "source_location": "L65",
+      "source_location": "L68",
       "weight": 0.8,
       "_src": "check_stage6_closeout_read_changed_files",
       "_tgt": "check_stage6_closeout_normalize",
@@ -27889,7 +28117,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/overlord/check_stage6_closeout.py",
-      "source_location": "L147",
+      "source_location": "L150",
       "weight": 0.8,
       "_src": "check_stage6_closeout_main",
       "_tgt": "check_stage6_closeout_read_changed_files",
@@ -27901,7 +28129,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/overlord/check_stage6_closeout.py",
-      "source_location": "L96",
+      "source_location": "L99",
       "weight": 0.8,
       "_src": "check_stage6_closeout_evaluate",
       "_tgt": "check_stage6_closeout_issue_number",
@@ -27913,7 +28141,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/overlord/check_stage6_closeout.py",
-      "source_location": "L91",
+      "source_location": "L94",
       "weight": 0.8,
       "_src": "check_stage6_closeout_evaluate",
       "_tgt": "check_stage6_closeout_is_governance_surface",
@@ -27925,7 +28153,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/overlord/check_stage6_closeout.py",
-      "source_location": "L95",
+      "source_location": "L98",
       "weight": 0.8,
       "_src": "check_stage6_closeout_evaluate",
       "_tgt": "check_stage6_closeout_is_planning_only",
@@ -27937,7 +28165,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/overlord/check_stage6_closeout.py",
-      "source_location": "L108",
+      "source_location": "L111",
       "weight": 0.8,
       "_src": "check_stage6_closeout_evaluate",
       "_tgt": "check_stage6_closeout_matching_closeouts",
@@ -27949,7 +28177,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/overlord/check_stage6_closeout.py",
-      "source_location": "L148",
+      "source_location": "L151",
       "weight": 0.8,
       "_src": "check_stage6_closeout_main",
       "_tgt": "check_stage6_closeout_evaluate",
@@ -27961,7 +28189,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/overlord/check_stage6_closeout.py",
-      "source_location": "L145",
+      "source_location": "L148",
       "weight": 0.8,
       "_src": "check_stage6_closeout_main",
       "_tgt": "check_stage6_closeout_build_parser",
@@ -29305,7 +29533,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/overlord/deploy_governance_tooling.py",
-      "source_location": "L22",
+      "source_location": "L23",
       "weight": 1.0,
       "_src": "deploy_governance_tooling",
       "_tgt": "deploy_governance_tooling_governancedeployerror",
@@ -29317,7 +29545,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/overlord/deploy_governance_tooling.py",
-      "source_location": "L27",
+      "source_location": "L28",
       "weight": 1.0,
       "_src": "deploy_governance_tooling",
       "_tgt": "deploy_governance_tooling_toolingplan",
@@ -29329,7 +29557,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/overlord/deploy_governance_tooling.py",
-      "source_location": "L79",
+      "source_location": "L78",
       "weight": 1.0,
       "_src": "deploy_governance_tooling",
       "_tgt": "deploy_governance_tooling_fail",
@@ -29341,7 +29569,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/overlord/deploy_governance_tooling.py",
-      "source_location": "L83",
+      "source_location": "L82",
       "weight": 1.0,
       "_src": "deploy_governance_tooling",
       "_tgt": "deploy_governance_tooling_run_git",
@@ -29353,7 +29581,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/overlord/deploy_governance_tooling.py",
-      "source_location": "L87",
+      "source_location": "L86",
       "weight": 1.0,
       "_src": "deploy_governance_tooling",
       "_tgt": "deploy_governance_tooling_git_root",
@@ -29365,7 +29593,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/overlord/deploy_governance_tooling.py",
-      "source_location": "L94",
+      "source_location": "L93",
       "weight": 1.0,
       "_src": "deploy_governance_tooling",
       "_tgt": "deploy_governance_tooling_git_is_dirty",
@@ -29377,7 +29605,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/overlord/deploy_governance_tooling.py",
-      "source_location": "L101",
+      "source_location": "L100",
       "weight": 1.0,
       "_src": "deploy_governance_tooling",
       "_tgt": "deploy_governance_tooling_git_head",
@@ -29389,7 +29617,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/overlord/deploy_governance_tooling.py",
-      "source_location": "L108",
+      "source_location": "L107",
       "weight": 1.0,
       "_src": "deploy_governance_tooling",
       "_tgt": "deploy_governance_tooling_load_manifest",
@@ -29401,7 +29629,19 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/overlord/deploy_governance_tooling.py",
-      "source_location": "L118",
+      "source_location": "L117",
+      "weight": 1.0,
+      "_src": "deploy_governance_tooling",
+      "_tgt": "deploy_governance_tooling_load_json",
+      "source": "deploy_governance_tooling",
+      "target": "deploy_governance_tooling_load_json",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/overlord/deploy_governance_tooling.py",
+      "source_location": "L127",
       "weight": 1.0,
       "_src": "deploy_governance_tooling",
       "_tgt": "deploy_governance_tooling_consumer_record_relpath",
@@ -29413,7 +29653,19 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/overlord/deploy_governance_tooling.py",
-      "source_location": "L127",
+      "source_location": "L136",
+      "weight": 1.0,
+      "_src": "deploy_governance_tooling",
+      "_tgt": "deploy_governance_tooling_profile_desired_state",
+      "source": "deploy_governance_tooling",
+      "target": "deploy_governance_tooling_profile_desired_state",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/overlord/deploy_governance_tooling.py",
+      "source_location": "L144",
       "weight": 1.0,
       "_src": "deploy_governance_tooling",
       "_tgt": "deploy_governance_tooling_package_version",
@@ -29425,7 +29677,31 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/overlord/deploy_governance_tooling.py",
-      "source_location": "L138",
+      "source_location": "L164",
+      "weight": 1.0,
+      "_src": "deploy_governance_tooling",
+      "_tgt": "deploy_governance_tooling_managed_file_contract_entries",
+      "source": "deploy_governance_tooling",
+      "target": "deploy_governance_tooling_managed_file_contract_entries",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/overlord/deploy_governance_tooling.py",
+      "source_location": "L207",
+      "weight": 1.0,
+      "_src": "deploy_governance_tooling",
+      "_tgt": "deploy_governance_tooling_profile_constraints",
+      "source": "deploy_governance_tooling",
+      "target": "deploy_governance_tooling_profile_constraints",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/overlord/deploy_governance_tooling.py",
+      "source_location": "L215",
       "weight": 1.0,
       "_src": "deploy_governance_tooling",
       "_tgt": "deploy_governance_tooling_record_state",
@@ -29437,7 +29713,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/overlord/deploy_governance_tooling.py",
-      "source_location": "L152",
+      "source_location": "L229",
       "weight": 1.0,
       "_src": "deploy_governance_tooling",
       "_tgt": "deploy_governance_tooling_ensure_relative_to",
@@ -29449,7 +29725,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/overlord/deploy_governance_tooling.py",
-      "source_location": "L159",
+      "source_location": "L236",
       "weight": 1.0,
       "_src": "deploy_governance_tooling",
       "_tgt": "deploy_governance_tooling_build_local_ci_plan",
@@ -29461,7 +29737,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/overlord/deploy_governance_tooling.py",
-      "source_location": "L170",
+      "source_location": "L247",
       "weight": 1.0,
       "_src": "deploy_governance_tooling",
       "_tgt": "deploy_governance_tooling_build_plan",
@@ -29473,7 +29749,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/overlord/deploy_governance_tooling.py",
-      "source_location": "L201",
+      "source_location": "L279",
       "weight": 1.0,
       "_src": "deploy_governance_tooling",
       "_tgt": "deploy_governance_tooling_refuse_dirty",
@@ -29485,7 +29761,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/overlord/deploy_governance_tooling.py",
-      "source_location": "L206",
+      "source_location": "L284",
       "weight": 1.0,
       "_src": "deploy_governance_tooling",
       "_tgt": "deploy_governance_tooling_refuse_unmanaged_record",
@@ -29497,7 +29773,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/overlord/deploy_governance_tooling.py",
-      "source_location": "L211",
+      "source_location": "L289",
       "weight": 1.0,
       "_src": "deploy_governance_tooling",
       "_tgt": "deploy_governance_tooling_consumer_record",
@@ -29509,7 +29785,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/overlord/deploy_governance_tooling.py",
-      "source_location": "L238",
+      "source_location": "L322",
       "weight": 1.0,
       "_src": "deploy_governance_tooling",
       "_tgt": "deploy_governance_tooling_apply",
@@ -29521,7 +29797,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/overlord/deploy_governance_tooling.py",
-      "source_location": "L248",
+      "source_location": "L332",
       "weight": 1.0,
       "_src": "deploy_governance_tooling",
       "_tgt": "deploy_governance_tooling_verify",
@@ -29533,7 +29809,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/overlord/deploy_governance_tooling.py",
-      "source_location": "L277",
+      "source_location": "L361",
       "weight": 1.0,
       "_src": "deploy_governance_tooling",
       "_tgt": "deploy_governance_tooling_required_record_fields",
@@ -29545,7 +29821,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/overlord/deploy_governance_tooling.py",
-      "source_location": "L299",
+      "source_location": "L383",
       "weight": 1.0,
       "_src": "deploy_governance_tooling",
       "_tgt": "deploy_governance_tooling_rollback",
@@ -29557,7 +29833,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/overlord/deploy_governance_tooling.py",
-      "source_location": "L327",
+      "source_location": "L411",
       "weight": 1.0,
       "_src": "deploy_governance_tooling",
       "_tgt": "deploy_governance_tooling_print_json",
@@ -29569,7 +29845,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/overlord/deploy_governance_tooling.py",
-      "source_location": "L332",
+      "source_location": "L416",
       "weight": 1.0,
       "_src": "deploy_governance_tooling",
       "_tgt": "deploy_governance_tooling_add_common_args",
@@ -29581,7 +29857,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/overlord/deploy_governance_tooling.py",
-      "source_location": "L342",
+      "source_location": "L426",
       "weight": 1.0,
       "_src": "deploy_governance_tooling",
       "_tgt": "deploy_governance_tooling_main",
@@ -29593,7 +29869,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/overlord/deploy_governance_tooling.py",
-      "source_location": "L80",
+      "source_location": "L79",
       "weight": 0.8,
       "_src": "deploy_governance_tooling_fail",
       "_tgt": "deploy_governance_tooling_governancedeployerror",
@@ -29605,7 +29881,7 @@
       "relation": "method",
       "confidence": "EXTRACTED",
       "source_file": "scripts/overlord/deploy_governance_tooling.py",
-      "source_location": "L40",
+      "source_location": "L41",
       "weight": 1.0,
       "_src": "deploy_governance_tooling_toolingplan",
       "_tgt": "deploy_governance_tooling_toolingplan_managed_files",
@@ -29617,7 +29893,7 @@
       "relation": "method",
       "confidence": "EXTRACTED",
       "source_file": "scripts/overlord/deploy_governance_tooling.py",
-      "source_location": "L54",
+      "source_location": "L53",
       "weight": 1.0,
       "_src": "deploy_governance_tooling_toolingplan",
       "_tgt": "deploy_governance_tooling_toolingplan_planned_write_set",
@@ -29629,7 +29905,7 @@
       "relation": "method",
       "confidence": "EXTRACTED",
       "source_file": "scripts/overlord/deploy_governance_tooling.py",
-      "source_location": "L57",
+      "source_location": "L56",
       "weight": 1.0,
       "_src": "deploy_governance_tooling_toolingplan",
       "_tgt": "deploy_governance_tooling_toolingplan_planned_rollback_set",
@@ -29641,7 +29917,7 @@
       "relation": "method",
       "confidence": "EXTRACTED",
       "source_file": "scripts/overlord/deploy_governance_tooling.py",
-      "source_location": "L60",
+      "source_location": "L59",
       "weight": 1.0,
       "_src": "deploy_governance_tooling_toolingplan",
       "_tgt": "deploy_governance_tooling_toolingplan_to_json",
@@ -29653,7 +29929,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/overlord/deploy_governance_tooling.py",
-      "source_location": "L186",
+      "source_location": "L264",
       "weight": 0.8,
       "_src": "deploy_governance_tooling_build_plan",
       "_tgt": "deploy_governance_tooling_toolingplan",
@@ -29665,7 +29941,31 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/overlord/deploy_governance_tooling.py",
-      "source_location": "L73",
+      "source_location": "L42",
+      "weight": 0.8,
+      "_src": "deploy_governance_tooling_toolingplan_managed_files",
+      "_tgt": "deploy_governance_tooling_load_json",
+      "source": "deploy_governance_tooling_toolingplan_managed_files",
+      "target": "deploy_governance_tooling_load_json",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/overlord/deploy_governance_tooling.py",
+      "source_location": "L43",
+      "weight": 0.8,
+      "_src": "deploy_governance_tooling_toolingplan_managed_files",
+      "_tgt": "deploy_governance_tooling_managed_file_contract_entries",
+      "source": "deploy_governance_tooling_toolingplan_managed_files",
+      "target": "deploy_governance_tooling_managed_file_contract_entries",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/overlord/deploy_governance_tooling.py",
+      "source_location": "L72",
       "weight": 0.8,
       "_src": "deploy_governance_tooling_toolingplan_to_json",
       "_tgt": "deploy_governance_tooling_toolingplan_managed_files",
@@ -29677,7 +29977,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/overlord/deploy_governance_tooling.py",
-      "source_location": "L220",
+      "source_location": "L301",
       "weight": 0.8,
       "_src": "deploy_governance_tooling_consumer_record",
       "_tgt": "deploy_governance_tooling_toolingplan_managed_files",
@@ -29689,7 +29989,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/overlord/deploy_governance_tooling.py",
-      "source_location": "L74",
+      "source_location": "L73",
       "weight": 0.8,
       "_src": "deploy_governance_tooling_toolingplan_to_json",
       "_tgt": "deploy_governance_tooling_toolingplan_planned_write_set",
@@ -29701,7 +30001,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/overlord/deploy_governance_tooling.py",
-      "source_location": "L75",
+      "source_location": "L74",
       "weight": 0.8,
       "_src": "deploy_governance_tooling_toolingplan_to_json",
       "_tgt": "deploy_governance_tooling_toolingplan_planned_rollback_set",
@@ -29713,7 +30013,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/overlord/deploy_governance_tooling.py",
-      "source_location": "L245",
+      "source_location": "L329",
       "weight": 0.8,
       "_src": "deploy_governance_tooling_apply",
       "_tgt": "deploy_governance_tooling_toolingplan_to_json",
@@ -29725,7 +30025,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/overlord/deploy_governance_tooling.py",
-      "source_location": "L273",
+      "source_location": "L357",
       "weight": 0.8,
       "_src": "deploy_governance_tooling_verify",
       "_tgt": "deploy_governance_tooling_toolingplan_to_json",
@@ -29737,7 +30037,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/overlord/deploy_governance_tooling.py",
-      "source_location": "L324",
+      "source_location": "L408",
       "weight": 0.8,
       "_src": "deploy_governance_tooling_rollback",
       "_tgt": "deploy_governance_tooling_toolingplan_to_json",
@@ -29749,7 +30049,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/overlord/deploy_governance_tooling.py",
-      "source_location": "L366",
+      "source_location": "L450",
       "weight": 0.8,
       "_src": "deploy_governance_tooling_main",
       "_tgt": "deploy_governance_tooling_toolingplan_to_json",
@@ -29761,7 +30061,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/overlord/deploy_governance_tooling.py",
-      "source_location": "L90",
+      "source_location": "L89",
       "weight": 0.8,
       "_src": "deploy_governance_tooling_git_root",
       "_tgt": "deploy_governance_tooling_fail",
@@ -29773,7 +30073,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/overlord/deploy_governance_tooling.py",
-      "source_location": "L97",
+      "source_location": "L96",
       "weight": 0.8,
       "_src": "deploy_governance_tooling_git_is_dirty",
       "_tgt": "deploy_governance_tooling_fail",
@@ -29785,7 +30085,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/overlord/deploy_governance_tooling.py",
-      "source_location": "L112",
+      "source_location": "L111",
       "weight": 0.8,
       "_src": "deploy_governance_tooling_load_manifest",
       "_tgt": "deploy_governance_tooling_fail",
@@ -29797,7 +30097,19 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/overlord/deploy_governance_tooling.py",
-      "source_location": "L142",
+      "source_location": "L121",
+      "weight": 0.8,
+      "_src": "deploy_governance_tooling_load_json",
+      "_tgt": "deploy_governance_tooling_fail",
+      "source": "deploy_governance_tooling_fail",
+      "target": "deploy_governance_tooling_load_json",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/overlord/deploy_governance_tooling.py",
+      "source_location": "L219",
       "weight": 0.8,
       "_src": "deploy_governance_tooling_record_state",
       "_tgt": "deploy_governance_tooling_fail",
@@ -29809,7 +30121,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/overlord/deploy_governance_tooling.py",
-      "source_location": "L156",
+      "source_location": "L233",
       "weight": 0.8,
       "_src": "deploy_governance_tooling_ensure_relative_to",
       "_tgt": "deploy_governance_tooling_fail",
@@ -29821,7 +30133,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/overlord/deploy_governance_tooling.py",
-      "source_location": "L173",
+      "source_location": "L250",
       "weight": 0.8,
       "_src": "deploy_governance_tooling_build_plan",
       "_tgt": "deploy_governance_tooling_fail",
@@ -29833,7 +30145,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/overlord/deploy_governance_tooling.py",
-      "source_location": "L203",
+      "source_location": "L281",
       "weight": 0.8,
       "_src": "deploy_governance_tooling_refuse_dirty",
       "_tgt": "deploy_governance_tooling_fail",
@@ -29845,7 +30157,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/overlord/deploy_governance_tooling.py",
-      "source_location": "L208",
+      "source_location": "L286",
       "weight": 0.8,
       "_src": "deploy_governance_tooling_refuse_unmanaged_record",
       "_tgt": "deploy_governance_tooling_fail",
@@ -29857,7 +30169,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/overlord/deploy_governance_tooling.py",
-      "source_location": "L315",
+      "source_location": "L399",
       "weight": 0.8,
       "_src": "deploy_governance_tooling_rollback",
       "_tgt": "deploy_governance_tooling_fail",
@@ -29869,7 +30181,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/overlord/deploy_governance_tooling.py",
-      "source_location": "L88",
+      "source_location": "L87",
       "weight": 0.8,
       "_src": "deploy_governance_tooling_git_root",
       "_tgt": "deploy_governance_tooling_run_git",
@@ -29881,7 +30193,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/overlord/deploy_governance_tooling.py",
-      "source_location": "L95",
+      "source_location": "L94",
       "weight": 0.8,
       "_src": "deploy_governance_tooling_git_is_dirty",
       "_tgt": "deploy_governance_tooling_run_git",
@@ -29893,7 +30205,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/overlord/deploy_governance_tooling.py",
-      "source_location": "L102",
+      "source_location": "L101",
       "weight": 0.8,
       "_src": "deploy_governance_tooling_git_head",
       "_tgt": "deploy_governance_tooling_run_git",
@@ -29905,7 +30217,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/overlord/deploy_governance_tooling.py",
-      "source_location": "L177",
+      "source_location": "L255",
       "weight": 0.8,
       "_src": "deploy_governance_tooling_build_plan",
       "_tgt": "deploy_governance_tooling_git_root",
@@ -29917,7 +30229,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/overlord/deploy_governance_tooling.py",
-      "source_location": "L195",
+      "source_location": "L273",
       "weight": 0.8,
       "_src": "deploy_governance_tooling_build_plan",
       "_tgt": "deploy_governance_tooling_git_is_dirty",
@@ -29929,7 +30241,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/overlord/deploy_governance_tooling.py",
-      "source_location": "L178",
+      "source_location": "L256",
       "weight": 0.8,
       "_src": "deploy_governance_tooling_build_plan",
       "_tgt": "deploy_governance_tooling_git_head",
@@ -29941,7 +30253,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/overlord/deploy_governance_tooling.py",
-      "source_location": "L175",
+      "source_location": "L252",
       "weight": 0.8,
       "_src": "deploy_governance_tooling_build_plan",
       "_tgt": "deploy_governance_tooling_load_manifest",
@@ -29953,7 +30265,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/overlord/deploy_governance_tooling.py",
-      "source_location": "L278",
+      "source_location": "L362",
       "weight": 0.8,
       "_src": "deploy_governance_tooling_required_record_fields",
       "_tgt": "deploy_governance_tooling_load_manifest",
@@ -29965,7 +30277,31 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/overlord/deploy_governance_tooling.py",
-      "source_location": "L183",
+      "source_location": "L253",
+      "weight": 0.8,
+      "_src": "deploy_governance_tooling_build_plan",
+      "_tgt": "deploy_governance_tooling_load_json",
+      "source": "deploy_governance_tooling_load_json",
+      "target": "deploy_governance_tooling_build_plan",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/overlord/deploy_governance_tooling.py",
+      "source_location": "L290",
+      "weight": 0.8,
+      "_src": "deploy_governance_tooling_consumer_record",
+      "_tgt": "deploy_governance_tooling_load_json",
+      "source": "deploy_governance_tooling_load_json",
+      "target": "deploy_governance_tooling_consumer_record",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/overlord/deploy_governance_tooling.py",
+      "source_location": "L261",
       "weight": 0.8,
       "_src": "deploy_governance_tooling_build_plan",
       "_tgt": "deploy_governance_tooling_consumer_record_relpath",
@@ -29977,7 +30313,43 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/overlord/deploy_governance_tooling.py",
-      "source_location": "L179",
+      "source_location": "L152",
+      "weight": 0.8,
+      "_src": "deploy_governance_tooling_package_version",
+      "_tgt": "deploy_governance_tooling_profile_desired_state",
+      "source": "deploy_governance_tooling_profile_desired_state",
+      "target": "deploy_governance_tooling_package_version",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/overlord/deploy_governance_tooling.py",
+      "source_location": "L173",
+      "weight": 0.8,
+      "_src": "deploy_governance_tooling_managed_file_contract_entries",
+      "_tgt": "deploy_governance_tooling_profile_desired_state",
+      "source": "deploy_governance_tooling_profile_desired_state",
+      "target": "deploy_governance_tooling_managed_file_contract_entries",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/overlord/deploy_governance_tooling.py",
+      "source_location": "L208",
+      "weight": 0.8,
+      "_src": "deploy_governance_tooling_profile_constraints",
+      "_tgt": "deploy_governance_tooling_profile_desired_state",
+      "source": "deploy_governance_tooling_profile_desired_state",
+      "target": "deploy_governance_tooling_profile_constraints",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/overlord/deploy_governance_tooling.py",
+      "source_location": "L258",
       "weight": 0.8,
       "_src": "deploy_governance_tooling_build_plan",
       "_tgt": "deploy_governance_tooling_package_version",
@@ -29989,7 +30361,19 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/overlord/deploy_governance_tooling.py",
-      "source_location": "L197",
+      "source_location": "L291",
+      "weight": 0.8,
+      "_src": "deploy_governance_tooling_consumer_record",
+      "_tgt": "deploy_governance_tooling_profile_constraints",
+      "source": "deploy_governance_tooling_profile_constraints",
+      "target": "deploy_governance_tooling_consumer_record",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/overlord/deploy_governance_tooling.py",
+      "source_location": "L275",
       "weight": 0.8,
       "_src": "deploy_governance_tooling_build_plan",
       "_tgt": "deploy_governance_tooling_record_state",
@@ -30001,7 +30385,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/overlord/deploy_governance_tooling.py",
-      "source_location": "L309",
+      "source_location": "L393",
       "weight": 0.8,
       "_src": "deploy_governance_tooling_rollback",
       "_tgt": "deploy_governance_tooling_record_state",
@@ -30013,7 +30397,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/overlord/deploy_governance_tooling.py",
-      "source_location": "L184",
+      "source_location": "L262",
       "weight": 0.8,
       "_src": "deploy_governance_tooling_build_plan",
       "_tgt": "deploy_governance_tooling_ensure_relative_to",
@@ -30025,7 +30409,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/overlord/deploy_governance_tooling.py",
-      "source_location": "L167",
+      "source_location": "L244",
       "weight": 0.8,
       "_src": "deploy_governance_tooling_build_local_ci_plan",
       "_tgt": "deploy_governance_tooling_build_plan",
@@ -30037,7 +30421,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/overlord/deploy_governance_tooling.py",
-      "source_location": "L241",
+      "source_location": "L325",
       "weight": 0.8,
       "_src": "deploy_governance_tooling_apply",
       "_tgt": "deploy_governance_tooling_build_local_ci_plan",
@@ -30049,7 +30433,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/overlord/deploy_governance_tooling.py",
-      "source_location": "L253",
+      "source_location": "L337",
       "weight": 0.8,
       "_src": "deploy_governance_tooling_verify",
       "_tgt": "deploy_governance_tooling_build_local_ci_plan",
@@ -30061,7 +30445,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/overlord/deploy_governance_tooling.py",
-      "source_location": "L364",
+      "source_location": "L448",
       "weight": 0.8,
       "_src": "deploy_governance_tooling_main",
       "_tgt": "deploy_governance_tooling_build_plan",
@@ -30073,7 +30457,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/overlord/deploy_governance_tooling.py",
-      "source_location": "L239",
+      "source_location": "L323",
       "weight": 0.8,
       "_src": "deploy_governance_tooling_apply",
       "_tgt": "deploy_governance_tooling_refuse_dirty",
@@ -30085,7 +30469,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/overlord/deploy_governance_tooling.py",
-      "source_location": "L300",
+      "source_location": "L384",
       "weight": 0.8,
       "_src": "deploy_governance_tooling_rollback",
       "_tgt": "deploy_governance_tooling_refuse_dirty",
@@ -30097,7 +30481,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/overlord/deploy_governance_tooling.py",
-      "source_location": "L240",
+      "source_location": "L324",
       "weight": 0.8,
       "_src": "deploy_governance_tooling_apply",
       "_tgt": "deploy_governance_tooling_refuse_unmanaged_record",
@@ -30109,7 +30493,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/overlord/deploy_governance_tooling.py",
-      "source_location": "L244",
+      "source_location": "L328",
       "weight": 0.8,
       "_src": "deploy_governance_tooling_apply",
       "_tgt": "deploy_governance_tooling_consumer_record",
@@ -30121,7 +30505,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/overlord/deploy_governance_tooling.py",
-      "source_location": "L369",
+      "source_location": "L453",
       "weight": 0.8,
       "_src": "deploy_governance_tooling_main",
       "_tgt": "deploy_governance_tooling_apply",
@@ -30133,7 +30517,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/overlord/deploy_governance_tooling.py",
-      "source_location": "L261",
+      "source_location": "L345",
       "weight": 0.8,
       "_src": "deploy_governance_tooling_verify",
       "_tgt": "deploy_governance_tooling_required_record_fields",
@@ -30145,7 +30529,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/overlord/deploy_governance_tooling.py",
-      "source_location": "L372",
+      "source_location": "L456",
       "weight": 0.8,
       "_src": "deploy_governance_tooling_main",
       "_tgt": "deploy_governance_tooling_verify",
@@ -30157,7 +30541,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/overlord/deploy_governance_tooling.py",
-      "source_location": "L376",
+      "source_location": "L460",
       "weight": 0.8,
       "_src": "deploy_governance_tooling_main",
       "_tgt": "deploy_governance_tooling_rollback",
@@ -30169,7 +30553,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/overlord/deploy_governance_tooling.py",
-      "source_location": "L366",
+      "source_location": "L450",
       "weight": 0.8,
       "_src": "deploy_governance_tooling_main",
       "_tgt": "deploy_governance_tooling_print_json",
@@ -30181,7 +30565,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/overlord/deploy_governance_tooling.py",
-      "source_location": "L347",
+      "source_location": "L431",
       "weight": 0.8,
       "_src": "deploy_governance_tooling_main",
       "_tgt": "deploy_governance_tooling_add_common_args",
@@ -35521,7 +35905,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/overlord/test_check_stage6_closeout.py",
-      "source_location": "L11",
+      "source_location": "L20",
       "weight": 1.0,
       "_src": "test_check_stage6_closeout",
       "_tgt": "test_check_stage6_closeout_write",
@@ -35533,7 +35917,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/overlord/test_check_stage6_closeout.py",
-      "source_location": "L16",
+      "source_location": "L25",
       "weight": 1.0,
       "_src": "test_check_stage6_closeout",
       "_tgt": "test_check_stage6_closeout_json",
@@ -35545,7 +35929,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/overlord/test_check_stage6_closeout.py",
-      "source_location": "L20",
+      "source_location": "L29",
       "weight": 1.0,
       "_src": "test_check_stage6_closeout",
       "_tgt": "test_check_stage6_closeout_testcheckstage6closeout",
@@ -35557,7 +35941,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/overlord/test_check_stage6_closeout.py",
-      "source_location": "L17",
+      "source_location": "L26",
       "weight": 0.8,
       "_src": "test_check_stage6_closeout_json",
       "_tgt": "test_check_stage6_closeout_write",
@@ -35569,7 +35953,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/overlord/test_check_stage6_closeout.py",
-      "source_location": "L26",
+      "source_location": "L38",
       "weight": 0.8,
       "_src": "test_check_stage6_closeout_testcheckstage6closeout_repo",
       "_tgt": "test_check_stage6_closeout_write",
@@ -35581,7 +35965,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/overlord/test_check_stage6_closeout.py",
-      "source_location": "L64",
+      "source_location": "L76",
       "weight": 0.8,
       "_src": "test_check_stage6_closeout_testcheckstage6closeout_closeout",
       "_tgt": "test_check_stage6_closeout_write",
@@ -35593,7 +35977,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/overlord/test_check_stage6_closeout.py",
-      "source_location": "L24",
+      "source_location": "L33",
       "weight": 0.8,
       "_src": "test_check_stage6_closeout_testcheckstage6closeout_repo",
       "_tgt": "test_check_stage6_closeout_json",
@@ -35605,7 +35989,7 @@
       "relation": "method",
       "confidence": "EXTRACTED",
       "source_file": "scripts/overlord/test_check_stage6_closeout.py",
-      "source_location": "L21",
+      "source_location": "L30",
       "weight": 1.0,
       "_src": "test_check_stage6_closeout_testcheckstage6closeout",
       "_tgt": "test_check_stage6_closeout_testcheckstage6closeout_repo",
@@ -35617,7 +36001,7 @@
       "relation": "method",
       "confidence": "EXTRACTED",
       "source_file": "scripts/overlord/test_check_stage6_closeout.py",
-      "source_location": "L63",
+      "source_location": "L75",
       "weight": 1.0,
       "_src": "test_check_stage6_closeout_testcheckstage6closeout",
       "_tgt": "test_check_stage6_closeout_testcheckstage6closeout_closeout",
@@ -35629,7 +36013,7 @@
       "relation": "method",
       "confidence": "EXTRACTED",
       "source_file": "scripts/overlord/test_check_stage6_closeout.py",
-      "source_location": "L102",
+      "source_location": "L114",
       "weight": 1.0,
       "_src": "test_check_stage6_closeout_testcheckstage6closeout",
       "_tgt": "test_check_stage6_closeout_testcheckstage6closeout_test_planning_only_changes_do_not_require_closeout",
@@ -35641,7 +36025,19 @@
       "relation": "method",
       "confidence": "EXTRACTED",
       "source_file": "scripts/overlord/test_check_stage6_closeout.py",
-      "source_location": "L114",
+      "source_location": "L126",
+      "weight": 1.0,
+      "_src": "test_check_stage6_closeout_testcheckstage6closeout",
+      "_tgt": "test_check_stage6_closeout_testcheckstage6closeout_test_planning_evidence_surfaces_remain_planning_only",
+      "source": "test_check_stage6_closeout_testcheckstage6closeout",
+      "target": "test_check_stage6_closeout_testcheckstage6closeout_test_planning_evidence_surfaces_remain_planning_only",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/overlord/test_check_stage6_closeout.py",
+      "source_location": "L143",
       "weight": 1.0,
       "_src": "test_check_stage6_closeout_testcheckstage6closeout",
       "_tgt": "test_check_stage6_closeout_testcheckstage6closeout_test_implementation_changes_without_closeout_fail",
@@ -35653,7 +36049,7 @@
       "relation": "method",
       "confidence": "EXTRACTED",
       "source_file": "scripts/overlord/test_check_stage6_closeout.py",
-      "source_location": "L127",
+      "source_location": "L156",
       "weight": 1.0,
       "_src": "test_check_stage6_closeout_testcheckstage6closeout",
       "_tgt": "test_check_stage6_closeout_testcheckstage6closeout_test_valid_matching_closeout_passes",
@@ -35665,7 +36061,7 @@
       "relation": "method",
       "confidence": "EXTRACTED",
       "source_file": "scripts/overlord/test_check_stage6_closeout.py",
-      "source_location": "L141",
+      "source_location": "L170",
       "weight": 1.0,
       "_src": "test_check_stage6_closeout_testcheckstage6closeout",
       "_tgt": "test_check_stage6_closeout_testcheckstage6closeout_test_invalid_matching_closeout_fails",
@@ -35677,7 +36073,7 @@
       "relation": "method",
       "confidence": "EXTRACTED",
       "source_file": "scripts/overlord/test_check_stage6_closeout.py",
-      "source_location": "L155",
+      "source_location": "L184",
       "weight": 1.0,
       "_src": "test_check_stage6_closeout_testcheckstage6closeout",
       "_tgt": "test_check_stage6_closeout_testcheckstage6closeout_test_multiple_matching_closeouts_fail",
@@ -35689,7 +36085,7 @@
       "relation": "method",
       "confidence": "EXTRACTED",
       "source_file": "scripts/overlord/test_check_stage6_closeout.py",
-      "source_location": "L169",
+      "source_location": "L198",
       "weight": 1.0,
       "_src": "test_check_stage6_closeout_testcheckstage6closeout",
       "_tgt": "test_check_stage6_closeout_testcheckstage6closeout_test_non_issue_branch_with_governance_changes_fails",
@@ -35701,7 +36097,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/overlord/test_check_stage6_closeout.py",
-      "source_location": "L103",
+      "source_location": "L115",
       "weight": 0.8,
       "_src": "test_check_stage6_closeout_testcheckstage6closeout_test_planning_only_changes_do_not_require_closeout",
       "_tgt": "test_check_stage6_closeout_testcheckstage6closeout_repo",
@@ -35713,7 +36109,19 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/overlord/test_check_stage6_closeout.py",
-      "source_location": "L115",
+      "source_location": "L127",
+      "weight": 0.8,
+      "_src": "test_check_stage6_closeout_testcheckstage6closeout_test_planning_evidence_surfaces_remain_planning_only",
+      "_tgt": "test_check_stage6_closeout_testcheckstage6closeout_repo",
+      "source": "test_check_stage6_closeout_testcheckstage6closeout_repo",
+      "target": "test_check_stage6_closeout_testcheckstage6closeout_test_planning_evidence_surfaces_remain_planning_only",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/overlord/test_check_stage6_closeout.py",
+      "source_location": "L144",
       "weight": 0.8,
       "_src": "test_check_stage6_closeout_testcheckstage6closeout_test_implementation_changes_without_closeout_fail",
       "_tgt": "test_check_stage6_closeout_testcheckstage6closeout_repo",
@@ -35725,7 +36133,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/overlord/test_check_stage6_closeout.py",
-      "source_location": "L128",
+      "source_location": "L157",
       "weight": 0.8,
       "_src": "test_check_stage6_closeout_testcheckstage6closeout_test_valid_matching_closeout_passes",
       "_tgt": "test_check_stage6_closeout_testcheckstage6closeout_repo",
@@ -35737,7 +36145,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/overlord/test_check_stage6_closeout.py",
-      "source_location": "L142",
+      "source_location": "L171",
       "weight": 0.8,
       "_src": "test_check_stage6_closeout_testcheckstage6closeout_test_invalid_matching_closeout_fails",
       "_tgt": "test_check_stage6_closeout_testcheckstage6closeout_repo",
@@ -35749,7 +36157,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/overlord/test_check_stage6_closeout.py",
-      "source_location": "L156",
+      "source_location": "L185",
       "weight": 0.8,
       "_src": "test_check_stage6_closeout_testcheckstage6closeout_test_multiple_matching_closeouts_fail",
       "_tgt": "test_check_stage6_closeout_testcheckstage6closeout_repo",
@@ -35761,7 +36169,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/overlord/test_check_stage6_closeout.py",
-      "source_location": "L170",
+      "source_location": "L199",
       "weight": 0.8,
       "_src": "test_check_stage6_closeout_testcheckstage6closeout_test_non_issue_branch_with_governance_changes_fails",
       "_tgt": "test_check_stage6_closeout_testcheckstage6closeout_repo",
@@ -35773,7 +36181,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/overlord/test_check_stage6_closeout.py",
-      "source_location": "L130",
+      "source_location": "L159",
       "weight": 0.8,
       "_src": "test_check_stage6_closeout_testcheckstage6closeout_test_valid_matching_closeout_passes",
       "_tgt": "test_check_stage6_closeout_testcheckstage6closeout_closeout",
@@ -35785,7 +36193,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/overlord/test_check_stage6_closeout.py",
-      "source_location": "L144",
+      "source_location": "L173",
       "weight": 0.8,
       "_src": "test_check_stage6_closeout_testcheckstage6closeout_test_invalid_matching_closeout_fails",
       "_tgt": "test_check_stage6_closeout_testcheckstage6closeout_closeout",
@@ -35797,7 +36205,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/overlord/test_check_stage6_closeout.py",
-      "source_location": "L158",
+      "source_location": "L187",
       "weight": 0.8,
       "_src": "test_check_stage6_closeout_testcheckstage6closeout_test_multiple_matching_closeouts_fail",
       "_tgt": "test_check_stage6_closeout_testcheckstage6closeout_closeout",
@@ -36520,6 +36928,18 @@
       "source_location": "L99",
       "weight": 1.0,
       "_src": "test_deploy_governance_tooling_testdeploygovernancetooling",
+      "_tgt": "test_deploy_governance_tooling_testdeploygovernancetooling_test_apply_consumer_profile_records_required_session_contract_surfaces",
+      "source": "test_deploy_governance_tooling_testdeploygovernancetooling",
+      "target": "test_deploy_governance_tooling_testdeploygovernancetooling_test_apply_consumer_profile_records_required_session_contract_surfaces",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/overlord/test_deploy_governance_tooling.py",
+      "source_location": "L138",
+      "weight": 1.0,
+      "_src": "test_deploy_governance_tooling_testdeploygovernancetooling",
       "_tgt": "test_deploy_governance_tooling_testdeploygovernancetooling_test_verify_passes_after_apply",
       "source": "test_deploy_governance_tooling_testdeploygovernancetooling",
       "target": "test_deploy_governance_tooling_testdeploygovernancetooling_test_verify_passes_after_apply",
@@ -36529,7 +36949,7 @@
       "relation": "method",
       "confidence": "EXTRACTED",
       "source_file": "scripts/overlord/test_deploy_governance_tooling.py",
-      "source_location": "L110",
+      "source_location": "L149",
       "weight": 1.0,
       "_src": "test_deploy_governance_tooling_testdeploygovernancetooling",
       "_tgt": "test_deploy_governance_tooling_testdeploygovernancetooling_test_rollback_removes_managed_files",
@@ -36541,7 +36961,7 @@
       "relation": "method",
       "confidence": "EXTRACTED",
       "source_file": "scripts/overlord/test_deploy_governance_tooling.py",
-      "source_location": "L122",
+      "source_location": "L161",
       "weight": 1.0,
       "_src": "test_deploy_governance_tooling_testdeploygovernancetooling",
       "_tgt": "test_deploy_governance_tooling_testdeploygovernancetooling_test_apply_is_idempotent_for_managed_files",
@@ -36553,7 +36973,7 @@
       "relation": "method",
       "confidence": "EXTRACTED",
       "source_file": "scripts/overlord/test_deploy_governance_tooling.py",
-      "source_location": "L133",
+      "source_location": "L172",
       "weight": 1.0,
       "_src": "test_deploy_governance_tooling_testdeploygovernancetooling",
       "_tgt": "test_deploy_governance_tooling_testdeploygovernancetooling_test_apply_refuses_unmanaged_shim_by_default",
@@ -36565,7 +36985,7 @@
       "relation": "method",
       "confidence": "EXTRACTED",
       "source_file": "scripts/overlord/test_deploy_governance_tooling.py",
-      "source_location": "L144",
+      "source_location": "L183",
       "weight": 1.0,
       "_src": "test_deploy_governance_tooling_testdeploygovernancetooling",
       "_tgt": "test_deploy_governance_tooling_testdeploygovernancetooling_test_apply_refuses_unmanaged_consumer_record_by_default",
@@ -36577,7 +36997,7 @@
       "relation": "method",
       "confidence": "EXTRACTED",
       "source_file": "scripts/overlord/test_deploy_governance_tooling.py",
-      "source_location": "L154",
+      "source_location": "L193",
       "weight": 1.0,
       "_src": "test_deploy_governance_tooling_testdeploygovernancetooling",
       "_tgt": "test_deploy_governance_tooling_testdeploygovernancetooling_test_apply_refuses_dirty_target_by_default",
@@ -36589,7 +37009,7 @@
       "relation": "method",
       "confidence": "EXTRACTED",
       "source_file": "scripts/overlord/test_deploy_governance_tooling.py",
-      "source_location": "L165",
+      "source_location": "L204",
       "weight": 1.0,
       "_src": "test_deploy_governance_tooling_testdeploygovernancetooling",
       "_tgt": "test_deploy_governance_tooling_testdeploygovernancetooling_test_verify_fails_when_record_is_missing",
@@ -36601,7 +37021,7 @@
       "relation": "method",
       "confidence": "EXTRACTED",
       "source_file": "scripts/overlord/test_deploy_governance_tooling.py",
-      "source_location": "L174",
+      "source_location": "L213",
       "weight": 1.0,
       "_src": "test_deploy_governance_tooling_testdeploygovernancetooling",
       "_tgt": "test_deploy_governance_tooling_testdeploygovernancetooling_test_verify_fails_when_managed_shim_body_is_tampered",
@@ -36613,7 +37033,7 @@
       "relation": "method",
       "confidence": "EXTRACTED",
       "source_file": "scripts/overlord/test_deploy_governance_tooling.py",
-      "source_location": "L190",
+      "source_location": "L229",
       "weight": 1.0,
       "_src": "test_deploy_governance_tooling_testdeploygovernancetooling",
       "_tgt": "test_deploy_governance_tooling_testdeploygovernancetooling_test_rollback_refuses_unmanaged_record_before_removing_shim",
@@ -36625,7 +37045,7 @@
       "relation": "method",
       "confidence": "EXTRACTED",
       "source_file": "scripts/overlord/test_deploy_governance_tooling.py",
-      "source_location": "L203",
+      "source_location": "L242",
       "weight": 1.0,
       "_src": "test_deploy_governance_tooling_testdeploygovernancetooling",
       "_tgt": "test_deploy_governance_tooling_testdeploygovernancetooling_test_real_e2e_apply_verify_rollback_against_temp_git_repo",
@@ -36661,7 +37081,19 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/overlord/test_deploy_governance_tooling.py",
-      "source_location": "L100",
+      "source_location": "L109",
+      "weight": 0.8,
+      "_src": "test_deploy_governance_tooling_testdeploygovernancetooling_test_apply_consumer_profile_records_required_session_contract_surfaces",
+      "_tgt": "test_deploy_governance_tooling_testdeploygovernancetooling_invoke",
+      "source": "test_deploy_governance_tooling_testdeploygovernancetooling_invoke",
+      "target": "test_deploy_governance_tooling_testdeploygovernancetooling_test_apply_consumer_profile_records_required_session_contract_surfaces",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/overlord/test_deploy_governance_tooling.py",
+      "source_location": "L139",
       "weight": 0.8,
       "_src": "test_deploy_governance_tooling_testdeploygovernancetooling_test_verify_passes_after_apply",
       "_tgt": "test_deploy_governance_tooling_testdeploygovernancetooling_invoke",
@@ -36673,7 +37105,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/overlord/test_deploy_governance_tooling.py",
-      "source_location": "L111",
+      "source_location": "L150",
       "weight": 0.8,
       "_src": "test_deploy_governance_tooling_testdeploygovernancetooling_test_rollback_removes_managed_files",
       "_tgt": "test_deploy_governance_tooling_testdeploygovernancetooling_invoke",
@@ -36685,7 +37117,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/overlord/test_deploy_governance_tooling.py",
-      "source_location": "L123",
+      "source_location": "L162",
       "weight": 0.8,
       "_src": "test_deploy_governance_tooling_testdeploygovernancetooling_test_apply_is_idempotent_for_managed_files",
       "_tgt": "test_deploy_governance_tooling_testdeploygovernancetooling_invoke",
@@ -36697,7 +37129,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/overlord/test_deploy_governance_tooling.py",
-      "source_location": "L137",
+      "source_location": "L176",
       "weight": 0.8,
       "_src": "test_deploy_governance_tooling_testdeploygovernancetooling_test_apply_refuses_unmanaged_shim_by_default",
       "_tgt": "test_deploy_governance_tooling_testdeploygovernancetooling_invoke",
@@ -36709,7 +37141,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/overlord/test_deploy_governance_tooling.py",
-      "source_location": "L148",
+      "source_location": "L187",
       "weight": 0.8,
       "_src": "test_deploy_governance_tooling_testdeploygovernancetooling_test_apply_refuses_unmanaged_consumer_record_by_default",
       "_tgt": "test_deploy_governance_tooling_testdeploygovernancetooling_invoke",
@@ -36721,7 +37153,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/overlord/test_deploy_governance_tooling.py",
-      "source_location": "L157",
+      "source_location": "L196",
       "weight": 0.8,
       "_src": "test_deploy_governance_tooling_testdeploygovernancetooling_test_apply_refuses_dirty_target_by_default",
       "_tgt": "test_deploy_governance_tooling_testdeploygovernancetooling_invoke",
@@ -36733,7 +37165,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/overlord/test_deploy_governance_tooling.py",
-      "source_location": "L166",
+      "source_location": "L205",
       "weight": 0.8,
       "_src": "test_deploy_governance_tooling_testdeploygovernancetooling_test_verify_fails_when_record_is_missing",
       "_tgt": "test_deploy_governance_tooling_testdeploygovernancetooling_invoke",
@@ -36745,7 +37177,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/overlord/test_deploy_governance_tooling.py",
-      "source_location": "L175",
+      "source_location": "L214",
       "weight": 0.8,
       "_src": "test_deploy_governance_tooling_testdeploygovernancetooling_test_verify_fails_when_managed_shim_body_is_tampered",
       "_tgt": "test_deploy_governance_tooling_testdeploygovernancetooling_invoke",
@@ -36757,7 +37189,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/overlord/test_deploy_governance_tooling.py",
-      "source_location": "L191",
+      "source_location": "L230",
       "weight": 0.8,
       "_src": "test_deploy_governance_tooling_testdeploygovernancetooling_test_rollback_refuses_unmanaged_record_before_removing_shim",
       "_tgt": "test_deploy_governance_tooling_testdeploygovernancetooling_invoke",
@@ -36769,7 +37201,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/overlord/test_deploy_governance_tooling.py",
-      "source_location": "L204",
+      "source_location": "L243",
       "weight": 0.8,
       "_src": "test_deploy_governance_tooling_testdeploygovernancetooling_test_real_e2e_apply_verify_rollback_against_temp_git_repo",
       "_tgt": "test_deploy_governance_tooling_testdeploygovernancetooling_invoke",
@@ -36805,7 +37237,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/overlord/test_deploy_governance_tooling.py",
-      "source_location": "L100",
+      "source_location": "L139",
       "weight": 0.8,
       "_src": "test_deploy_governance_tooling_testdeploygovernancetooling_test_verify_passes_after_apply",
       "_tgt": "test_deploy_governance_tooling_testdeploygovernancetooling_base_args",
@@ -36817,7 +37249,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/overlord/test_deploy_governance_tooling.py",
-      "source_location": "L111",
+      "source_location": "L150",
       "weight": 0.8,
       "_src": "test_deploy_governance_tooling_testdeploygovernancetooling_test_rollback_removes_managed_files",
       "_tgt": "test_deploy_governance_tooling_testdeploygovernancetooling_base_args",
@@ -36829,7 +37261,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/overlord/test_deploy_governance_tooling.py",
-      "source_location": "L123",
+      "source_location": "L162",
       "weight": 0.8,
       "_src": "test_deploy_governance_tooling_testdeploygovernancetooling_test_apply_is_idempotent_for_managed_files",
       "_tgt": "test_deploy_governance_tooling_testdeploygovernancetooling_base_args",
@@ -36841,7 +37273,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/overlord/test_deploy_governance_tooling.py",
-      "source_location": "L137",
+      "source_location": "L176",
       "weight": 0.8,
       "_src": "test_deploy_governance_tooling_testdeploygovernancetooling_test_apply_refuses_unmanaged_shim_by_default",
       "_tgt": "test_deploy_governance_tooling_testdeploygovernancetooling_base_args",
@@ -36853,7 +37285,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/overlord/test_deploy_governance_tooling.py",
-      "source_location": "L148",
+      "source_location": "L187",
       "weight": 0.8,
       "_src": "test_deploy_governance_tooling_testdeploygovernancetooling_test_apply_refuses_unmanaged_consumer_record_by_default",
       "_tgt": "test_deploy_governance_tooling_testdeploygovernancetooling_base_args",
@@ -36865,7 +37297,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/overlord/test_deploy_governance_tooling.py",
-      "source_location": "L157",
+      "source_location": "L196",
       "weight": 0.8,
       "_src": "test_deploy_governance_tooling_testdeploygovernancetooling_test_apply_refuses_dirty_target_by_default",
       "_tgt": "test_deploy_governance_tooling_testdeploygovernancetooling_base_args",
@@ -36877,7 +37309,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/overlord/test_deploy_governance_tooling.py",
-      "source_location": "L166",
+      "source_location": "L205",
       "weight": 0.8,
       "_src": "test_deploy_governance_tooling_testdeploygovernancetooling_test_verify_fails_when_record_is_missing",
       "_tgt": "test_deploy_governance_tooling_testdeploygovernancetooling_base_args",
@@ -36889,7 +37321,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/overlord/test_deploy_governance_tooling.py",
-      "source_location": "L175",
+      "source_location": "L214",
       "weight": 0.8,
       "_src": "test_deploy_governance_tooling_testdeploygovernancetooling_test_verify_fails_when_managed_shim_body_is_tampered",
       "_tgt": "test_deploy_governance_tooling_testdeploygovernancetooling_base_args",
@@ -36901,7 +37333,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/overlord/test_deploy_governance_tooling.py",
-      "source_location": "L191",
+      "source_location": "L230",
       "weight": 0.8,
       "_src": "test_deploy_governance_tooling_testdeploygovernancetooling_test_rollback_refuses_unmanaged_record_before_removing_shim",
       "_tgt": "test_deploy_governance_tooling_testdeploygovernancetooling_base_args",
@@ -36913,7 +37345,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/overlord/test_deploy_governance_tooling.py",
-      "source_location": "L204",
+      "source_location": "L243",
       "weight": 0.8,
       "_src": "test_deploy_governance_tooling_testdeploygovernancetooling_test_real_e2e_apply_verify_rollback_against_temp_git_repo",
       "_tgt": "test_deploy_governance_tooling_testdeploygovernancetooling_base_args",
@@ -36949,7 +37381,19 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/overlord/test_deploy_governance_tooling.py",
-      "source_location": "L120",
+      "source_location": "L123",
+      "weight": 0.8,
+      "_src": "test_deploy_governance_tooling_testdeploygovernancetooling_test_apply_consumer_profile_records_required_session_contract_surfaces",
+      "_tgt": "test_deploy_governance_tooling_testdeploygovernancetooling_record",
+      "source": "test_deploy_governance_tooling_testdeploygovernancetooling_record",
+      "target": "test_deploy_governance_tooling_testdeploygovernancetooling_test_apply_consumer_profile_records_required_session_contract_surfaces",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/overlord/test_deploy_governance_tooling.py",
+      "source_location": "L159",
       "weight": 0.8,
       "_src": "test_deploy_governance_tooling_testdeploygovernancetooling_test_rollback_removes_managed_files",
       "_tgt": "test_deploy_governance_tooling_testdeploygovernancetooling_record",
@@ -36961,7 +37405,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/overlord/test_deploy_governance_tooling.py",
-      "source_location": "L131",
+      "source_location": "L170",
       "weight": 0.8,
       "_src": "test_deploy_governance_tooling_testdeploygovernancetooling_test_apply_is_idempotent_for_managed_files",
       "_tgt": "test_deploy_governance_tooling_testdeploygovernancetooling_record",
@@ -36973,7 +37417,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/overlord/test_deploy_governance_tooling.py",
-      "source_location": "L142",
+      "source_location": "L181",
       "weight": 0.8,
       "_src": "test_deploy_governance_tooling_testdeploygovernancetooling_test_apply_refuses_unmanaged_shim_by_default",
       "_tgt": "test_deploy_governance_tooling_testdeploygovernancetooling_record",
@@ -36985,7 +37429,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/overlord/test_deploy_governance_tooling.py",
-      "source_location": "L145",
+      "source_location": "L184",
       "weight": 0.8,
       "_src": "test_deploy_governance_tooling_testdeploygovernancetooling_test_apply_refuses_unmanaged_consumer_record_by_default",
       "_tgt": "test_deploy_governance_tooling_testdeploygovernancetooling_record",
@@ -36997,7 +37441,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/overlord/test_deploy_governance_tooling.py",
-      "source_location": "L163",
+      "source_location": "L202",
       "weight": 0.8,
       "_src": "test_deploy_governance_tooling_testdeploygovernancetooling_test_apply_refuses_dirty_target_by_default",
       "_tgt": "test_deploy_governance_tooling_testdeploygovernancetooling_record",
@@ -37009,7 +37453,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/overlord/test_deploy_governance_tooling.py",
-      "source_location": "L193",
+      "source_location": "L232",
       "weight": 0.8,
       "_src": "test_deploy_governance_tooling_testdeploygovernancetooling_test_rollback_refuses_unmanaged_record_before_removing_shim",
       "_tgt": "test_deploy_governance_tooling_testdeploygovernancetooling_record",
@@ -37021,7 +37465,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/overlord/test_deploy_governance_tooling.py",
-      "source_location": "L220",
+      "source_location": "L259",
       "weight": 0.8,
       "_src": "test_deploy_governance_tooling_testdeploygovernancetooling_test_real_e2e_apply_verify_rollback_against_temp_git_repo",
       "_tgt": "test_deploy_governance_tooling_testdeploygovernancetooling_record",
@@ -37057,7 +37501,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/overlord/test_deploy_governance_tooling.py",
-      "source_location": "L119",
+      "source_location": "L158",
       "weight": 0.8,
       "_src": "test_deploy_governance_tooling_testdeploygovernancetooling_test_rollback_removes_managed_files",
       "_tgt": "test_deploy_governance_tooling_testdeploygovernancetooling_shim",
@@ -37069,7 +37513,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/overlord/test_deploy_governance_tooling.py",
-      "source_location": "L130",
+      "source_location": "L169",
       "weight": 0.8,
       "_src": "test_deploy_governance_tooling_testdeploygovernancetooling_test_apply_is_idempotent_for_managed_files",
       "_tgt": "test_deploy_governance_tooling_testdeploygovernancetooling_shim",
@@ -37081,7 +37525,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/overlord/test_deploy_governance_tooling.py",
-      "source_location": "L134",
+      "source_location": "L173",
       "weight": 0.8,
       "_src": "test_deploy_governance_tooling_testdeploygovernancetooling_test_apply_refuses_unmanaged_shim_by_default",
       "_tgt": "test_deploy_governance_tooling_testdeploygovernancetooling_shim",
@@ -37093,7 +37537,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/overlord/test_deploy_governance_tooling.py",
-      "source_location": "L162",
+      "source_location": "L201",
       "weight": 0.8,
       "_src": "test_deploy_governance_tooling_testdeploygovernancetooling_test_apply_refuses_dirty_target_by_default",
       "_tgt": "test_deploy_governance_tooling_testdeploygovernancetooling_shim",
@@ -37105,7 +37549,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/overlord/test_deploy_governance_tooling.py",
-      "source_location": "L177",
+      "source_location": "L216",
       "weight": 0.8,
       "_src": "test_deploy_governance_tooling_testdeploygovernancetooling_test_verify_fails_when_managed_shim_body_is_tampered",
       "_tgt": "test_deploy_governance_tooling_testdeploygovernancetooling_shim",
@@ -37117,7 +37561,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/overlord/test_deploy_governance_tooling.py",
-      "source_location": "L200",
+      "source_location": "L239",
       "weight": 0.8,
       "_src": "test_deploy_governance_tooling_testdeploygovernancetooling_test_rollback_refuses_unmanaged_record_before_removing_shim",
       "_tgt": "test_deploy_governance_tooling_testdeploygovernancetooling_shim",
@@ -37129,7 +37573,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/overlord/test_deploy_governance_tooling.py",
-      "source_location": "L219",
+      "source_location": "L258",
       "weight": 0.8,
       "_src": "test_deploy_governance_tooling_testdeploygovernancetooling_test_real_e2e_apply_verify_rollback_against_temp_git_repo",
       "_tgt": "test_deploy_governance_tooling_testdeploygovernancetooling_shim",
@@ -39238,22 +39682,10 @@
       "confidence_score": 1.0
     },
     {
-      "relation": "imports",
-      "confidence": "EXTRACTED",
-      "source_file": "scripts/overlord/test_validate_closeout.py",
-      "source_location": "L8",
-      "weight": 1.0,
-      "_src": "test_validate_closeout",
-      "_tgt": "validate_closeout",
-      "source": "test_validate_closeout",
-      "target": "validate_closeout",
-      "confidence_score": 1.0
-    },
-    {
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/overlord/test_validate_closeout.py",
-      "source_location": "L11",
+      "source_location": "L20",
       "weight": 1.0,
       "_src": "test_validate_closeout",
       "_tgt": "test_validate_closeout_write",
@@ -39265,7 +39697,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/overlord/test_validate_closeout.py",
-      "source_location": "L16",
+      "source_location": "L25",
       "weight": 1.0,
       "_src": "test_validate_closeout",
       "_tgt": "test_validate_closeout_json",
@@ -39277,7 +39709,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/overlord/test_validate_closeout.py",
-      "source_location": "L20",
+      "source_location": "L29",
       "weight": 1.0,
       "_src": "test_validate_closeout",
       "_tgt": "test_validate_closeout_testvalidatecloseout",
@@ -39289,7 +39721,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/overlord/test_validate_closeout.py",
-      "source_location": "L17",
+      "source_location": "L26",
       "weight": 0.8,
       "_src": "test_validate_closeout_json",
       "_tgt": "test_validate_closeout_write",
@@ -39301,7 +39733,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/overlord/test_validate_closeout.py",
-      "source_location": "L32",
+      "source_location": "L41",
       "weight": 0.8,
       "_src": "test_validate_closeout_testvalidatecloseout_repo",
       "_tgt": "test_validate_closeout_write",
@@ -39313,7 +39745,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/overlord/test_validate_closeout.py",
-      "source_location": "L71",
+      "source_location": "L80",
       "weight": 0.8,
       "_src": "test_validate_closeout_testvalidatecloseout_closeout",
       "_tgt": "test_validate_closeout_write",
@@ -39325,7 +39757,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/overlord/test_validate_closeout.py",
-      "source_location": "L24",
+      "source_location": "L33",
       "weight": 0.8,
       "_src": "test_validate_closeout_testvalidatecloseout_repo",
       "_tgt": "test_validate_closeout_json",
@@ -39337,7 +39769,7 @@
       "relation": "method",
       "confidence": "EXTRACTED",
       "source_file": "scripts/overlord/test_validate_closeout.py",
-      "source_location": "L21",
+      "source_location": "L30",
       "weight": 1.0,
       "_src": "test_validate_closeout_testvalidatecloseout",
       "_tgt": "test_validate_closeout_testvalidatecloseout_repo",
@@ -39349,7 +39781,7 @@
       "relation": "method",
       "confidence": "EXTRACTED",
       "source_file": "scripts/overlord/test_validate_closeout.py",
-      "source_location": "L69",
+      "source_location": "L78",
       "weight": 1.0,
       "_src": "test_validate_closeout_testvalidatecloseout",
       "_tgt": "test_validate_closeout_testvalidatecloseout_closeout",
@@ -39361,7 +39793,7 @@
       "relation": "method",
       "confidence": "EXTRACTED",
       "source_file": "scripts/overlord/test_validate_closeout.py",
-      "source_location": "L109",
+      "source_location": "L118",
       "weight": 1.0,
       "_src": "test_validate_closeout_testvalidatecloseout",
       "_tgt": "test_validate_closeout_testvalidatecloseout_test_valid_closeout_passes",
@@ -39373,7 +39805,7 @@
       "relation": "method",
       "confidence": "EXTRACTED",
       "source_file": "scripts/overlord/test_validate_closeout.py",
-      "source_location": "L115",
+      "source_location": "L124",
       "weight": 1.0,
       "_src": "test_validate_closeout_testvalidatecloseout",
       "_tgt": "test_validate_closeout_testvalidatecloseout_test_missing_referenced_artifact_fails",
@@ -39385,7 +39817,7 @@
       "relation": "method",
       "confidence": "EXTRACTED",
       "source_file": "scripts/overlord/test_validate_closeout.py",
-      "source_location": "L122",
+      "source_location": "L131",
       "weight": 1.0,
       "_src": "test_validate_closeout_testvalidatecloseout",
       "_tgt": "test_validate_closeout_testvalidatecloseout_test_residual_without_issue_ref_fails",
@@ -39397,7 +39829,7 @@
       "relation": "method",
       "confidence": "EXTRACTED",
       "source_file": "scripts/overlord/test_validate_closeout.py",
-      "source_location": "L128",
+      "source_location": "L137",
       "weight": 1.0,
       "_src": "test_validate_closeout_testvalidatecloseout",
       "_tgt": "test_validate_closeout_testvalidatecloseout_test_handoff_without_lifecycle_record_fails",
@@ -39409,7 +39841,7 @@
       "relation": "method",
       "confidence": "EXTRACTED",
       "source_file": "scripts/overlord/test_validate_closeout.py",
-      "source_location": "L134",
+      "source_location": "L143",
       "weight": 1.0,
       "_src": "test_validate_closeout_testvalidatecloseout",
       "_tgt": "test_validate_closeout_testvalidatecloseout_test_placeholder_text_in_required_section_fails",
@@ -39421,7 +39853,7 @@
       "relation": "method",
       "confidence": "EXTRACTED",
       "source_file": "scripts/overlord/test_validate_closeout.py",
-      "source_location": "L143",
+      "source_location": "L152",
       "weight": 1.0,
       "_src": "test_validate_closeout_testvalidatecloseout",
       "_tgt": "test_validate_closeout_testvalidatecloseout_test_gate_evidence_requires_artifact_or_command_result",
@@ -39433,7 +39865,31 @@
       "relation": "method",
       "confidence": "EXTRACTED",
       "source_file": "scripts/overlord/test_validate_closeout.py",
-      "source_location": "L152",
+      "source_location": "L161",
+      "weight": 1.0,
+      "_src": "test_validate_closeout_testvalidatecloseout",
+      "_tgt": "test_validate_closeout_testvalidatecloseout_test_resolve_closeout_execution_mode_reads_scope",
+      "source": "test_validate_closeout_testvalidatecloseout",
+      "target": "test_validate_closeout_testvalidatecloseout_test_resolve_closeout_execution_mode_reads_scope",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/overlord/test_validate_closeout.py",
+      "source_location": "L168",
+      "weight": 1.0,
+      "_src": "test_validate_closeout_testvalidatecloseout",
+      "_tgt": "test_validate_closeout_testvalidatecloseout_test_resolve_closeout_execution_mode_defaults_planning_only",
+      "source": "test_validate_closeout_testvalidatecloseout",
+      "target": "test_validate_closeout_testvalidatecloseout_test_resolve_closeout_execution_mode_defaults_planning_only",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/overlord/test_validate_closeout.py",
+      "source_location": "L179",
       "weight": 1.0,
       "_src": "test_validate_closeout_testvalidatecloseout",
       "_tgt": "test_validate_closeout_testvalidatecloseout_test_hook_invokes_validator_before_graph_refresh",
@@ -39445,96 +39901,12 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/overlord/test_validate_closeout.py",
-      "source_location": "L110",
-      "weight": 0.8,
-      "_src": "test_validate_closeout_testvalidatecloseout_test_valid_closeout_passes",
-      "_tgt": "test_validate_closeout_testvalidatecloseout_repo",
-      "source": "test_validate_closeout_testvalidatecloseout_repo",
-      "target": "test_validate_closeout_testvalidatecloseout_test_valid_closeout_passes",
-      "confidence_score": 0.5
-    },
-    {
-      "relation": "calls",
-      "confidence": "INFERRED",
-      "source_file": "scripts/overlord/test_validate_closeout.py",
-      "source_location": "L116",
-      "weight": 0.8,
-      "_src": "test_validate_closeout_testvalidatecloseout_test_missing_referenced_artifact_fails",
-      "_tgt": "test_validate_closeout_testvalidatecloseout_repo",
-      "source": "test_validate_closeout_testvalidatecloseout_repo",
-      "target": "test_validate_closeout_testvalidatecloseout_test_missing_referenced_artifact_fails",
-      "confidence_score": 0.5
-    },
-    {
-      "relation": "calls",
-      "confidence": "INFERRED",
-      "source_file": "scripts/overlord/test_validate_closeout.py",
-      "source_location": "L123",
-      "weight": 0.8,
-      "_src": "test_validate_closeout_testvalidatecloseout_test_residual_without_issue_ref_fails",
-      "_tgt": "test_validate_closeout_testvalidatecloseout_repo",
-      "source": "test_validate_closeout_testvalidatecloseout_repo",
-      "target": "test_validate_closeout_testvalidatecloseout_test_residual_without_issue_ref_fails",
-      "confidence_score": 0.5
-    },
-    {
-      "relation": "calls",
-      "confidence": "INFERRED",
-      "source_file": "scripts/overlord/test_validate_closeout.py",
-      "source_location": "L129",
-      "weight": 0.8,
-      "_src": "test_validate_closeout_testvalidatecloseout_test_handoff_without_lifecycle_record_fails",
-      "_tgt": "test_validate_closeout_testvalidatecloseout_repo",
-      "source": "test_validate_closeout_testvalidatecloseout_repo",
-      "target": "test_validate_closeout_testvalidatecloseout_test_handoff_without_lifecycle_record_fails",
-      "confidence_score": 0.5
-    },
-    {
-      "relation": "calls",
-      "confidence": "INFERRED",
-      "source_file": "scripts/overlord/test_validate_closeout.py",
-      "source_location": "L135",
-      "weight": 0.8,
-      "_src": "test_validate_closeout_testvalidatecloseout_test_placeholder_text_in_required_section_fails",
-      "_tgt": "test_validate_closeout_testvalidatecloseout_repo",
-      "source": "test_validate_closeout_testvalidatecloseout_repo",
-      "target": "test_validate_closeout_testvalidatecloseout_test_placeholder_text_in_required_section_fails",
-      "confidence_score": 0.5
-    },
-    {
-      "relation": "calls",
-      "confidence": "INFERRED",
-      "source_file": "scripts/overlord/test_validate_closeout.py",
-      "source_location": "L144",
-      "weight": 0.8,
-      "_src": "test_validate_closeout_testvalidatecloseout_test_gate_evidence_requires_artifact_or_command_result",
-      "_tgt": "test_validate_closeout_testvalidatecloseout_repo",
-      "source": "test_validate_closeout_testvalidatecloseout_repo",
-      "target": "test_validate_closeout_testvalidatecloseout_test_gate_evidence_requires_artifact_or_command_result",
-      "confidence_score": 0.5
-    },
-    {
-      "relation": "calls",
-      "confidence": "INFERRED",
-      "source_file": "scripts/overlord/test_validate_closeout.py",
-      "source_location": "L112",
-      "weight": 0.8,
-      "_src": "test_validate_closeout_testvalidatecloseout_test_valid_closeout_passes",
-      "_tgt": "test_validate_closeout_testvalidatecloseout_closeout",
-      "source": "test_validate_closeout_testvalidatecloseout_closeout",
-      "target": "test_validate_closeout_testvalidatecloseout_test_valid_closeout_passes",
-      "confidence_score": 0.5
-    },
-    {
-      "relation": "calls",
-      "confidence": "INFERRED",
-      "source_file": "scripts/overlord/test_validate_closeout.py",
       "source_location": "L119",
       "weight": 0.8,
-      "_src": "test_validate_closeout_testvalidatecloseout_test_missing_referenced_artifact_fails",
-      "_tgt": "test_validate_closeout_testvalidatecloseout_closeout",
-      "source": "test_validate_closeout_testvalidatecloseout_closeout",
-      "target": "test_validate_closeout_testvalidatecloseout_test_missing_referenced_artifact_fails",
+      "_src": "test_validate_closeout_testvalidatecloseout_test_valid_closeout_passes",
+      "_tgt": "test_validate_closeout_testvalidatecloseout_repo",
+      "source": "test_validate_closeout_testvalidatecloseout_repo",
+      "target": "test_validate_closeout_testvalidatecloseout_test_valid_closeout_passes",
       "confidence_score": 0.5
     },
     {
@@ -39543,6 +39915,114 @@
       "source_file": "scripts/overlord/test_validate_closeout.py",
       "source_location": "L125",
       "weight": 0.8,
+      "_src": "test_validate_closeout_testvalidatecloseout_test_missing_referenced_artifact_fails",
+      "_tgt": "test_validate_closeout_testvalidatecloseout_repo",
+      "source": "test_validate_closeout_testvalidatecloseout_repo",
+      "target": "test_validate_closeout_testvalidatecloseout_test_missing_referenced_artifact_fails",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/overlord/test_validate_closeout.py",
+      "source_location": "L132",
+      "weight": 0.8,
+      "_src": "test_validate_closeout_testvalidatecloseout_test_residual_without_issue_ref_fails",
+      "_tgt": "test_validate_closeout_testvalidatecloseout_repo",
+      "source": "test_validate_closeout_testvalidatecloseout_repo",
+      "target": "test_validate_closeout_testvalidatecloseout_test_residual_without_issue_ref_fails",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/overlord/test_validate_closeout.py",
+      "source_location": "L138",
+      "weight": 0.8,
+      "_src": "test_validate_closeout_testvalidatecloseout_test_handoff_without_lifecycle_record_fails",
+      "_tgt": "test_validate_closeout_testvalidatecloseout_repo",
+      "source": "test_validate_closeout_testvalidatecloseout_repo",
+      "target": "test_validate_closeout_testvalidatecloseout_test_handoff_without_lifecycle_record_fails",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/overlord/test_validate_closeout.py",
+      "source_location": "L144",
+      "weight": 0.8,
+      "_src": "test_validate_closeout_testvalidatecloseout_test_placeholder_text_in_required_section_fails",
+      "_tgt": "test_validate_closeout_testvalidatecloseout_repo",
+      "source": "test_validate_closeout_testvalidatecloseout_repo",
+      "target": "test_validate_closeout_testvalidatecloseout_test_placeholder_text_in_required_section_fails",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/overlord/test_validate_closeout.py",
+      "source_location": "L153",
+      "weight": 0.8,
+      "_src": "test_validate_closeout_testvalidatecloseout_test_gate_evidence_requires_artifact_or_command_result",
+      "_tgt": "test_validate_closeout_testvalidatecloseout_repo",
+      "source": "test_validate_closeout_testvalidatecloseout_repo",
+      "target": "test_validate_closeout_testvalidatecloseout_test_gate_evidence_requires_artifact_or_command_result",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/overlord/test_validate_closeout.py",
+      "source_location": "L162",
+      "weight": 0.8,
+      "_src": "test_validate_closeout_testvalidatecloseout_test_resolve_closeout_execution_mode_reads_scope",
+      "_tgt": "test_validate_closeout_testvalidatecloseout_repo",
+      "source": "test_validate_closeout_testvalidatecloseout_repo",
+      "target": "test_validate_closeout_testvalidatecloseout_test_resolve_closeout_execution_mode_reads_scope",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/overlord/test_validate_closeout.py",
+      "source_location": "L169",
+      "weight": 0.8,
+      "_src": "test_validate_closeout_testvalidatecloseout_test_resolve_closeout_execution_mode_defaults_planning_only",
+      "_tgt": "test_validate_closeout_testvalidatecloseout_repo",
+      "source": "test_validate_closeout_testvalidatecloseout_repo",
+      "target": "test_validate_closeout_testvalidatecloseout_test_resolve_closeout_execution_mode_defaults_planning_only",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/overlord/test_validate_closeout.py",
+      "source_location": "L121",
+      "weight": 0.8,
+      "_src": "test_validate_closeout_testvalidatecloseout_test_valid_closeout_passes",
+      "_tgt": "test_validate_closeout_testvalidatecloseout_closeout",
+      "source": "test_validate_closeout_testvalidatecloseout_closeout",
+      "target": "test_validate_closeout_testvalidatecloseout_test_valid_closeout_passes",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/overlord/test_validate_closeout.py",
+      "source_location": "L128",
+      "weight": 0.8,
+      "_src": "test_validate_closeout_testvalidatecloseout_test_missing_referenced_artifact_fails",
+      "_tgt": "test_validate_closeout_testvalidatecloseout_closeout",
+      "source": "test_validate_closeout_testvalidatecloseout_closeout",
+      "target": "test_validate_closeout_testvalidatecloseout_test_missing_referenced_artifact_fails",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/overlord/test_validate_closeout.py",
+      "source_location": "L134",
+      "weight": 0.8,
       "_src": "test_validate_closeout_testvalidatecloseout_test_residual_without_issue_ref_fails",
       "_tgt": "test_validate_closeout_testvalidatecloseout_closeout",
       "source": "test_validate_closeout_testvalidatecloseout_closeout",
@@ -39553,7 +40033,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/overlord/test_validate_closeout.py",
-      "source_location": "L131",
+      "source_location": "L140",
       "weight": 0.8,
       "_src": "test_validate_closeout_testvalidatecloseout_test_handoff_without_lifecycle_record_fails",
       "_tgt": "test_validate_closeout_testvalidatecloseout_closeout",
@@ -39565,7 +40045,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/overlord/test_validate_closeout.py",
-      "source_location": "L137",
+      "source_location": "L146",
       "weight": 0.8,
       "_src": "test_validate_closeout_testvalidatecloseout_test_placeholder_text_in_required_section_fails",
       "_tgt": "test_validate_closeout_testvalidatecloseout_closeout",
@@ -39577,12 +40057,36 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/overlord/test_validate_closeout.py",
-      "source_location": "L146",
+      "source_location": "L155",
       "weight": 0.8,
       "_src": "test_validate_closeout_testvalidatecloseout_test_gate_evidence_requires_artifact_or_command_result",
       "_tgt": "test_validate_closeout_testvalidatecloseout_closeout",
       "source": "test_validate_closeout_testvalidatecloseout_closeout",
       "target": "test_validate_closeout_testvalidatecloseout_test_gate_evidence_requires_artifact_or_command_result",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/overlord/test_validate_closeout.py",
+      "source_location": "L164",
+      "weight": 0.8,
+      "_src": "test_validate_closeout_testvalidatecloseout_test_resolve_closeout_execution_mode_reads_scope",
+      "_tgt": "test_validate_closeout_testvalidatecloseout_closeout",
+      "source": "test_validate_closeout_testvalidatecloseout_closeout",
+      "target": "test_validate_closeout_testvalidatecloseout_test_resolve_closeout_execution_mode_reads_scope",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/overlord/test_validate_closeout.py",
+      "source_location": "L175",
+      "weight": 0.8,
+      "_src": "test_validate_closeout_testvalidatecloseout_test_resolve_closeout_execution_mode_defaults_planning_only",
+      "_tgt": "test_validate_closeout_testvalidatecloseout_closeout",
+      "source": "test_validate_closeout_testvalidatecloseout_closeout",
+      "target": "test_validate_closeout_testvalidatecloseout_test_resolve_closeout_execution_mode_defaults_planning_only",
       "confidence_score": 0.5
     },
     {
@@ -39876,7 +40380,7 @@
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_handoff_package.py",
+      "source_file": "scripts/overlord/test_validate_handoff_package.py",
       "source_location": "L24",
       "weight": 1.0,
       "_src": "test_validate_handoff_package",
@@ -39888,7 +40392,7 @@
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_handoff_package.py",
+      "source_file": "scripts/overlord/test_validate_handoff_package.py",
       "source_location": "L75",
       "weight": 1.0,
       "_src": "test_validate_handoff_package",
@@ -39900,7 +40404,7 @@
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_handoff_package.py",
+      "source_file": "scripts/overlord/test_validate_handoff_package.py",
       "source_location": "L100",
       "weight": 1.0,
       "_src": "test_validate_handoff_package",
@@ -39912,7 +40416,7 @@
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_handoff_package.py",
+      "source_file": "scripts/overlord/test_validate_handoff_package.py",
       "source_location": "L109",
       "weight": 1.0,
       "_src": "test_validate_handoff_package",
@@ -39924,7 +40428,7 @@
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_handoff_package.py",
+      "source_file": "scripts/overlord/test_validate_handoff_package.py",
       "source_location": "L141",
       "weight": 1.0,
       "_src": "test_validate_handoff_package",
@@ -39936,7 +40440,7 @@
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_handoff_package.py",
+      "source_file": "scripts/overlord/test_validate_handoff_package.py",
       "source_location": "L148",
       "weight": 1.0,
       "_src": "test_validate_handoff_package",
@@ -39948,7 +40452,7 @@
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_handoff_package.py",
+      "source_file": "scripts/overlord/test_validate_handoff_package.py",
       "source_location": "L163",
       "weight": 1.0,
       "_src": "test_validate_handoff_package",
@@ -39960,7 +40464,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_handoff_package.py",
+      "source_file": "scripts/overlord/test_validate_handoff_package.py",
       "source_location": "L149",
       "weight": 0.8,
       "_src": "test_validate_handoff_package_write_supporting_files",
@@ -39972,7 +40476,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_handoff_package.py",
+      "source_file": "scripts/overlord/test_validate_handoff_package.py",
       "source_location": "L193",
       "weight": 0.8,
       "_src": "test_validate_handoff_package_testvalidatehandoffpackage_test_structured_plan_issue_mismatch_fails",
@@ -39984,7 +40488,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_handoff_package.py",
+      "source_file": "scripts/overlord/test_validate_handoff_package.py",
       "source_location": "L101",
       "weight": 0.8,
       "_src": "test_validate_handoff_package_consumer_scope",
@@ -39996,7 +40500,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_handoff_package.py",
+      "source_file": "scripts/overlord/test_validate_handoff_package.py",
       "source_location": "L150",
       "weight": 0.8,
       "_src": "test_validate_handoff_package_write_supporting_files",
@@ -40008,7 +40512,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_handoff_package.py",
+      "source_file": "scripts/overlord/test_validate_handoff_package.py",
       "source_location": "L202",
       "weight": 0.8,
       "_src": "test_validate_handoff_package_testvalidatehandoffpackage_test_execution_scope_lane_claim_mismatch_fails",
@@ -40020,7 +40524,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_handoff_package.py",
+      "source_file": "scripts/overlord/test_validate_handoff_package.py",
       "source_location": "L354",
       "weight": 0.8,
       "_src": "test_validate_handoff_package_testvalidatehandoffpackage_test_accepted_consumer_managed_handoff_requires_consumer_verifier_command",
@@ -40032,7 +40536,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_handoff_package.py",
+      "source_file": "scripts/overlord/test_validate_handoff_package.py",
       "source_location": "L372",
       "weight": 0.8,
       "_src": "test_validate_handoff_package_testvalidatehandoffpackage_test_accepted_consumer_managed_handoff_requires_verifier_evidence_refs",
@@ -40044,7 +40548,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_handoff_package.py",
+      "source_file": "scripts/overlord/test_validate_handoff_package.py",
       "source_location": "L390",
       "weight": 0.8,
       "_src": "test_validate_handoff_package_testvalidatehandoffpackage_test_accepted_consumer_managed_handoff_passes_with_verifier_command_and_evidence",
@@ -40056,7 +40560,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_handoff_package.py",
+      "source_file": "scripts/overlord/test_validate_handoff_package.py",
       "source_location": "L160",
       "weight": 0.8,
       "_src": "test_validate_handoff_package_write_supporting_files",
@@ -40068,7 +40572,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_handoff_package.py",
+      "source_file": "scripts/overlord/test_validate_handoff_package.py",
       "source_location": "L211",
       "weight": 0.8,
       "_src": "test_validate_handoff_package_testvalidatehandoffpackage_test_accepted_package_requires_closeout_ref",
@@ -40080,7 +40584,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_handoff_package.py",
+      "source_file": "scripts/overlord/test_validate_handoff_package.py",
       "source_location": "L223",
       "weight": 0.8,
       "_src": "test_validate_handoff_package_testvalidatehandoffpackage_test_validation_ready_package_requires_packet_ref",
@@ -40092,7 +40596,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_handoff_package.py",
+      "source_file": "scripts/overlord/test_validate_handoff_package.py",
       "source_location": "L234",
       "weight": 0.8,
       "_src": "test_validate_handoff_package_testvalidatehandoffpackage_test_implementation_ready_requires_non_empty_review_artifact_refs",
@@ -40104,7 +40608,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_handoff_package.py",
+      "source_file": "scripts/overlord/test_validate_handoff_package.py",
       "source_location": "L245",
       "weight": 0.8,
       "_src": "test_validate_handoff_package_testvalidatehandoffpackage_test_in_progress_requires_non_empty_gate_artifact_refs",
@@ -40116,7 +40620,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_handoff_package.py",
+      "source_file": "scripts/overlord/test_validate_handoff_package.py",
       "source_location": "L257",
       "weight": 0.8,
       "_src": "test_validate_handoff_package_testvalidatehandoffpackage_test_historical_implementation_ready_package_is_grandfathered_without_new_evidence_refs",
@@ -40128,7 +40632,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_handoff_package.py",
+      "source_file": "scripts/overlord/test_validate_handoff_package.py",
       "source_location": "L268",
       "weight": 0.8,
       "_src": "test_validate_handoff_package_testvalidatehandoffpackage_test_validation_ready_requires_non_empty_review_and_gate_artifact_refs",
@@ -40140,7 +40644,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_handoff_package.py",
+      "source_file": "scripts/overlord/test_validate_handoff_package.py",
       "source_location": "L286",
       "weight": 0.8,
       "_src": "test_validate_handoff_package_testvalidatehandoffpackage_test_accepted_requires_non_empty_review_and_gate_artifact_refs",
@@ -40152,7 +40656,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_handoff_package.py",
+      "source_file": "scripts/overlord/test_validate_handoff_package.py",
       "source_location": "L318",
       "weight": 0.8,
       "_src": "test_validate_handoff_package_testvalidatehandoffpackage_test_empty_acceptance_criteria_fails",
@@ -40164,7 +40668,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_handoff_package.py",
+      "source_file": "scripts/overlord/test_validate_handoff_package.py",
       "source_location": "L330",
       "weight": 0.8,
       "_src": "test_validate_handoff_package_testvalidatehandoffpackage_test_unsafe_handoff_ref_fails_without_traceback",
@@ -40176,7 +40680,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_handoff_package.py",
+      "source_file": "scripts/overlord/test_validate_handoff_package.py",
       "source_location": "L342",
       "weight": 0.8,
       "_src": "test_validate_handoff_package_testvalidatehandoffpackage_test_invalid_handoff_id_fails",
@@ -40188,7 +40692,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_handoff_package.py",
+      "source_file": "scripts/overlord/test_validate_handoff_package.py",
       "source_location": "L355",
       "weight": 0.8,
       "_src": "test_validate_handoff_package_testvalidatehandoffpackage_test_accepted_consumer_managed_handoff_requires_consumer_verifier_command",
@@ -40200,7 +40704,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_handoff_package.py",
+      "source_file": "scripts/overlord/test_validate_handoff_package.py",
       "source_location": "L373",
       "weight": 0.8,
       "_src": "test_validate_handoff_package_testvalidatehandoffpackage_test_accepted_consumer_managed_handoff_requires_verifier_evidence_refs",
@@ -40212,7 +40716,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_handoff_package.py",
+      "source_file": "scripts/overlord/test_validate_handoff_package.py",
       "source_location": "L394",
       "weight": 0.8,
       "_src": "test_validate_handoff_package_testvalidatehandoffpackage_test_accepted_consumer_managed_handoff_passes_with_verifier_command_and_evidence",
@@ -40224,7 +40728,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_handoff_package.py",
+      "source_file": "scripts/overlord/test_validate_handoff_package.py",
       "source_location": "L149",
       "weight": 0.8,
       "_src": "test_validate_handoff_package_write_supporting_files",
@@ -40236,7 +40740,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_handoff_package.py",
+      "source_file": "scripts/overlord/test_validate_handoff_package.py",
       "source_location": "L193",
       "weight": 0.8,
       "_src": "test_validate_handoff_package_testvalidatehandoffpackage_test_structured_plan_issue_mismatch_fails",
@@ -40248,7 +40752,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_handoff_package.py",
+      "source_file": "scripts/overlord/test_validate_handoff_package.py",
       "source_location": "L202",
       "weight": 0.8,
       "_src": "test_validate_handoff_package_testvalidatehandoffpackage_test_execution_scope_lane_claim_mismatch_fails",
@@ -40260,7 +40764,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_handoff_package.py",
+      "source_file": "scripts/overlord/test_validate_handoff_package.py",
       "source_location": "L213",
       "weight": 0.8,
       "_src": "test_validate_handoff_package_testvalidatehandoffpackage_test_accepted_package_requires_closeout_ref",
@@ -40272,7 +40776,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_handoff_package.py",
+      "source_file": "scripts/overlord/test_validate_handoff_package.py",
       "source_location": "L225",
       "weight": 0.8,
       "_src": "test_validate_handoff_package_testvalidatehandoffpackage_test_validation_ready_package_requires_packet_ref",
@@ -40284,7 +40788,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_handoff_package.py",
+      "source_file": "scripts/overlord/test_validate_handoff_package.py",
       "source_location": "L236",
       "weight": 0.8,
       "_src": "test_validate_handoff_package_testvalidatehandoffpackage_test_implementation_ready_requires_non_empty_review_artifact_refs",
@@ -40296,7 +40800,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_handoff_package.py",
+      "source_file": "scripts/overlord/test_validate_handoff_package.py",
       "source_location": "L248",
       "weight": 0.8,
       "_src": "test_validate_handoff_package_testvalidatehandoffpackage_test_in_progress_requires_non_empty_gate_artifact_refs",
@@ -40308,7 +40812,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_handoff_package.py",
+      "source_file": "scripts/overlord/test_validate_handoff_package.py",
       "source_location": "L260",
       "weight": 0.8,
       "_src": "test_validate_handoff_package_testvalidatehandoffpackage_test_historical_implementation_ready_package_is_grandfathered_without_new_evidence_refs",
@@ -40320,7 +40824,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_handoff_package.py",
+      "source_file": "scripts/overlord/test_validate_handoff_package.py",
       "source_location": "L276",
       "weight": 0.8,
       "_src": "test_validate_handoff_package_testvalidatehandoffpackage_test_validation_ready_requires_non_empty_review_and_gate_artifact_refs",
@@ -40332,7 +40836,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_handoff_package.py",
+      "source_file": "scripts/overlord/test_validate_handoff_package.py",
       "source_location": "L298",
       "weight": 0.8,
       "_src": "test_validate_handoff_package_testvalidatehandoffpackage_test_accepted_requires_non_empty_review_and_gate_artifact_refs",
@@ -40344,7 +40848,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_handoff_package.py",
+      "source_file": "scripts/overlord/test_validate_handoff_package.py",
       "source_location": "L320",
       "weight": 0.8,
       "_src": "test_validate_handoff_package_testvalidatehandoffpackage_test_empty_acceptance_criteria_fails",
@@ -40356,7 +40860,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_handoff_package.py",
+      "source_file": "scripts/overlord/test_validate_handoff_package.py",
       "source_location": "L332",
       "weight": 0.8,
       "_src": "test_validate_handoff_package_testvalidatehandoffpackage_test_unsafe_handoff_ref_fails_without_traceback",
@@ -40368,7 +40872,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_handoff_package.py",
+      "source_file": "scripts/overlord/test_validate_handoff_package.py",
       "source_location": "L344",
       "weight": 0.8,
       "_src": "test_validate_handoff_package_testvalidatehandoffpackage_test_invalid_handoff_id_fails",
@@ -40380,7 +40884,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_handoff_package.py",
+      "source_file": "scripts/overlord/test_validate_handoff_package.py",
       "source_location": "L354",
       "weight": 0.8,
       "_src": "test_validate_handoff_package_testvalidatehandoffpackage_test_accepted_consumer_managed_handoff_requires_consumer_verifier_command",
@@ -40392,7 +40896,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_handoff_package.py",
+      "source_file": "scripts/overlord/test_validate_handoff_package.py",
       "source_location": "L372",
       "weight": 0.8,
       "_src": "test_validate_handoff_package_testvalidatehandoffpackage_test_accepted_consumer_managed_handoff_requires_verifier_evidence_refs",
@@ -40404,7 +40908,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_handoff_package.py",
+      "source_file": "scripts/overlord/test_validate_handoff_package.py",
       "source_location": "L390",
       "weight": 0.8,
       "_src": "test_validate_handoff_package_testvalidatehandoffpackage_test_accepted_consumer_managed_handoff_passes_with_verifier_command_and_evidence",
@@ -40416,7 +40920,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_handoff_package.py",
+      "source_file": "scripts/overlord/test_validate_handoff_package.py",
       "source_location": "L174",
       "weight": 0.8,
       "_src": "test_validate_handoff_package_testvalidatehandoffpackage_test_valid_package_passes",
@@ -40428,7 +40932,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_handoff_package.py",
+      "source_file": "scripts/overlord/test_validate_handoff_package.py",
       "source_location": "L182",
       "weight": 0.8,
       "_src": "test_validate_handoff_package_testvalidatehandoffpackage_test_missing_execution_scope_fails_for_implementation_ready",
@@ -40440,7 +40944,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_handoff_package.py",
+      "source_file": "scripts/overlord/test_validate_handoff_package.py",
       "source_location": "L192",
       "weight": 0.8,
       "_src": "test_validate_handoff_package_testvalidatehandoffpackage_test_structured_plan_issue_mismatch_fails",
@@ -40452,7 +40956,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_handoff_package.py",
+      "source_file": "scripts/overlord/test_validate_handoff_package.py",
       "source_location": "L201",
       "weight": 0.8,
       "_src": "test_validate_handoff_package_testvalidatehandoffpackage_test_execution_scope_lane_claim_mismatch_fails",
@@ -40464,7 +40968,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_handoff_package.py",
+      "source_file": "scripts/overlord/test_validate_handoff_package.py",
       "source_location": "L210",
       "weight": 0.8,
       "_src": "test_validate_handoff_package_testvalidatehandoffpackage_test_accepted_package_requires_closeout_ref",
@@ -40476,7 +40980,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_handoff_package.py",
+      "source_file": "scripts/overlord/test_validate_handoff_package.py",
       "source_location": "L222",
       "weight": 0.8,
       "_src": "test_validate_handoff_package_testvalidatehandoffpackage_test_validation_ready_package_requires_packet_ref",
@@ -40488,7 +40992,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_handoff_package.py",
+      "source_file": "scripts/overlord/test_validate_handoff_package.py",
       "source_location": "L233",
       "weight": 0.8,
       "_src": "test_validate_handoff_package_testvalidatehandoffpackage_test_implementation_ready_requires_non_empty_review_artifact_refs",
@@ -40500,7 +41004,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_handoff_package.py",
+      "source_file": "scripts/overlord/test_validate_handoff_package.py",
       "source_location": "L244",
       "weight": 0.8,
       "_src": "test_validate_handoff_package_testvalidatehandoffpackage_test_in_progress_requires_non_empty_gate_artifact_refs",
@@ -40512,7 +41016,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_handoff_package.py",
+      "source_file": "scripts/overlord/test_validate_handoff_package.py",
       "source_location": "L256",
       "weight": 0.8,
       "_src": "test_validate_handoff_package_testvalidatehandoffpackage_test_historical_implementation_ready_package_is_grandfathered_without_new_evidence_refs",
@@ -40524,7 +41028,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_handoff_package.py",
+      "source_file": "scripts/overlord/test_validate_handoff_package.py",
       "source_location": "L267",
       "weight": 0.8,
       "_src": "test_validate_handoff_package_testvalidatehandoffpackage_test_validation_ready_requires_non_empty_review_and_gate_artifact_refs",
@@ -40536,7 +41040,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_handoff_package.py",
+      "source_file": "scripts/overlord/test_validate_handoff_package.py",
       "source_location": "L285",
       "weight": 0.8,
       "_src": "test_validate_handoff_package_testvalidatehandoffpackage_test_accepted_requires_non_empty_review_and_gate_artifact_refs",
@@ -40548,7 +41052,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_handoff_package.py",
+      "source_file": "scripts/overlord/test_validate_handoff_package.py",
       "source_location": "L307",
       "weight": 0.8,
       "_src": "test_validate_handoff_package_testvalidatehandoffpackage_test_missing_structured_plan_ref_fails",
@@ -40560,7 +41064,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_handoff_package.py",
+      "source_file": "scripts/overlord/test_validate_handoff_package.py",
       "source_location": "L317",
       "weight": 0.8,
       "_src": "test_validate_handoff_package_testvalidatehandoffpackage_test_empty_acceptance_criteria_fails",
@@ -40572,7 +41076,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_handoff_package.py",
+      "source_file": "scripts/overlord/test_validate_handoff_package.py",
       "source_location": "L329",
       "weight": 0.8,
       "_src": "test_validate_handoff_package_testvalidatehandoffpackage_test_unsafe_handoff_ref_fails_without_traceback",
@@ -40584,7 +41088,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_handoff_package.py",
+      "source_file": "scripts/overlord/test_validate_handoff_package.py",
       "source_location": "L341",
       "weight": 0.8,
       "_src": "test_validate_handoff_package_testvalidatehandoffpackage_test_invalid_handoff_id_fails",
@@ -40596,7 +41100,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_handoff_package.py",
+      "source_file": "scripts/overlord/test_validate_handoff_package.py",
       "source_location": "L353",
       "weight": 0.8,
       "_src": "test_validate_handoff_package_testvalidatehandoffpackage_test_accepted_consumer_managed_handoff_requires_consumer_verifier_command",
@@ -40608,7 +41112,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_handoff_package.py",
+      "source_file": "scripts/overlord/test_validate_handoff_package.py",
       "source_location": "L371",
       "weight": 0.8,
       "_src": "test_validate_handoff_package_testvalidatehandoffpackage_test_accepted_consumer_managed_handoff_requires_verifier_evidence_refs",
@@ -40620,7 +41124,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_handoff_package.py",
+      "source_file": "scripts/overlord/test_validate_handoff_package.py",
       "source_location": "L389",
       "weight": 0.8,
       "_src": "test_validate_handoff_package_testvalidatehandoffpackage_test_accepted_consumer_managed_handoff_passes_with_verifier_command_and_evidence",
@@ -40632,7 +41136,7 @@
     {
       "relation": "method",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_handoff_package.py",
+      "source_file": "scripts/overlord/test_validate_handoff_package.py",
       "source_location": "L164",
       "weight": 1.0,
       "_src": "test_validate_handoff_package_testvalidatehandoffpackage",
@@ -40644,7 +41148,7 @@
     {
       "relation": "method",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_handoff_package.py",
+      "source_file": "scripts/overlord/test_validate_handoff_package.py",
       "source_location": "L171",
       "weight": 1.0,
       "_src": "test_validate_handoff_package_testvalidatehandoffpackage",
@@ -40656,7 +41160,7 @@
     {
       "relation": "method",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_handoff_package.py",
+      "source_file": "scripts/overlord/test_validate_handoff_package.py",
       "source_location": "L179",
       "weight": 1.0,
       "_src": "test_validate_handoff_package_testvalidatehandoffpackage",
@@ -40668,7 +41172,7 @@
     {
       "relation": "method",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_handoff_package.py",
+      "source_file": "scripts/overlord/test_validate_handoff_package.py",
       "source_location": "L189",
       "weight": 1.0,
       "_src": "test_validate_handoff_package_testvalidatehandoffpackage",
@@ -40680,7 +41184,7 @@
     {
       "relation": "method",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_handoff_package.py",
+      "source_file": "scripts/overlord/test_validate_handoff_package.py",
       "source_location": "L198",
       "weight": 1.0,
       "_src": "test_validate_handoff_package_testvalidatehandoffpackage",
@@ -40692,7 +41196,7 @@
     {
       "relation": "method",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_handoff_package.py",
+      "source_file": "scripts/overlord/test_validate_handoff_package.py",
       "source_location": "L207",
       "weight": 1.0,
       "_src": "test_validate_handoff_package_testvalidatehandoffpackage",
@@ -40704,7 +41208,7 @@
     {
       "relation": "method",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_handoff_package.py",
+      "source_file": "scripts/overlord/test_validate_handoff_package.py",
       "source_location": "L219",
       "weight": 1.0,
       "_src": "test_validate_handoff_package_testvalidatehandoffpackage",
@@ -40716,7 +41220,7 @@
     {
       "relation": "method",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_handoff_package.py",
+      "source_file": "scripts/overlord/test_validate_handoff_package.py",
       "source_location": "L230",
       "weight": 1.0,
       "_src": "test_validate_handoff_package_testvalidatehandoffpackage",
@@ -40728,7 +41232,7 @@
     {
       "relation": "method",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_handoff_package.py",
+      "source_file": "scripts/overlord/test_validate_handoff_package.py",
       "source_location": "L241",
       "weight": 1.0,
       "_src": "test_validate_handoff_package_testvalidatehandoffpackage",
@@ -40740,7 +41244,7 @@
     {
       "relation": "method",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_handoff_package.py",
+      "source_file": "scripts/overlord/test_validate_handoff_package.py",
       "source_location": "L253",
       "weight": 1.0,
       "_src": "test_validate_handoff_package_testvalidatehandoffpackage",
@@ -40752,7 +41256,7 @@
     {
       "relation": "method",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_handoff_package.py",
+      "source_file": "scripts/overlord/test_validate_handoff_package.py",
       "source_location": "L264",
       "weight": 1.0,
       "_src": "test_validate_handoff_package_testvalidatehandoffpackage",
@@ -40764,7 +41268,7 @@
     {
       "relation": "method",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_handoff_package.py",
+      "source_file": "scripts/overlord/test_validate_handoff_package.py",
       "source_location": "L282",
       "weight": 1.0,
       "_src": "test_validate_handoff_package_testvalidatehandoffpackage",
@@ -40776,7 +41280,7 @@
     {
       "relation": "method",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_handoff_package.py",
+      "source_file": "scripts/overlord/test_validate_handoff_package.py",
       "source_location": "L304",
       "weight": 1.0,
       "_src": "test_validate_handoff_package_testvalidatehandoffpackage",
@@ -40788,7 +41292,7 @@
     {
       "relation": "method",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_handoff_package.py",
+      "source_file": "scripts/overlord/test_validate_handoff_package.py",
       "source_location": "L314",
       "weight": 1.0,
       "_src": "test_validate_handoff_package_testvalidatehandoffpackage",
@@ -40800,7 +41304,7 @@
     {
       "relation": "method",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_handoff_package.py",
+      "source_file": "scripts/overlord/test_validate_handoff_package.py",
       "source_location": "L326",
       "weight": 1.0,
       "_src": "test_validate_handoff_package_testvalidatehandoffpackage",
@@ -40812,7 +41316,7 @@
     {
       "relation": "method",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_handoff_package.py",
+      "source_file": "scripts/overlord/test_validate_handoff_package.py",
       "source_location": "L338",
       "weight": 1.0,
       "_src": "test_validate_handoff_package_testvalidatehandoffpackage",
@@ -40824,7 +41328,7 @@
     {
       "relation": "method",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_handoff_package.py",
+      "source_file": "scripts/overlord/test_validate_handoff_package.py",
       "source_location": "L350",
       "weight": 1.0,
       "_src": "test_validate_handoff_package_testvalidatehandoffpackage",
@@ -40836,7 +41340,7 @@
     {
       "relation": "method",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_handoff_package.py",
+      "source_file": "scripts/overlord/test_validate_handoff_package.py",
       "source_location": "L368",
       "weight": 1.0,
       "_src": "test_validate_handoff_package_testvalidatehandoffpackage",
@@ -40848,7 +41352,7 @@
     {
       "relation": "method",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_handoff_package.py",
+      "source_file": "scripts/overlord/test_validate_handoff_package.py",
       "source_location": "L386",
       "weight": 1.0,
       "_src": "test_validate_handoff_package_testvalidatehandoffpackage",
@@ -40860,7 +41364,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_handoff_package.py",
+      "source_file": "scripts/overlord/test_validate_handoff_package.py",
       "source_location": "L175",
       "weight": 0.8,
       "_src": "test_validate_handoff_package_testvalidatehandoffpackage_test_valid_package_passes",
@@ -40872,7 +41376,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_handoff_package.py",
+      "source_file": "scripts/overlord/test_validate_handoff_package.py",
       "source_location": "L184",
       "weight": 0.8,
       "_src": "test_validate_handoff_package_testvalidatehandoffpackage_test_missing_execution_scope_fails_for_implementation_ready",
@@ -40884,7 +41388,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_handoff_package.py",
+      "source_file": "scripts/overlord/test_validate_handoff_package.py",
       "source_location": "L194",
       "weight": 0.8,
       "_src": "test_validate_handoff_package_testvalidatehandoffpackage_test_structured_plan_issue_mismatch_fails",
@@ -40896,7 +41400,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_handoff_package.py",
+      "source_file": "scripts/overlord/test_validate_handoff_package.py",
       "source_location": "L203",
       "weight": 0.8,
       "_src": "test_validate_handoff_package_testvalidatehandoffpackage_test_execution_scope_lane_claim_mismatch_fails",
@@ -40908,7 +41412,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_handoff_package.py",
+      "source_file": "scripts/overlord/test_validate_handoff_package.py",
       "source_location": "L214",
       "weight": 0.8,
       "_src": "test_validate_handoff_package_testvalidatehandoffpackage_test_accepted_package_requires_closeout_ref",
@@ -40920,7 +41424,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_handoff_package.py",
+      "source_file": "scripts/overlord/test_validate_handoff_package.py",
       "source_location": "L226",
       "weight": 0.8,
       "_src": "test_validate_handoff_package_testvalidatehandoffpackage_test_validation_ready_package_requires_packet_ref",
@@ -40932,7 +41436,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_handoff_package.py",
+      "source_file": "scripts/overlord/test_validate_handoff_package.py",
       "source_location": "L237",
       "weight": 0.8,
       "_src": "test_validate_handoff_package_testvalidatehandoffpackage_test_implementation_ready_requires_non_empty_review_artifact_refs",
@@ -40944,7 +41448,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_handoff_package.py",
+      "source_file": "scripts/overlord/test_validate_handoff_package.py",
       "source_location": "L249",
       "weight": 0.8,
       "_src": "test_validate_handoff_package_testvalidatehandoffpackage_test_in_progress_requires_non_empty_gate_artifact_refs",
@@ -40956,7 +41460,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_handoff_package.py",
+      "source_file": "scripts/overlord/test_validate_handoff_package.py",
       "source_location": "L261",
       "weight": 0.8,
       "_src": "test_validate_handoff_package_testvalidatehandoffpackage_test_historical_implementation_ready_package_is_grandfathered_without_new_evidence_refs",
@@ -40968,7 +41472,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_handoff_package.py",
+      "source_file": "scripts/overlord/test_validate_handoff_package.py",
       "source_location": "L277",
       "weight": 0.8,
       "_src": "test_validate_handoff_package_testvalidatehandoffpackage_test_validation_ready_requires_non_empty_review_and_gate_artifact_refs",
@@ -40980,7 +41484,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_handoff_package.py",
+      "source_file": "scripts/overlord/test_validate_handoff_package.py",
       "source_location": "L299",
       "weight": 0.8,
       "_src": "test_validate_handoff_package_testvalidatehandoffpackage_test_accepted_requires_non_empty_review_and_gate_artifact_refs",
@@ -40992,7 +41496,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_handoff_package.py",
+      "source_file": "scripts/overlord/test_validate_handoff_package.py",
       "source_location": "L309",
       "weight": 0.8,
       "_src": "test_validate_handoff_package_testvalidatehandoffpackage_test_missing_structured_plan_ref_fails",
@@ -41004,7 +41508,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_handoff_package.py",
+      "source_file": "scripts/overlord/test_validate_handoff_package.py",
       "source_location": "L321",
       "weight": 0.8,
       "_src": "test_validate_handoff_package_testvalidatehandoffpackage_test_empty_acceptance_criteria_fails",
@@ -41016,7 +41520,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_handoff_package.py",
+      "source_file": "scripts/overlord/test_validate_handoff_package.py",
       "source_location": "L333",
       "weight": 0.8,
       "_src": "test_validate_handoff_package_testvalidatehandoffpackage_test_unsafe_handoff_ref_fails_without_traceback",
@@ -41028,7 +41532,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_handoff_package.py",
+      "source_file": "scripts/overlord/test_validate_handoff_package.py",
       "source_location": "L345",
       "weight": 0.8,
       "_src": "test_validate_handoff_package_testvalidatehandoffpackage_test_invalid_handoff_id_fails",
@@ -41040,7 +41544,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_handoff_package.py",
+      "source_file": "scripts/overlord/test_validate_handoff_package.py",
       "source_location": "L363",
       "weight": 0.8,
       "_src": "test_validate_handoff_package_testvalidatehandoffpackage_test_accepted_consumer_managed_handoff_requires_consumer_verifier_command",
@@ -41052,7 +41556,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_handoff_package.py",
+      "source_file": "scripts/overlord/test_validate_handoff_package.py",
       "source_location": "L381",
       "weight": 0.8,
       "_src": "test_validate_handoff_package_testvalidatehandoffpackage_test_accepted_consumer_managed_handoff_requires_verifier_evidence_refs",
@@ -41064,7 +41568,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_handoff_package.py",
+      "source_file": "scripts/overlord/test_validate_handoff_package.py",
       "source_location": "L404",
       "weight": 0.8,
       "_src": "test_validate_handoff_package_testvalidatehandoffpackage_test_accepted_consumer_managed_handoff_passes_with_verifier_command_and_evidence",
@@ -41436,7 +41940,7 @@
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_session_contract_surfaces.py",
+      "source_file": "scripts/overlord/test_validate_session_contract_surfaces.py",
       "source_location": "L12",
       "weight": 1.0,
       "_src": "test_validate_session_contract_surfaces",
@@ -41448,7 +41952,7 @@
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_session_contract_surfaces.py",
+      "source_file": "scripts/overlord/test_validate_session_contract_surfaces.py",
       "source_location": "L18",
       "weight": 1.0,
       "_src": "test_validate_session_contract_surfaces",
@@ -41460,7 +41964,7 @@
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_session_contract_surfaces.py",
+      "source_file": "scripts/overlord/test_validate_session_contract_surfaces.py",
       "source_location": "L48",
       "weight": 1.0,
       "_src": "test_validate_session_contract_surfaces",
@@ -41472,7 +41976,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_session_contract_surfaces.py",
+      "source_file": "scripts/overlord/test_validate_session_contract_surfaces.py",
       "source_location": "L52",
       "weight": 0.8,
       "_src": "test_validate_session_contract_surfaces_validatesessioncontractsurfacestests_test_valid_surfaces_pass",
@@ -41484,7 +41988,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_session_contract_surfaces.py",
+      "source_file": "scripts/overlord/test_validate_session_contract_surfaces.py",
       "source_location": "L68",
       "weight": 0.8,
       "_src": "test_validate_session_contract_surfaces_validatesessioncontractsurfacestests_test_missing_wrapper_fails",
@@ -41496,7 +42000,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_session_contract_surfaces.py",
+      "source_file": "scripts/overlord/test_validate_session_contract_surfaces.py",
       "source_location": "L84",
       "weight": 0.8,
       "_src": "test_validate_session_contract_surfaces_validatesessioncontractsurfacestests_test_missing_user_prompt_submit_command_fails",
@@ -41508,7 +42012,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_session_contract_surfaces.py",
+      "source_file": "scripts/overlord/test_validate_session_contract_surfaces.py",
       "source_location": "L58",
       "weight": 0.8,
       "_src": "test_validate_session_contract_surfaces_validatesessioncontractsurfacestests_test_valid_surfaces_pass",
@@ -41520,7 +42024,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_session_contract_surfaces.py",
+      "source_file": "scripts/overlord/test_validate_session_contract_surfaces.py",
       "source_location": "L73",
       "weight": 0.8,
       "_src": "test_validate_session_contract_surfaces_validatesessioncontractsurfacestests_test_missing_wrapper_fails",
@@ -41532,7 +42036,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_session_contract_surfaces.py",
+      "source_file": "scripts/overlord/test_validate_session_contract_surfaces.py",
       "source_location": "L90",
       "weight": 0.8,
       "_src": "test_validate_session_contract_surfaces_validatesessioncontractsurfacestests_test_missing_user_prompt_submit_command_fails",
@@ -41544,7 +42048,7 @@
     {
       "relation": "method",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_session_contract_surfaces.py",
+      "source_file": "scripts/overlord/test_validate_session_contract_surfaces.py",
       "source_location": "L49",
       "weight": 1.0,
       "_src": "test_validate_session_contract_surfaces_validatesessioncontractsurfacestests",
@@ -41556,7 +42060,7 @@
     {
       "relation": "method",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_session_contract_surfaces.py",
+      "source_file": "scripts/overlord/test_validate_session_contract_surfaces.py",
       "source_location": "L65",
       "weight": 1.0,
       "_src": "test_validate_session_contract_surfaces_validatesessioncontractsurfacestests",
@@ -41568,7 +42072,7 @@
     {
       "relation": "method",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_session_contract_surfaces.py",
+      "source_file": "scripts/overlord/test_validate_session_contract_surfaces.py",
       "source_location": "L81",
       "weight": 1.0,
       "_src": "test_validate_session_contract_surfaces_validatesessioncontractsurfacestests",
@@ -41904,7 +42408,7 @@
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_structured_agent_cycle_plan.py",
+      "source_file": "scripts/overlord/test_validate_structured_agent_cycle_plan.py",
       "source_location": "L15",
       "weight": 1.0,
       "_src": "test_validate_structured_agent_cycle_plan",
@@ -41916,8 +42420,8 @@
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_structured_agent_cycle_plan.py",
-      "source_location": "L74",
+      "source_file": "scripts/overlord/test_validate_structured_agent_cycle_plan.py",
+      "source_location": "L103",
       "weight": 1.0,
       "_src": "test_validate_structured_agent_cycle_plan",
       "_tgt": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate",
@@ -41928,8 +42432,8 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_structured_agent_cycle_plan.py",
-      "source_location": "L143",
+      "source_file": "scripts/overlord/test_validate_structured_agent_cycle_plan.py",
+      "source_location": "L172",
       "weight": 0.8,
       "_src": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate_test_non_issue_branch_does_not_validate_unmatched_plans_for_readiness",
       "_tgt": "test_validate_structured_agent_cycle_plan_plan",
@@ -41940,8 +42444,8 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_structured_agent_cycle_plan.py",
-      "source_location": "L240",
+      "source_file": "scripts/overlord/test_validate_structured_agent_cycle_plan.py",
+      "source_location": "L269",
       "weight": 0.8,
       "_src": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate_test_issue_branch_matching_approved_plan_passes",
       "_tgt": "test_validate_structured_agent_cycle_plan_plan",
@@ -41952,8 +42456,8 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_structured_agent_cycle_plan.py",
-      "source_location": "L249",
+      "source_file": "scripts/overlord/test_validate_structured_agent_cycle_plan.py",
+      "source_location": "L278",
       "weight": 0.8,
       "_src": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate_test_planner_boundary_scope_gate_requires_issue_specific_scope",
       "_tgt": "test_validate_structured_agent_cycle_plan_plan",
@@ -41964,8 +42468,8 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_structured_agent_cycle_plan.py",
-      "source_location": "L267",
+      "source_file": "scripts/overlord/test_validate_structured_agent_cycle_plan.py",
+      "source_location": "L296",
       "weight": 0.8,
       "_src": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate_test_planner_boundary_scope_gate_accepts_matching_scope",
       "_tgt": "test_validate_structured_agent_cycle_plan_plan",
@@ -41976,8 +42480,8 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_structured_agent_cycle_plan.py",
-      "source_location": "L285",
+      "source_file": "scripts/overlord/test_validate_structured_agent_cycle_plan.py",
+      "source_location": "L314",
       "weight": 0.8,
       "_src": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate_test_matching_plan_must_be_implementation_ready",
       "_tgt": "test_validate_structured_agent_cycle_plan_plan",
@@ -41988,8 +42492,20 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_structured_agent_cycle_plan.py",
-      "source_location": "L295",
+      "source_file": "scripts/overlord/test_validate_structured_agent_cycle_plan.py",
+      "source_location": "L324",
+      "weight": 0.8,
+      "_src": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate_test_planning_evidence_only_changes_allow_planning_only_mode",
+      "_tgt": "test_validate_structured_agent_cycle_plan_plan",
+      "source": "test_validate_structured_agent_cycle_plan_plan",
+      "target": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate_test_planning_evidence_only_changes_allow_planning_only_mode",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/overlord/test_validate_structured_agent_cycle_plan.py",
+      "source_location": "L342",
       "weight": 0.8,
       "_src": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate_test_required_alternate_review_must_be_accepted",
       "_tgt": "test_validate_structured_agent_cycle_plan_plan",
@@ -42000,8 +42516,8 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_structured_agent_cycle_plan.py",
-      "source_location": "L305",
+      "source_file": "scripts/overlord/test_validate_structured_agent_cycle_plan.py",
+      "source_location": "L352",
       "weight": 0.8,
       "_src": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate_test_active_issue_branch_validates_matching_plan_review_gate_without_governance_surface_flag",
       "_tgt": "test_validate_structured_agent_cycle_plan_plan",
@@ -42012,8 +42528,8 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_structured_agent_cycle_plan.py",
-      "source_location": "L328",
+      "source_file": "scripts/overlord/test_validate_structured_agent_cycle_plan.py",
+      "source_location": "L375",
       "weight": 0.8,
       "_src": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate_test_active_issue_branch_requires_review_gate_to_be_marked_required",
       "_tgt": "test_validate_structured_agent_cycle_plan_plan",
@@ -42024,8 +42540,92 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_structured_agent_cycle_plan.py",
-      "source_location": "L353",
+      "source_file": "scripts/overlord/test_validate_structured_agent_cycle_plan.py",
+      "source_location": "L399",
+      "weight": 0.8,
+      "_src": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate_test_active_issue_branch_requires_plan_author_identity",
+      "_tgt": "test_validate_structured_agent_cycle_plan_plan",
+      "source": "test_validate_structured_agent_cycle_plan_plan",
+      "target": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate_test_active_issue_branch_requires_plan_author_identity",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/overlord/test_validate_structured_agent_cycle_plan.py",
+      "source_location": "L425",
+      "weight": 0.8,
+      "_src": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate_test_active_issue_branch_rejects_same_model_self_review",
+      "_tgt": "test_validate_structured_agent_cycle_plan_plan",
+      "source": "test_validate_structured_agent_cycle_plan_plan",
+      "target": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate_test_active_issue_branch_rejects_same_model_self_review",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/overlord/test_validate_structured_agent_cycle_plan.py",
+      "source_location": "L451",
+      "weight": 0.8,
+      "_src": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate_test_active_issue_branch_requires_review_refs_once_specialist_review_is_accepted",
+      "_tgt": "test_validate_structured_agent_cycle_plan_plan",
+      "source": "test_validate_structured_agent_cycle_plan_plan",
+      "target": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate_test_active_issue_branch_requires_review_refs_once_specialist_review_is_accepted",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/overlord/test_validate_structured_agent_cycle_plan.py",
+      "source_location": "L477",
+      "weight": 0.8,
+      "_src": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate_test_active_issue_branch_requires_handoff_package_ref",
+      "_tgt": "test_validate_structured_agent_cycle_plan_plan",
+      "source": "test_validate_structured_agent_cycle_plan_plan",
+      "target": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate_test_active_issue_branch_requires_handoff_package_ref",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/overlord/test_validate_structured_agent_cycle_plan.py",
+      "source_location": "L504",
+      "weight": 0.8,
+      "_src": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate_test_planning_only_active_issue_branch_requires_legal_alternate_review_exemption",
+      "_tgt": "test_validate_structured_agent_cycle_plan_plan",
+      "source": "test_validate_structured_agent_cycle_plan_plan",
+      "target": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate_test_planning_only_active_issue_branch_requires_legal_alternate_review_exemption",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/overlord/test_validate_structured_agent_cycle_plan.py",
+      "source_location": "L538",
+      "weight": 0.8,
+      "_src": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate_test_planning_only_active_issue_branch_accepts_bounded_historical_exemption",
+      "_tgt": "test_validate_structured_agent_cycle_plan_plan",
+      "source": "test_validate_structured_agent_cycle_plan_plan",
+      "target": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate_test_planning_only_active_issue_branch_accepts_bounded_historical_exemption",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/overlord/test_validate_structured_agent_cycle_plan.py",
+      "source_location": "L575",
+      "weight": 0.8,
+      "_src": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate_test_stampede_issue_184_failure_shape_is_rejected",
+      "_tgt": "test_validate_structured_agent_cycle_plan_plan",
+      "source": "test_validate_structured_agent_cycle_plan_plan",
+      "target": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate_test_stampede_issue_184_failure_shape_is_rejected",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/overlord/test_validate_structured_agent_cycle_plan.py",
+      "source_location": "L618",
       "weight": 0.8,
       "_src": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate_test_historical_implementation_ready_plan_does_not_fail_without_matching_issue_branch",
       "_tgt": "test_validate_structured_agent_cycle_plan_plan",
@@ -42036,20 +42636,20 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_structured_agent_cycle_plan.py",
-      "source_location": "L373",
+      "source_file": "scripts/overlord/test_validate_structured_agent_cycle_plan.py",
+      "source_location": "L638",
       "weight": 0.8,
-      "_src": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate_test_historical_issue_branch_plan_is_grandfathered_before_review_gate_cutover",
+      "_src": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate_test_active_issue_branch_is_not_grandfathered_out_of_new_identity_gate",
       "_tgt": "test_validate_structured_agent_cycle_plan_plan",
       "source": "test_validate_structured_agent_cycle_plan_plan",
-      "target": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate_test_historical_issue_branch_plan_is_grandfathered_before_review_gate_cutover",
+      "target": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate_test_active_issue_branch_is_not_grandfathered_out_of_new_identity_gate",
       "confidence_score": 0.5
     },
     {
       "relation": "method",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_structured_agent_cycle_plan.py",
-      "source_location": "L75",
+      "source_file": "scripts/overlord/test_validate_structured_agent_cycle_plan.py",
+      "source_location": "L104",
       "weight": 1.0,
       "_src": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate",
       "_tgt": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate_run",
@@ -42060,8 +42660,8 @@
     {
       "relation": "method",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_structured_agent_cycle_plan.py",
-      "source_location": "L95",
+      "source_file": "scripts/overlord/test_validate_structured_agent_cycle_plan.py",
+      "source_location": "L124",
       "weight": 1.0,
       "_src": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate",
       "_tgt": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate_run_with_scope_gate",
@@ -42072,8 +42672,8 @@
     {
       "relation": "method",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_structured_agent_cycle_plan.py",
-      "source_location": "L116",
+      "source_file": "scripts/overlord/test_validate_structured_agent_cycle_plan.py",
+      "source_location": "L145",
       "weight": 1.0,
       "_src": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate",
       "_tgt": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate_write_scope",
@@ -42084,8 +42684,8 @@
     {
       "relation": "method",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_structured_agent_cycle_plan.py",
-      "source_location": "L132",
+      "source_file": "scripts/overlord/test_validate_structured_agent_cycle_plan.py",
+      "source_location": "L161",
       "weight": 1.0,
       "_src": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate",
       "_tgt": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate_test_non_issue_branch_with_governance_surface_change_fails",
@@ -42096,8 +42696,8 @@
     {
       "relation": "method",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_structured_agent_cycle_plan.py",
-      "source_location": "L138",
+      "source_file": "scripts/overlord/test_validate_structured_agent_cycle_plan.py",
+      "source_location": "L167",
       "weight": 1.0,
       "_src": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate",
       "_tgt": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate_test_non_issue_branch_does_not_validate_unmatched_plans_for_readiness",
@@ -42108,8 +42708,8 @@
     {
       "relation": "method",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_structured_agent_cycle_plan.py",
-      "source_location": "L149",
+      "source_file": "scripts/overlord/test_validate_structured_agent_cycle_plan.py",
+      "source_location": "L178",
       "weight": 1.0,
       "_src": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate",
       "_tgt": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate_test_github_scripts_are_governance_surface",
@@ -42120,8 +42720,8 @@
     {
       "relation": "method",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_structured_agent_cycle_plan.py",
-      "source_location": "L155",
+      "source_file": "scripts/overlord/test_validate_structured_agent_cycle_plan.py",
+      "source_location": "L184",
       "weight": 1.0,
       "_src": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate",
       "_tgt": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate_test_github_workflows_with_leading_dot_are_governance_surface",
@@ -42132,8 +42732,8 @@
     {
       "relation": "method",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_structured_agent_cycle_plan.py",
-      "source_location": "L161",
+      "source_file": "scripts/overlord/test_validate_structured_agent_cycle_plan.py",
+      "source_location": "L190",
       "weight": 1.0,
       "_src": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate",
       "_tgt": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate_test_launchd_and_orchestrator_paths_are_governance_surface",
@@ -42144,8 +42744,8 @@
     {
       "relation": "method",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_structured_agent_cycle_plan.py",
-      "source_location": "L168",
+      "source_file": "scripts/overlord/test_validate_structured_agent_cycle_plan.py",
+      "source_location": "L197",
       "weight": 1.0,
       "_src": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate",
       "_tgt": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate_test_lam_runtime_paths_are_governance_surface",
@@ -42156,8 +42756,8 @@
     {
       "relation": "method",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_structured_agent_cycle_plan.py",
-      "source_location": "L174",
+      "source_file": "scripts/overlord/test_validate_structured_agent_cycle_plan.py",
+      "source_location": "L203",
       "weight": 1.0,
       "_src": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate",
       "_tgt": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate_test_packet_paths_are_governance_surface",
@@ -42168,8 +42768,8 @@
     {
       "relation": "method",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_structured_agent_cycle_plan.py",
-      "source_location": "L190",
+      "source_file": "scripts/overlord/test_validate_structured_agent_cycle_plan.py",
+      "source_location": "L219",
       "weight": 1.0,
       "_src": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate",
       "_tgt": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate_test_self_learning_paths_are_governance_surface",
@@ -42180,8 +42780,8 @@
     {
       "relation": "method",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_structured_agent_cycle_plan.py",
-      "source_location": "L204",
+      "source_file": "scripts/overlord/test_validate_structured_agent_cycle_plan.py",
+      "source_location": "L233",
       "weight": 1.0,
       "_src": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate",
       "_tgt": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate_test_pilot_gate_and_metrics_paths_are_governance_surface",
@@ -42192,8 +42792,8 @@
     {
       "relation": "method",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_structured_agent_cycle_plan.py",
-      "source_location": "L218",
+      "source_file": "scripts/overlord/test_validate_structured_agent_cycle_plan.py",
+      "source_location": "L247",
       "weight": 1.0,
       "_src": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate",
       "_tgt": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate_test_riskfix_branch_without_issue_number_gets_specific_issue_hint",
@@ -42204,8 +42804,8 @@
     {
       "relation": "method",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_structured_agent_cycle_plan.py",
-      "source_location": "L224",
+      "source_file": "scripts/overlord/test_validate_structured_agent_cycle_plan.py",
+      "source_location": "L253",
       "weight": 1.0,
       "_src": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate",
       "_tgt": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate_test_non_governance_surface_change_without_plan_passes",
@@ -42216,8 +42816,8 @@
     {
       "relation": "method",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_structured_agent_cycle_plan.py",
-      "source_location": "L229",
+      "source_file": "scripts/overlord/test_validate_structured_agent_cycle_plan.py",
+      "source_location": "L258",
       "weight": 1.0,
       "_src": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate",
       "_tgt": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate_test_issue_branch_requires_matching_plan",
@@ -42228,8 +42828,8 @@
     {
       "relation": "method",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_structured_agent_cycle_plan.py",
-      "source_location": "L235",
+      "source_file": "scripts/overlord/test_validate_structured_agent_cycle_plan.py",
+      "source_location": "L264",
       "weight": 1.0,
       "_src": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate",
       "_tgt": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate_test_issue_branch_matching_approved_plan_passes",
@@ -42240,8 +42840,8 @@
     {
       "relation": "method",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_structured_agent_cycle_plan.py",
-      "source_location": "L244",
+      "source_file": "scripts/overlord/test_validate_structured_agent_cycle_plan.py",
+      "source_location": "L273",
       "weight": 1.0,
       "_src": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate",
       "_tgt": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate_test_planner_boundary_scope_gate_requires_issue_specific_scope",
@@ -42252,8 +42852,8 @@
     {
       "relation": "method",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_structured_agent_cycle_plan.py",
-      "source_location": "L262",
+      "source_file": "scripts/overlord/test_validate_structured_agent_cycle_plan.py",
+      "source_location": "L291",
       "weight": 1.0,
       "_src": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate",
       "_tgt": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate_test_planner_boundary_scope_gate_accepts_matching_scope",
@@ -42264,8 +42864,8 @@
     {
       "relation": "method",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_structured_agent_cycle_plan.py",
-      "source_location": "L280",
+      "source_file": "scripts/overlord/test_validate_structured_agent_cycle_plan.py",
+      "source_location": "L309",
       "weight": 1.0,
       "_src": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate",
       "_tgt": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate_test_matching_plan_must_be_implementation_ready",
@@ -42276,8 +42876,20 @@
     {
       "relation": "method",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_structured_agent_cycle_plan.py",
-      "source_location": "L290",
+      "source_file": "scripts/overlord/test_validate_structured_agent_cycle_plan.py",
+      "source_location": "L319",
+      "weight": 1.0,
+      "_src": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate",
+      "_tgt": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate_test_planning_evidence_only_changes_allow_planning_only_mode",
+      "source": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate",
+      "target": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate_test_planning_evidence_only_changes_allow_planning_only_mode",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/overlord/test_validate_structured_agent_cycle_plan.py",
+      "source_location": "L337",
       "weight": 1.0,
       "_src": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate",
       "_tgt": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate_test_required_alternate_review_must_be_accepted",
@@ -42288,8 +42900,8 @@
     {
       "relation": "method",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_structured_agent_cycle_plan.py",
-      "source_location": "L300",
+      "source_file": "scripts/overlord/test_validate_structured_agent_cycle_plan.py",
+      "source_location": "L347",
       "weight": 1.0,
       "_src": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate",
       "_tgt": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate_test_active_issue_branch_validates_matching_plan_review_gate_without_governance_surface_flag",
@@ -42300,8 +42912,8 @@
     {
       "relation": "method",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_structured_agent_cycle_plan.py",
-      "source_location": "L323",
+      "source_file": "scripts/overlord/test_validate_structured_agent_cycle_plan.py",
+      "source_location": "L370",
       "weight": 1.0,
       "_src": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate",
       "_tgt": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate_test_active_issue_branch_requires_review_gate_to_be_marked_required",
@@ -42312,8 +42924,92 @@
     {
       "relation": "method",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_structured_agent_cycle_plan.py",
-      "source_location": "L346",
+      "source_file": "scripts/overlord/test_validate_structured_agent_cycle_plan.py",
+      "source_location": "L393",
+      "weight": 1.0,
+      "_src": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate",
+      "_tgt": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate_test_active_issue_branch_requires_plan_author_identity",
+      "source": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate",
+      "target": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate_test_active_issue_branch_requires_plan_author_identity",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/overlord/test_validate_structured_agent_cycle_plan.py",
+      "source_location": "L419",
+      "weight": 1.0,
+      "_src": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate",
+      "_tgt": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate_test_active_issue_branch_rejects_same_model_self_review",
+      "source": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate",
+      "target": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate_test_active_issue_branch_rejects_same_model_self_review",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/overlord/test_validate_structured_agent_cycle_plan.py",
+      "source_location": "L445",
+      "weight": 1.0,
+      "_src": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate",
+      "_tgt": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate_test_active_issue_branch_requires_review_refs_once_specialist_review_is_accepted",
+      "source": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate",
+      "target": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate_test_active_issue_branch_requires_review_refs_once_specialist_review_is_accepted",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/overlord/test_validate_structured_agent_cycle_plan.py",
+      "source_location": "L471",
+      "weight": 1.0,
+      "_src": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate",
+      "_tgt": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate_test_active_issue_branch_requires_handoff_package_ref",
+      "source": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate",
+      "target": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate_test_active_issue_branch_requires_handoff_package_ref",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/overlord/test_validate_structured_agent_cycle_plan.py",
+      "source_location": "L497",
+      "weight": 1.0,
+      "_src": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate",
+      "_tgt": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate_test_planning_only_active_issue_branch_requires_legal_alternate_review_exemption",
+      "source": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate",
+      "target": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate_test_planning_only_active_issue_branch_requires_legal_alternate_review_exemption",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/overlord/test_validate_structured_agent_cycle_plan.py",
+      "source_location": "L531",
+      "weight": 1.0,
+      "_src": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate",
+      "_tgt": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate_test_planning_only_active_issue_branch_accepts_bounded_historical_exemption",
+      "source": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate",
+      "target": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate_test_planning_only_active_issue_branch_accepts_bounded_historical_exemption",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/overlord/test_validate_structured_agent_cycle_plan.py",
+      "source_location": "L570",
+      "weight": 1.0,
+      "_src": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate",
+      "_tgt": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate_test_stampede_issue_184_failure_shape_is_rejected",
+      "source": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate",
+      "target": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate_test_stampede_issue_184_failure_shape_is_rejected",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/overlord/test_validate_structured_agent_cycle_plan.py",
+      "source_location": "L611",
       "weight": 1.0,
       "_src": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate",
       "_tgt": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate_test_historical_implementation_ready_plan_does_not_fail_without_matching_issue_branch",
@@ -42324,20 +43020,20 @@
     {
       "relation": "method",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_structured_agent_cycle_plan.py",
-      "source_location": "L366",
+      "source_file": "scripts/overlord/test_validate_structured_agent_cycle_plan.py",
+      "source_location": "L631",
       "weight": 1.0,
       "_src": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate",
-      "_tgt": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate_test_historical_issue_branch_plan_is_grandfathered_before_review_gate_cutover",
+      "_tgt": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate_test_active_issue_branch_is_not_grandfathered_out_of_new_identity_gate",
       "source": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate",
-      "target": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate_test_historical_issue_branch_plan_is_grandfathered_before_review_gate_cutover",
+      "target": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate_test_active_issue_branch_is_not_grandfathered_out_of_new_identity_gate",
       "confidence_score": 1.0
     },
     {
       "relation": "method",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_structured_agent_cycle_plan.py",
-      "source_location": "L398",
+      "source_file": "scripts/overlord/test_validate_structured_agent_cycle_plan.py",
+      "source_location": "L668",
       "weight": 1.0,
       "_src": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate",
       "_tgt": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate_test_malformed_json_reports_structured_fail_without_traceback",
@@ -42348,8 +43044,8 @@
     {
       "relation": "method",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_structured_agent_cycle_plan.py",
-      "source_location": "L414",
+      "source_file": "scripts/overlord/test_validate_structured_agent_cycle_plan.py",
+      "source_location": "L684",
       "weight": 1.0,
       "_src": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate",
       "_tgt": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate_test_malformed_matching_plan_does_not_crash_governance_surface_gate",
@@ -42360,8 +43056,8 @@
     {
       "relation": "method",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_structured_agent_cycle_plan.py",
-      "source_location": "L427",
+      "source_file": "scripts/overlord/test_validate_structured_agent_cycle_plan.py",
+      "source_location": "L697",
       "weight": 1.0,
       "_src": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate",
       "_tgt": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate_test_plan_read_error_reports_structured_fail_without_traceback",
@@ -42372,8 +43068,8 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_structured_agent_cycle_plan.py",
-      "source_location": "L134",
+      "source_file": "scripts/overlord/test_validate_structured_agent_cycle_plan.py",
+      "source_location": "L163",
       "weight": 0.8,
       "_src": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate_test_non_issue_branch_with_governance_surface_change_fails",
       "_tgt": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate_run",
@@ -42384,8 +43080,8 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_structured_agent_cycle_plan.py",
-      "source_location": "L144",
+      "source_file": "scripts/overlord/test_validate_structured_agent_cycle_plan.py",
+      "source_location": "L173",
       "weight": 0.8,
       "_src": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate_test_non_issue_branch_does_not_validate_unmatched_plans_for_readiness",
       "_tgt": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate_run",
@@ -42396,8 +43092,8 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_structured_agent_cycle_plan.py",
-      "source_location": "L151",
+      "source_file": "scripts/overlord/test_validate_structured_agent_cycle_plan.py",
+      "source_location": "L180",
       "weight": 0.8,
       "_src": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate_test_github_scripts_are_governance_surface",
       "_tgt": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate_run",
@@ -42408,8 +43104,8 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_structured_agent_cycle_plan.py",
-      "source_location": "L157",
+      "source_file": "scripts/overlord/test_validate_structured_agent_cycle_plan.py",
+      "source_location": "L186",
       "weight": 0.8,
       "_src": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate_test_github_workflows_with_leading_dot_are_governance_surface",
       "_tgt": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate_run",
@@ -42420,8 +43116,8 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_structured_agent_cycle_plan.py",
-      "source_location": "L163",
+      "source_file": "scripts/overlord/test_validate_structured_agent_cycle_plan.py",
+      "source_location": "L192",
       "weight": 0.8,
       "_src": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate_test_launchd_and_orchestrator_paths_are_governance_surface",
       "_tgt": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate_run",
@@ -42432,8 +43128,8 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_structured_agent_cycle_plan.py",
-      "source_location": "L170",
+      "source_file": "scripts/overlord/test_validate_structured_agent_cycle_plan.py",
+      "source_location": "L199",
       "weight": 0.8,
       "_src": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate_test_lam_runtime_paths_are_governance_surface",
       "_tgt": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate_run",
@@ -42444,8 +43140,8 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_structured_agent_cycle_plan.py",
-      "source_location": "L176",
+      "source_file": "scripts/overlord/test_validate_structured_agent_cycle_plan.py",
+      "source_location": "L205",
       "weight": 0.8,
       "_src": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate_test_packet_paths_are_governance_surface",
       "_tgt": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate_run",
@@ -42456,8 +43152,8 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_structured_agent_cycle_plan.py",
-      "source_location": "L192",
+      "source_file": "scripts/overlord/test_validate_structured_agent_cycle_plan.py",
+      "source_location": "L221",
       "weight": 0.8,
       "_src": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate_test_self_learning_paths_are_governance_surface",
       "_tgt": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate_run",
@@ -42468,8 +43164,8 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_structured_agent_cycle_plan.py",
-      "source_location": "L206",
+      "source_file": "scripts/overlord/test_validate_structured_agent_cycle_plan.py",
+      "source_location": "L235",
       "weight": 0.8,
       "_src": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate_test_pilot_gate_and_metrics_paths_are_governance_surface",
       "_tgt": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate_run",
@@ -42480,8 +43176,8 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_structured_agent_cycle_plan.py",
-      "source_location": "L220",
+      "source_file": "scripts/overlord/test_validate_structured_agent_cycle_plan.py",
+      "source_location": "L249",
       "weight": 0.8,
       "_src": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate_test_riskfix_branch_without_issue_number_gets_specific_issue_hint",
       "_tgt": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate_run",
@@ -42492,8 +43188,8 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_structured_agent_cycle_plan.py",
-      "source_location": "L226",
+      "source_file": "scripts/overlord/test_validate_structured_agent_cycle_plan.py",
+      "source_location": "L255",
       "weight": 0.8,
       "_src": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate_test_non_governance_surface_change_without_plan_passes",
       "_tgt": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate_run",
@@ -42504,8 +43200,8 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_structured_agent_cycle_plan.py",
-      "source_location": "L231",
+      "source_file": "scripts/overlord/test_validate_structured_agent_cycle_plan.py",
+      "source_location": "L260",
       "weight": 0.8,
       "_src": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate_test_issue_branch_requires_matching_plan",
       "_tgt": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate_run",
@@ -42516,8 +43212,8 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_structured_agent_cycle_plan.py",
-      "source_location": "L241",
+      "source_file": "scripts/overlord/test_validate_structured_agent_cycle_plan.py",
+      "source_location": "L270",
       "weight": 0.8,
       "_src": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate_test_issue_branch_matching_approved_plan_passes",
       "_tgt": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate_run",
@@ -42528,8 +43224,8 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_structured_agent_cycle_plan.py",
-      "source_location": "L286",
+      "source_file": "scripts/overlord/test_validate_structured_agent_cycle_plan.py",
+      "source_location": "L315",
       "weight": 0.8,
       "_src": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate_test_matching_plan_must_be_implementation_ready",
       "_tgt": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate_run",
@@ -42540,8 +43236,20 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_structured_agent_cycle_plan.py",
-      "source_location": "L296",
+      "source_file": "scripts/overlord/test_validate_structured_agent_cycle_plan.py",
+      "source_location": "L325",
+      "weight": 0.8,
+      "_src": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate_test_planning_evidence_only_changes_allow_planning_only_mode",
+      "_tgt": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate_run",
+      "source": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate_run",
+      "target": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate_test_planning_evidence_only_changes_allow_planning_only_mode",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/overlord/test_validate_structured_agent_cycle_plan.py",
+      "source_location": "L343",
       "weight": 0.8,
       "_src": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate_test_required_alternate_review_must_be_accepted",
       "_tgt": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate_run",
@@ -42552,8 +43260,8 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_structured_agent_cycle_plan.py",
-      "source_location": "L420",
+      "source_file": "scripts/overlord/test_validate_structured_agent_cycle_plan.py",
+      "source_location": "L690",
       "weight": 0.8,
       "_src": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate_test_malformed_matching_plan_does_not_crash_governance_surface_gate",
       "_tgt": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate_run",
@@ -42564,8 +43272,8 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_structured_agent_cycle_plan.py",
-      "source_location": "L250",
+      "source_file": "scripts/overlord/test_validate_structured_agent_cycle_plan.py",
+      "source_location": "L279",
       "weight": 0.8,
       "_src": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate_test_planner_boundary_scope_gate_requires_issue_specific_scope",
       "_tgt": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate_run_with_scope_gate",
@@ -42576,8 +43284,8 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_structured_agent_cycle_plan.py",
-      "source_location": "L269",
+      "source_file": "scripts/overlord/test_validate_structured_agent_cycle_plan.py",
+      "source_location": "L298",
       "weight": 0.8,
       "_src": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate_test_planner_boundary_scope_gate_accepts_matching_scope",
       "_tgt": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate_run_with_scope_gate",
@@ -42588,8 +43296,8 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_validate_structured_agent_cycle_plan.py",
-      "source_location": "L268",
+      "source_file": "scripts/overlord/test_validate_structured_agent_cycle_plan.py",
+      "source_location": "L297",
       "weight": 0.8,
       "_src": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate_test_planner_boundary_scope_gate_accepts_matching_scope",
       "_tgt": "test_validate_structured_agent_cycle_plan_testgovernancesurfaceplangate_write_scope",
@@ -42600,7 +43308,7 @@
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L36",
       "weight": 1.0,
       "_src": "test_verify_governance_consumer",
@@ -42612,7 +43320,7 @@
     {
       "relation": "method",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L37",
       "weight": 1.0,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer",
@@ -42624,7 +43332,7 @@
     {
       "relation": "method",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L50",
       "weight": 1.0,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer",
@@ -42636,7 +43344,7 @@
     {
       "relation": "method",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L53",
       "weight": 1.0,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer",
@@ -42648,7 +43356,7 @@
     {
       "relation": "method",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L71",
       "weight": 1.0,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer",
@@ -42660,7 +43368,7 @@
     {
       "relation": "method",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L78",
       "weight": 1.0,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer",
@@ -42672,7 +43380,7 @@
     {
       "relation": "method",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L90",
       "weight": 1.0,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer",
@@ -42684,7 +43392,7 @@
     {
       "relation": "method",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L93",
       "weight": 1.0,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer",
@@ -42696,7 +43404,7 @@
     {
       "relation": "method",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L96",
       "weight": 1.0,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer",
@@ -42708,7 +43416,7 @@
     {
       "relation": "method",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L99",
       "weight": 1.0,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer",
@@ -42720,7 +43428,7 @@
     {
       "relation": "method",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L102",
       "weight": 1.0,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer",
@@ -42732,7 +43440,7 @@
     {
       "relation": "method",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L110",
       "weight": 1.0,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer",
@@ -42744,7 +43452,7 @@
     {
       "relation": "method",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L114",
       "weight": 1.0,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer",
@@ -42756,7 +43464,7 @@
     {
       "relation": "method",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L118",
       "weight": 1.0,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer",
@@ -42768,7 +43476,7 @@
     {
       "relation": "method",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L130",
       "weight": 1.0,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer",
@@ -42780,7 +43488,7 @@
     {
       "relation": "method",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L137",
       "weight": 1.0,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer",
@@ -42792,7 +43500,7 @@
     {
       "relation": "method",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L156",
       "weight": 1.0,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer",
@@ -42804,7 +43512,7 @@
     {
       "relation": "method",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L167",
       "weight": 1.0,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer",
@@ -42816,7 +43524,7 @@
     {
       "relation": "method",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L184",
       "weight": 1.0,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer",
@@ -42828,7 +43536,7 @@
     {
       "relation": "method",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L194",
       "weight": 1.0,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer",
@@ -42840,7 +43548,7 @@
     {
       "relation": "method",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L210",
       "weight": 1.0,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer",
@@ -42852,7 +43560,7 @@
     {
       "relation": "method",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L222",
       "weight": 1.0,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer",
@@ -42864,7 +43572,7 @@
     {
       "relation": "method",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L239",
       "weight": 1.0,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer",
@@ -42876,7 +43584,7 @@
     {
       "relation": "method",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L252",
       "weight": 1.0,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer",
@@ -42888,7 +43596,7 @@
     {
       "relation": "method",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L267",
       "weight": 1.0,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer",
@@ -42900,7 +43608,7 @@
     {
       "relation": "method",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L284",
       "weight": 1.0,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer",
@@ -42912,7 +43620,7 @@
     {
       "relation": "method",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L301",
       "weight": 1.0,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer",
@@ -42924,7 +43632,7 @@
     {
       "relation": "method",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L319",
       "weight": 1.0,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer",
@@ -42936,7 +43644,7 @@
     {
       "relation": "method",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L340",
       "weight": 1.0,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer",
@@ -42948,7 +43656,7 @@
     {
       "relation": "method",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L361",
       "weight": 1.0,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer",
@@ -42960,7 +43668,7 @@
     {
       "relation": "method",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L376",
       "weight": 1.0,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer",
@@ -42972,7 +43680,7 @@
     {
       "relation": "method",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L390",
       "weight": 1.0,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer",
@@ -42984,7 +43692,7 @@
     {
       "relation": "method",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L405",
       "weight": 1.0,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer",
@@ -42996,7 +43704,7 @@
     {
       "relation": "method",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L420",
       "weight": 1.0,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer",
@@ -43008,7 +43716,7 @@
     {
       "relation": "method",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L435",
       "weight": 1.0,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer",
@@ -43020,7 +43728,7 @@
     {
       "relation": "method",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L454",
       "weight": 1.0,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer",
@@ -43032,7 +43740,7 @@
     {
       "relation": "method",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L468",
       "weight": 1.0,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer",
@@ -43044,7 +43752,7 @@
     {
       "relation": "method",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L482",
       "weight": 1.0,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer",
@@ -43056,7 +43764,7 @@
     {
       "relation": "method",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L496",
       "weight": 1.0,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer",
@@ -43068,7 +43776,7 @@
     {
       "relation": "method",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L510",
       "weight": 1.0,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer",
@@ -43080,7 +43788,7 @@
     {
       "relation": "method",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L524",
       "weight": 1.0,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer",
@@ -43092,7 +43800,7 @@
     {
       "relation": "method",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L538",
       "weight": 1.0,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer",
@@ -43104,7 +43812,7 @@
     {
       "relation": "method",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L564",
       "weight": 1.0,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer",
@@ -43116,8 +43824,32 @@
     {
       "relation": "method",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
-      "source_location": "L615",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
+      "source_location": "L623",
+      "weight": 1.0,
+      "_src": "test_verify_governance_consumer_testverifygovernanceconsumer",
+      "_tgt": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_when_consumer_profile_omits_required_session_contract_entries",
+      "source": "test_verify_governance_consumer_testverifygovernanceconsumer",
+      "target": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_when_consumer_profile_omits_required_session_contract_entries",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
+      "source_location": "L646",
+      "weight": 1.0,
+      "_src": "test_verify_governance_consumer_testverifygovernanceconsumer",
+      "_tgt": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_when_consumer_profile_session_contract_content_is_stale",
+      "source": "test_verify_governance_consumer_testverifygovernanceconsumer",
+      "target": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_when_consumer_profile_session_contract_content_is_stale",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
+      "source_location": "L677",
       "weight": 1.0,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer",
       "_tgt": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_for_tracked_session_contract_missing_required_content",
@@ -43128,8 +43860,8 @@
     {
       "relation": "method",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
-      "source_location": "L637",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
+      "source_location": "L699",
       "weight": 1.0,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer",
       "_tgt": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_for_hook_settings_contract_missing_post_tool_use_matcher",
@@ -43140,8 +43872,8 @@
     {
       "relation": "method",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
-      "source_location": "L670",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
+      "source_location": "L732",
       "weight": 1.0,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer",
       "_tgt": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_passes_for_session_contract_and_hook_settings_contract_entries",
@@ -43152,7 +43884,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L119",
       "weight": 0.8,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_passes_for_deployed_pinned_consumer_record",
@@ -43164,7 +43896,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L138",
       "weight": 0.8,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_when_governance_root_is_typoed",
@@ -43176,7 +43908,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L168",
       "weight": 0.8,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_when_governance_ref_is_not_sha",
@@ -43188,7 +43920,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L185",
       "weight": 0.8,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_when_shim_missing_marker",
@@ -43200,7 +43932,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L195",
       "weight": 0.8,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_when_expected_profile_mismatches",
@@ -43212,7 +43944,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L211",
       "weight": 0.8,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_when_managed_file_record_omits_expected_path",
@@ -43224,7 +43956,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L223",
       "weight": 0.8,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_when_profile_is_unknown",
@@ -43236,7 +43968,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L240",
       "weight": 0.8,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_when_profile_is_missing",
@@ -43248,7 +43980,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L253",
       "weight": 0.8,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_for_mutable_governance_workflow_ref",
@@ -43260,7 +43992,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L268",
       "weight": 0.8,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_workflow_ref_is_tag",
@@ -43272,7 +44004,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L285",
       "weight": 0.8,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_workflow_ref_is_short_sha",
@@ -43284,7 +44016,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L302",
       "weight": 0.8,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_workflow_ref_sha_mismatch",
@@ -43296,7 +44028,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L320",
       "weight": 0.8,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_stale_workflow_ref_before_acceptance",
@@ -43308,7 +44040,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L341",
       "weight": 0.8,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_for_managed_hook_checksum_drift",
@@ -43320,7 +44052,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L362",
       "weight": 0.8,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_for_managed_hook_missing_marker",
@@ -43332,7 +44064,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L377",
       "weight": 0.8,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_for_invalid_override_metadata_and_reports_observed_override",
@@ -43344,7 +44076,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L391",
       "weight": 0.8,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_for_malformed_local_overrides",
@@ -43356,7 +44088,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L406",
       "weight": 0.8,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_override_empty_owner",
@@ -43368,7 +44100,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L421",
       "weight": 0.8,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_override_non_string_reason",
@@ -43380,7 +44112,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L436",
       "weight": 0.8,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_override_empty_expires_at",
@@ -43392,7 +44124,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L455",
       "weight": 0.8,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_override_weakens_healthcareplatform_hipaa",
@@ -43404,7 +44136,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L469",
       "weight": 0.8,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_override_disables_seek_plan_mode",
@@ -43416,7 +44148,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L483",
       "weight": 0.8,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_override_routes_pii_away_from_lam",
@@ -43428,7 +44160,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L497",
       "weight": 0.8,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_override_core_fork_without_exception",
@@ -43440,7 +44172,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L511",
       "weight": 0.8,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_override_disables_ci_required_gate",
@@ -43452,7 +44184,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L525",
       "weight": 0.8,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_override_dry_run_as_live_evidence",
@@ -43464,7 +44196,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L540",
       "weight": 0.8,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_when_healthcareplatform_v2_profile_weakens_constraints",
@@ -43476,7 +44208,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L566",
       "weight": 0.8,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_passes_for_valid_v2_managed_consumer",
@@ -43488,8 +44220,32 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
-      "source_location": "L616",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
+      "source_location": "L624",
+      "weight": 0.8,
+      "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_when_consumer_profile_omits_required_session_contract_entries",
+      "_tgt": "test_verify_governance_consumer_testverifygovernanceconsumer_deploy",
+      "source": "test_verify_governance_consumer_testverifygovernanceconsumer_deploy",
+      "target": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_when_consumer_profile_omits_required_session_contract_entries",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
+      "source_location": "L648",
+      "weight": 0.8,
+      "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_when_consumer_profile_session_contract_content_is_stale",
+      "_tgt": "test_verify_governance_consumer_testverifygovernanceconsumer_deploy",
+      "source": "test_verify_governance_consumer_testverifygovernanceconsumer_deploy",
+      "target": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_when_consumer_profile_session_contract_content_is_stale",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
+      "source_location": "L678",
       "weight": 0.8,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_for_tracked_session_contract_missing_required_content",
       "_tgt": "test_verify_governance_consumer_testverifygovernanceconsumer_deploy",
@@ -43500,8 +44256,8 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
-      "source_location": "L638",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
+      "source_location": "L700",
       "weight": 0.8,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_for_hook_settings_contract_missing_post_tool_use_matcher",
       "_tgt": "test_verify_governance_consumer_testverifygovernanceconsumer_deploy",
@@ -43512,8 +44268,8 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
-      "source_location": "L672",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
+      "source_location": "L734",
       "weight": 0.8,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_passes_for_session_contract_and_hook_settings_contract_entries",
       "_tgt": "test_verify_governance_consumer_testverifygovernanceconsumer_deploy",
@@ -43524,7 +44280,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L121",
       "weight": 0.8,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_passes_for_deployed_pinned_consumer_record",
@@ -43536,7 +44292,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L131",
       "weight": 0.8,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_when_record_missing",
@@ -43548,7 +44304,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L141",
       "weight": 0.8,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_when_governance_root_is_typoed",
@@ -43560,7 +44316,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L161",
       "weight": 0.8,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_when_record_is_malformed_shape",
@@ -43572,7 +44328,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L170",
       "weight": 0.8,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_when_governance_ref_is_not_sha",
@@ -43584,7 +44340,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L188",
       "weight": 0.8,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_when_shim_missing_marker",
@@ -43596,7 +44352,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L197",
       "weight": 0.8,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_when_expected_profile_mismatches",
@@ -43608,7 +44364,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L216",
       "weight": 0.8,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_when_managed_file_record_omits_expected_path",
@@ -43620,7 +44376,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L228",
       "weight": 0.8,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_when_profile_is_unknown",
@@ -43632,7 +44388,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L245",
       "weight": 0.8,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_when_profile_is_missing",
@@ -43644,7 +44400,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L261",
       "weight": 0.8,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_for_mutable_governance_workflow_ref",
@@ -43656,7 +44412,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L276",
       "weight": 0.8,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_workflow_ref_is_tag",
@@ -43668,7 +44424,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L293",
       "weight": 0.8,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_workflow_ref_is_short_sha",
@@ -43680,7 +44436,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L311",
       "weight": 0.8,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_workflow_ref_sha_mismatch",
@@ -43692,7 +44448,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L332",
       "weight": 0.8,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_stale_workflow_ref_before_acceptance",
@@ -43704,7 +44460,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L355",
       "weight": 0.8,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_for_managed_hook_checksum_drift",
@@ -43716,7 +44472,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L370",
       "weight": 0.8,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_for_managed_hook_missing_marker",
@@ -43728,7 +44484,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L382",
       "weight": 0.8,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_for_invalid_override_metadata_and_reports_observed_override",
@@ -43740,7 +44496,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L396",
       "weight": 0.8,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_for_malformed_local_overrides",
@@ -43752,7 +44508,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L413",
       "weight": 0.8,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_override_empty_owner",
@@ -43764,7 +44520,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L428",
       "weight": 0.8,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_override_non_string_reason",
@@ -43776,7 +44532,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L447",
       "weight": 0.8,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_override_empty_expires_at",
@@ -43788,7 +44544,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L460",
       "weight": 0.8,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_override_weakens_healthcareplatform_hipaa",
@@ -43800,7 +44556,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L474",
       "weight": 0.8,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_override_disables_seek_plan_mode",
@@ -43812,7 +44568,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L488",
       "weight": 0.8,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_override_routes_pii_away_from_lam",
@@ -43824,7 +44580,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L502",
       "weight": 0.8,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_override_core_fork_without_exception",
@@ -43836,7 +44592,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L516",
       "weight": 0.8,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_override_disables_ci_required_gate",
@@ -43848,7 +44604,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L530",
       "weight": 0.8,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_override_dry_run_as_live_evidence",
@@ -43860,7 +44616,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L547",
       "weight": 0.8,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_when_healthcareplatform_v2_profile_weakens_constraints",
@@ -43872,8 +44628,8 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
-      "source_location": "L596",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
+      "source_location": "L604",
       "weight": 0.8,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_passes_for_valid_v2_managed_consumer",
       "_tgt": "test_verify_governance_consumer_testverifygovernanceconsumer_invoke",
@@ -43884,8 +44640,32 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
-      "source_location": "L630",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
+      "source_location": "L626",
+      "weight": 0.8,
+      "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_when_consumer_profile_omits_required_session_contract_entries",
+      "_tgt": "test_verify_governance_consumer_testverifygovernanceconsumer_invoke",
+      "source": "test_verify_governance_consumer_testverifygovernanceconsumer_invoke",
+      "target": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_when_consumer_profile_omits_required_session_contract_entries",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
+      "source_location": "L658",
+      "weight": 0.8,
+      "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_when_consumer_profile_session_contract_content_is_stale",
+      "_tgt": "test_verify_governance_consumer_testverifygovernanceconsumer_invoke",
+      "source": "test_verify_governance_consumer_testverifygovernanceconsumer_invoke",
+      "target": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_when_consumer_profile_session_contract_content_is_stale",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
+      "source_location": "L692",
       "weight": 0.8,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_for_tracked_session_contract_missing_required_content",
       "_tgt": "test_verify_governance_consumer_testverifygovernanceconsumer_invoke",
@@ -43896,8 +44676,8 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
-      "source_location": "L664",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
+      "source_location": "L726",
       "weight": 0.8,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_for_hook_settings_contract_missing_post_tool_use_matcher",
       "_tgt": "test_verify_governance_consumer_testverifygovernanceconsumer_invoke",
@@ -43908,8 +44688,8 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
-      "source_location": "L726",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
+      "source_location": "L820",
       "weight": 0.8,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_passes_for_session_contract_and_hook_settings_contract_entries",
       "_tgt": "test_verify_governance_consumer_testverifygovernanceconsumer_invoke",
@@ -43920,7 +44700,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L121",
       "weight": 0.8,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_passes_for_deployed_pinned_consumer_record",
@@ -43932,7 +44712,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L131",
       "weight": 0.8,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_when_record_missing",
@@ -43944,7 +44724,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L161",
       "weight": 0.8,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_when_record_is_malformed_shape",
@@ -43956,7 +44736,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L188",
       "weight": 0.8,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_when_shim_missing_marker",
@@ -43968,7 +44748,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L216",
       "weight": 0.8,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_when_managed_file_record_omits_expected_path",
@@ -43980,7 +44760,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L245",
       "weight": 0.8,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_when_profile_is_missing",
@@ -43992,7 +44772,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L261",
       "weight": 0.8,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_for_mutable_governance_workflow_ref",
@@ -44004,7 +44784,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L276",
       "weight": 0.8,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_workflow_ref_is_tag",
@@ -44016,7 +44796,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L293",
       "weight": 0.8,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_workflow_ref_is_short_sha",
@@ -44028,7 +44808,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L311",
       "weight": 0.8,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_workflow_ref_sha_mismatch",
@@ -44040,7 +44820,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L332",
       "weight": 0.8,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_stale_workflow_ref_before_acceptance",
@@ -44052,7 +44832,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L355",
       "weight": 0.8,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_for_managed_hook_checksum_drift",
@@ -44064,7 +44844,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L370",
       "weight": 0.8,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_for_managed_hook_missing_marker",
@@ -44076,7 +44856,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L382",
       "weight": 0.8,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_for_invalid_override_metadata_and_reports_observed_override",
@@ -44088,7 +44868,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L396",
       "weight": 0.8,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_for_malformed_local_overrides",
@@ -44100,7 +44880,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L413",
       "weight": 0.8,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_override_empty_owner",
@@ -44112,7 +44892,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L428",
       "weight": 0.8,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_override_non_string_reason",
@@ -44124,7 +44904,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L447",
       "weight": 0.8,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_override_empty_expires_at",
@@ -44136,7 +44916,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L460",
       "weight": 0.8,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_override_weakens_healthcareplatform_hipaa",
@@ -44148,7 +44928,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L474",
       "weight": 0.8,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_override_disables_seek_plan_mode",
@@ -44160,7 +44940,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L488",
       "weight": 0.8,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_override_routes_pii_away_from_lam",
@@ -44172,7 +44952,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L502",
       "weight": 0.8,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_override_core_fork_without_exception",
@@ -44184,7 +44964,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L516",
       "weight": 0.8,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_override_disables_ci_required_gate",
@@ -44196,7 +44976,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L530",
       "weight": 0.8,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_override_dry_run_as_live_evidence",
@@ -44208,8 +44988,8 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
-      "source_location": "L630",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
+      "source_location": "L692",
       "weight": 0.8,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_for_tracked_session_contract_missing_required_content",
       "_tgt": "test_verify_governance_consumer_testverifygovernanceconsumer_base_args",
@@ -44220,8 +45000,8 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
-      "source_location": "L664",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
+      "source_location": "L726",
       "weight": 0.8,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_for_hook_settings_contract_missing_post_tool_use_matcher",
       "_tgt": "test_verify_governance_consumer_testverifygovernanceconsumer_base_args",
@@ -44232,7 +45012,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L97",
       "weight": 0.8,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_read_record",
@@ -44244,7 +45024,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L100",
       "weight": 0.8,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_write_record",
@@ -44256,7 +45036,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L212",
       "weight": 0.8,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_when_managed_file_record_omits_expected_path",
@@ -44268,7 +45048,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L186",
       "weight": 0.8,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_when_shim_missing_marker",
@@ -44280,7 +45060,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L224",
       "weight": 0.8,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_when_profile_is_unknown",
@@ -44292,7 +45072,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L241",
       "weight": 0.8,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_when_profile_is_missing",
@@ -44304,7 +45084,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L345",
       "weight": 0.8,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_for_managed_hook_checksum_drift",
@@ -44316,7 +45096,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L366",
       "weight": 0.8,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_for_managed_hook_missing_marker",
@@ -44328,7 +45108,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L378",
       "weight": 0.8,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_for_invalid_override_metadata_and_reports_observed_override",
@@ -44340,7 +45120,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L392",
       "weight": 0.8,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_for_malformed_local_overrides",
@@ -44352,7 +45132,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L407",
       "weight": 0.8,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_override_empty_owner",
@@ -44364,7 +45144,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L422",
       "weight": 0.8,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_override_non_string_reason",
@@ -44376,7 +45156,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L437",
       "weight": 0.8,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_override_empty_expires_at",
@@ -44388,7 +45168,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L456",
       "weight": 0.8,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_override_weakens_healthcareplatform_hipaa",
@@ -44400,7 +45180,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L470",
       "weight": 0.8,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_override_disables_seek_plan_mode",
@@ -44412,7 +45192,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L484",
       "weight": 0.8,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_override_routes_pii_away_from_lam",
@@ -44424,7 +45204,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L498",
       "weight": 0.8,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_override_core_fork_without_exception",
@@ -44436,7 +45216,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L512",
       "weight": 0.8,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_override_disables_ci_required_gate",
@@ -44448,7 +45228,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L526",
       "weight": 0.8,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_override_dry_run_as_live_evidence",
@@ -44460,7 +45240,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L542",
       "weight": 0.8,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_when_healthcareplatform_v2_profile_weakens_constraints",
@@ -44472,8 +45252,8 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
-      "source_location": "L570",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
+      "source_location": "L578",
       "weight": 0.8,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_passes_for_valid_v2_managed_consumer",
       "_tgt": "test_verify_governance_consumer_testverifygovernanceconsumer_read_record",
@@ -44484,8 +45264,8 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
-      "source_location": "L619",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
+      "source_location": "L681",
       "weight": 0.8,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_for_tracked_session_contract_missing_required_content",
       "_tgt": "test_verify_governance_consumer_testverifygovernanceconsumer_read_record",
@@ -44496,8 +45276,8 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
-      "source_location": "L652",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
+      "source_location": "L714",
       "weight": 0.8,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_for_hook_settings_contract_missing_post_tool_use_matcher",
       "_tgt": "test_verify_governance_consumer_testverifygovernanceconsumer_read_record",
@@ -44508,8 +45288,8 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
-      "source_location": "L691",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
+      "source_location": "L761",
       "weight": 0.8,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_passes_for_session_contract_and_hook_settings_contract_entries",
       "_tgt": "test_verify_governance_consumer_testverifygovernanceconsumer_read_record",
@@ -44520,7 +45300,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L226",
       "weight": 0.8,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_when_profile_is_unknown",
@@ -44532,7 +45312,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L243",
       "weight": 0.8,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_when_profile_is_missing",
@@ -44544,7 +45324,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L353",
       "weight": 0.8,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_for_managed_hook_checksum_drift",
@@ -44556,7 +45336,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L368",
       "weight": 0.8,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_for_managed_hook_missing_marker",
@@ -44568,7 +45348,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L380",
       "weight": 0.8,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_for_invalid_override_metadata_and_reports_observed_override",
@@ -44580,7 +45360,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L394",
       "weight": 0.8,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_for_malformed_local_overrides",
@@ -44592,7 +45372,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L411",
       "weight": 0.8,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_override_empty_owner",
@@ -44604,7 +45384,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L426",
       "weight": 0.8,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_override_non_string_reason",
@@ -44616,7 +45396,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L445",
       "weight": 0.8,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_override_empty_expires_at",
@@ -44628,7 +45408,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L458",
       "weight": 0.8,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_override_weakens_healthcareplatform_hipaa",
@@ -44640,7 +45420,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L472",
       "weight": 0.8,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_override_disables_seek_plan_mode",
@@ -44652,7 +45432,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L486",
       "weight": 0.8,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_override_routes_pii_away_from_lam",
@@ -44664,7 +45444,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L500",
       "weight": 0.8,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_override_core_fork_without_exception",
@@ -44676,7 +45456,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L514",
       "weight": 0.8,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_override_disables_ci_required_gate",
@@ -44688,7 +45468,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L528",
       "weight": 0.8,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_override_dry_run_as_live_evidence",
@@ -44700,7 +45480,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L545",
       "weight": 0.8,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_when_healthcareplatform_v2_profile_weakens_constraints",
@@ -44712,8 +45492,8 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
-      "source_location": "L588",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
+      "source_location": "L596",
       "weight": 0.8,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_passes_for_valid_v2_managed_consumer",
       "_tgt": "test_verify_governance_consumer_testverifygovernanceconsumer_write_record",
@@ -44724,8 +45504,8 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
-      "source_location": "L628",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
+      "source_location": "L690",
       "weight": 0.8,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_for_tracked_session_contract_missing_required_content",
       "_tgt": "test_verify_governance_consumer_testverifygovernanceconsumer_write_record",
@@ -44736,8 +45516,8 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
-      "source_location": "L662",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
+      "source_location": "L724",
       "weight": 0.8,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_for_hook_settings_contract_missing_post_tool_use_matcher",
       "_tgt": "test_verify_governance_consumer_testverifygovernanceconsumer_write_record",
@@ -44748,8 +45528,8 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
-      "source_location": "L718",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
+      "source_location": "L812",
       "weight": 0.8,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_passes_for_session_contract_and_hook_settings_contract_entries",
       "_tgt": "test_verify_governance_consumer_testverifygovernanceconsumer_write_record",
@@ -44760,7 +45540,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L408",
       "weight": 0.8,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_override_empty_owner",
@@ -44772,7 +45552,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L423",
       "weight": 0.8,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_override_non_string_reason",
@@ -44784,7 +45564,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L457",
       "weight": 0.8,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_override_weakens_healthcareplatform_hipaa",
@@ -44796,7 +45576,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L471",
       "weight": 0.8,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_override_disables_seek_plan_mode",
@@ -44808,7 +45588,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L485",
       "weight": 0.8,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_override_routes_pii_away_from_lam",
@@ -44820,7 +45600,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L499",
       "weight": 0.8,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_override_core_fork_without_exception",
@@ -44832,7 +45612,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L513",
       "weight": 0.8,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_override_disables_ci_required_gate",
@@ -44844,7 +45624,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L527",
       "weight": 0.8,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_override_dry_run_as_live_evidence",
@@ -44856,7 +45636,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L539",
       "weight": 0.8,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_when_healthcareplatform_v2_profile_weakens_constraints",
@@ -44868,7 +45648,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L565",
       "weight": 0.8,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_passes_for_valid_v2_managed_consumer",
@@ -44880,8 +45660,32 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
-      "source_location": "L671",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
+      "source_location": "L624",
+      "weight": 0.8,
+      "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_when_consumer_profile_omits_required_session_contract_entries",
+      "_tgt": "test_verify_governance_consumer_testverifygovernanceconsumer_next_package_version",
+      "source": "test_verify_governance_consumer_testverifygovernanceconsumer_next_package_version",
+      "target": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_when_consumer_profile_omits_required_session_contract_entries",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
+      "source_location": "L647",
+      "weight": 0.8,
+      "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_when_consumer_profile_session_contract_content_is_stale",
+      "_tgt": "test_verify_governance_consumer_testverifygovernanceconsumer_next_package_version",
+      "source": "test_verify_governance_consumer_testverifygovernanceconsumer_next_package_version",
+      "target": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_when_consumer_profile_session_contract_content_is_stale",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
+      "source_location": "L733",
       "weight": 0.8,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_passes_for_session_contract_and_hook_settings_contract_entries",
       "_tgt": "test_verify_governance_consumer_testverifygovernanceconsumer_next_package_version",
@@ -44892,7 +45696,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
       "source_location": "L541",
       "weight": 0.8,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_fails_when_healthcareplatform_v2_profile_weakens_constraints",
@@ -44904,8 +45708,8 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
-      "source_location": "L572",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
+      "source_location": "L580",
       "weight": 0.8,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_passes_for_valid_v2_managed_consumer",
       "_tgt": "test_verify_governance_consumer_testverifygovernanceconsumer_required_constraints",
@@ -44916,8 +45720,8 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/test_verify_governance_consumer.py",
-      "source_location": "L693",
+      "source_file": "scripts/overlord/test_verify_governance_consumer.py",
+      "source_location": "L763",
       "weight": 0.8,
       "_src": "test_verify_governance_consumer_testverifygovernanceconsumer_test_verify_passes_for_session_contract_and_hook_settings_contract_entries",
       "_tgt": "test_verify_governance_consumer_testverifygovernanceconsumer_required_constraints",
@@ -45340,6 +46144,18 @@
       "source_location": "L83",
       "weight": 1.0,
       "_src": "validate_closeout",
+      "_tgt": "validate_closeout_execution_scope_refs",
+      "source": "validate_closeout",
+      "target": "validate_closeout_execution_scope_refs",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/overlord/validate_closeout.py",
+      "source_location": "L87",
+      "weight": 1.0,
+      "_src": "validate_closeout",
       "_tgt": "validate_closeout_validate_residuals",
       "source": "validate_closeout",
       "target": "validate_closeout_validate_residuals",
@@ -45349,7 +46165,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/overlord/validate_closeout.py",
-      "source_location": "L98",
+      "source_location": "L102",
       "weight": 1.0,
       "_src": "validate_closeout",
       "_tgt": "validate_closeout_validate_refs",
@@ -45361,7 +46177,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/overlord/validate_closeout.py",
-      "source_location": "L125",
+      "source_location": "L129",
       "weight": 1.0,
       "_src": "validate_closeout",
       "_tgt": "validate_closeout_validate_handoff_refs",
@@ -45373,7 +46189,19 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/overlord/validate_closeout.py",
-      "source_location": "L154",
+      "source_location": "L158",
+      "weight": 1.0,
+      "_src": "validate_closeout",
+      "_tgt": "validate_closeout_resolve_closeout_execution_mode",
+      "source": "validate_closeout",
+      "target": "validate_closeout_resolve_closeout_execution_mode",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/overlord/validate_closeout.py",
+      "source_location": "L180",
       "weight": 1.0,
       "_src": "validate_closeout",
       "_tgt": "validate_closeout_validate_closeout",
@@ -45385,7 +46213,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/overlord/validate_closeout.py",
-      "source_location": "L177",
+      "source_location": "L203",
       "weight": 1.0,
       "_src": "validate_closeout",
       "_tgt": "validate_closeout_build_parser",
@@ -45397,7 +46225,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/overlord/validate_closeout.py",
-      "source_location": "L184",
+      "source_location": "L210",
       "weight": 1.0,
       "_src": "validate_closeout",
       "_tgt": "validate_closeout_main",
@@ -45409,7 +46237,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/overlord/validate_closeout.py",
-      "source_location": "L129",
+      "source_location": "L133",
       "weight": 0.8,
       "_src": "validate_closeout_validate_handoff_refs",
       "_tgt": "validate_closeout_repo_rel",
@@ -45421,7 +46249,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/overlord/validate_closeout.py",
-      "source_location": "L162",
+      "source_location": "L188",
       "weight": 0.8,
       "_src": "validate_closeout_validate_closeout",
       "_tgt": "validate_closeout_sections",
@@ -45433,7 +46261,19 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/overlord/validate_closeout.py",
-      "source_location": "L170",
+      "source_location": "L164",
+      "weight": 0.8,
+      "_src": "validate_closeout_resolve_closeout_execution_mode",
+      "_tgt": "validate_closeout_extract_repo_refs",
+      "source": "validate_closeout_extract_repo_refs",
+      "target": "validate_closeout_resolve_closeout_execution_mode",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/overlord/validate_closeout.py",
+      "source_location": "L196",
       "weight": 0.8,
       "_src": "validate_closeout_validate_closeout",
       "_tgt": "validate_closeout_extract_repo_refs",
@@ -45445,7 +46285,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/overlord/validate_closeout.py",
-      "source_location": "L141",
+      "source_location": "L145",
       "weight": 0.8,
       "_src": "validate_closeout_validate_handoff_refs",
       "_tgt": "validate_closeout_load_json",
@@ -45457,7 +46297,31 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/overlord/validate_closeout.py",
-      "source_location": "L172",
+      "source_location": "L170",
+      "weight": 0.8,
+      "_src": "validate_closeout_resolve_closeout_execution_mode",
+      "_tgt": "validate_closeout_load_json",
+      "source": "validate_closeout_load_json",
+      "target": "validate_closeout_resolve_closeout_execution_mode",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/overlord/validate_closeout.py",
+      "source_location": "L165",
+      "weight": 0.8,
+      "_src": "validate_closeout_resolve_closeout_execution_mode",
+      "_tgt": "validate_closeout_execution_scope_refs",
+      "source": "validate_closeout_execution_scope_refs",
+      "target": "validate_closeout_resolve_closeout_execution_mode",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/overlord/validate_closeout.py",
+      "source_location": "L198",
       "weight": 0.8,
       "_src": "validate_closeout_validate_closeout",
       "_tgt": "validate_closeout_validate_residuals",
@@ -45469,7 +46333,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/overlord/validate_closeout.py",
-      "source_location": "L171",
+      "source_location": "L197",
       "weight": 0.8,
       "_src": "validate_closeout_validate_closeout",
       "_tgt": "validate_closeout_validate_refs",
@@ -45481,7 +46345,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/overlord/validate_closeout.py",
-      "source_location": "L173",
+      "source_location": "L199",
       "weight": 0.8,
       "_src": "validate_closeout_validate_closeout",
       "_tgt": "validate_closeout_validate_handoff_refs",
@@ -45493,7 +46357,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/overlord/validate_closeout.py",
-      "source_location": "L187",
+      "source_location": "L213",
       "weight": 0.8,
       "_src": "validate_closeout_main",
       "_tgt": "validate_closeout_validate_closeout",
@@ -45505,7 +46369,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/overlord/validate_closeout.py",
-      "source_location": "L185",
+      "source_location": "L211",
       "weight": 0.8,
       "_src": "validate_closeout_main",
       "_tgt": "validate_closeout_build_parser",
@@ -45684,7 +46548,7 @@
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/validate_handoff_package.py",
+      "source_file": "scripts/overlord/validate_handoff_package.py",
       "source_location": "L78",
       "weight": 1.0,
       "_src": "validate_handoff_package",
@@ -45696,7 +46560,7 @@
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/validate_handoff_package.py",
+      "source_file": "scripts/overlord/validate_handoff_package.py",
       "source_location": "L82",
       "weight": 1.0,
       "_src": "validate_handoff_package",
@@ -45708,7 +46572,7 @@
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/validate_handoff_package.py",
+      "source_file": "scripts/overlord/validate_handoff_package.py",
       "source_location": "L94",
       "weight": 1.0,
       "_src": "validate_handoff_package",
@@ -45720,7 +46584,7 @@
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/validate_handoff_package.py",
+      "source_file": "scripts/overlord/validate_handoff_package.py",
       "source_location": "L100",
       "weight": 1.0,
       "_src": "validate_handoff_package",
@@ -45732,7 +46596,7 @@
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/validate_handoff_package.py",
+      "source_file": "scripts/overlord/validate_handoff_package.py",
       "source_location": "L104",
       "weight": 1.0,
       "_src": "validate_handoff_package",
@@ -45744,7 +46608,7 @@
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/validate_handoff_package.py",
+      "source_file": "scripts/overlord/validate_handoff_package.py",
       "source_location": "L119",
       "weight": 1.0,
       "_src": "validate_handoff_package",
@@ -45756,7 +46620,7 @@
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/validate_handoff_package.py",
+      "source_file": "scripts/overlord/validate_handoff_package.py",
       "source_location": "L140",
       "weight": 1.0,
       "_src": "validate_handoff_package",
@@ -45768,7 +46632,7 @@
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/validate_handoff_package.py",
+      "source_file": "scripts/overlord/validate_handoff_package.py",
       "source_location": "L154",
       "weight": 1.0,
       "_src": "validate_handoff_package",
@@ -45780,7 +46644,7 @@
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/validate_handoff_package.py",
+      "source_file": "scripts/overlord/validate_handoff_package.py",
       "source_location": "L161",
       "weight": 1.0,
       "_src": "validate_handoff_package",
@@ -45792,7 +46656,7 @@
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/validate_handoff_package.py",
+      "source_file": "scripts/overlord/validate_handoff_package.py",
       "source_location": "L204",
       "weight": 1.0,
       "_src": "validate_handoff_package",
@@ -45804,7 +46668,7 @@
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/validate_handoff_package.py",
+      "source_file": "scripts/overlord/validate_handoff_package.py",
       "source_location": "L220",
       "weight": 1.0,
       "_src": "validate_handoff_package",
@@ -45816,7 +46680,7 @@
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/validate_handoff_package.py",
+      "source_file": "scripts/overlord/validate_handoff_package.py",
       "source_location": "L234",
       "weight": 1.0,
       "_src": "validate_handoff_package",
@@ -45828,7 +46692,7 @@
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/validate_handoff_package.py",
+      "source_file": "scripts/overlord/validate_handoff_package.py",
       "source_location": "L241",
       "weight": 1.0,
       "_src": "validate_handoff_package",
@@ -45840,7 +46704,7 @@
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/validate_handoff_package.py",
+      "source_file": "scripts/overlord/validate_handoff_package.py",
       "source_location": "L277",
       "weight": 1.0,
       "_src": "validate_handoff_package",
@@ -45852,7 +46716,7 @@
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/validate_handoff_package.py",
+      "source_file": "scripts/overlord/validate_handoff_package.py",
       "source_location": "L377",
       "weight": 1.0,
       "_src": "validate_handoff_package",
@@ -45864,7 +46728,7 @@
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/validate_handoff_package.py",
+      "source_file": "scripts/overlord/validate_handoff_package.py",
       "source_location": "L386",
       "weight": 1.0,
       "_src": "validate_handoff_package",
@@ -45876,7 +46740,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/validate_handoff_package.py",
+      "source_file": "scripts/overlord/validate_handoff_package.py",
       "source_location": "L95",
       "weight": 0.8,
       "_src": "validate_handoff_package_repo_file_exists",
@@ -45888,7 +46752,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/validate_handoff_package.py",
+      "source_file": "scripts/overlord/validate_handoff_package.py",
       "source_location": "L105",
       "weight": 0.8,
       "_src": "validate_handoff_package_read_json_ref",
@@ -45900,7 +46764,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/validate_handoff_package.py",
+      "source_file": "scripts/overlord/validate_handoff_package.py",
       "source_location": "L132",
       "weight": 0.8,
       "_src": "validate_handoff_package_validate_ref_array",
@@ -45912,7 +46776,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/validate_handoff_package.py",
+      "source_file": "scripts/overlord/validate_handoff_package.py",
       "source_location": "L191",
       "weight": 0.8,
       "_src": "validate_handoff_package_validate_acceptance_criteria",
@@ -45924,7 +46788,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/validate_handoff_package.py",
+      "source_file": "scripts/overlord/validate_handoff_package.py",
       "source_location": "L132",
       "weight": 0.8,
       "_src": "validate_handoff_package_validate_ref_array",
@@ -45936,7 +46800,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/validate_handoff_package.py",
+      "source_file": "scripts/overlord/validate_handoff_package.py",
       "source_location": "L194",
       "weight": 0.8,
       "_src": "validate_handoff_package_validate_acceptance_criteria",
@@ -45948,7 +46812,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/validate_handoff_package.py",
+      "source_file": "scripts/overlord/validate_handoff_package.py",
       "source_location": "L312",
       "weight": 0.8,
       "_src": "validate_handoff_package_validate_package",
@@ -45960,7 +46824,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/validate_handoff_package.py",
+      "source_file": "scripts/overlord/validate_handoff_package.py",
       "source_location": "L136",
       "weight": 0.8,
       "_src": "validate_handoff_package_validate_ref_array",
@@ -45972,7 +46836,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/validate_handoff_package.py",
+      "source_file": "scripts/overlord/validate_handoff_package.py",
       "source_location": "L198",
       "weight": 0.8,
       "_src": "validate_handoff_package_validate_acceptance_criteria",
@@ -45984,7 +46848,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/validate_handoff_package.py",
+      "source_file": "scripts/overlord/validate_handoff_package.py",
       "source_location": "L348",
       "weight": 0.8,
       "_src": "validate_handoff_package_validate_package",
@@ -45996,7 +46860,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/validate_handoff_package.py",
+      "source_file": "scripts/overlord/validate_handoff_package.py",
       "source_location": "L113",
       "weight": 0.8,
       "_src": "validate_handoff_package_read_json_ref",
@@ -46008,7 +46872,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/validate_handoff_package.py",
+      "source_file": "scripts/overlord/validate_handoff_package.py",
       "source_location": "L280",
       "weight": 0.8,
       "_src": "validate_handoff_package_validate_package",
@@ -46020,7 +46884,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/validate_handoff_package.py",
+      "source_file": "scripts/overlord/validate_handoff_package.py",
       "source_location": "L316",
       "weight": 0.8,
       "_src": "validate_handoff_package_validate_package",
@@ -46032,7 +46896,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/validate_handoff_package.py",
+      "source_file": "scripts/overlord/validate_handoff_package.py",
       "source_location": "L372",
       "weight": 0.8,
       "_src": "validate_handoff_package_validate_package",
@@ -46044,7 +46908,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/validate_handoff_package.py",
+      "source_file": "scripts/overlord/validate_handoff_package.py",
       "source_location": "L367",
       "weight": 0.8,
       "_src": "validate_handoff_package_validate_package",
@@ -46056,7 +46920,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/validate_handoff_package.py",
+      "source_file": "scripts/overlord/validate_handoff_package.py",
       "source_location": "L365",
       "weight": 0.8,
       "_src": "validate_handoff_package_validate_package",
@@ -46068,7 +46932,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/validate_handoff_package.py",
+      "source_file": "scripts/overlord/validate_handoff_package.py",
       "source_location": "L369",
       "weight": 0.8,
       "_src": "validate_handoff_package_validate_package",
@@ -46080,7 +46944,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/validate_handoff_package.py",
+      "source_file": "scripts/overlord/validate_handoff_package.py",
       "source_location": "L253",
       "weight": 0.8,
       "_src": "validate_handoff_package_validate_consumer_verifier_acceptance",
@@ -46092,7 +46956,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/validate_handoff_package.py",
+      "source_file": "scripts/overlord/validate_handoff_package.py",
       "source_location": "L265",
       "weight": 0.8,
       "_src": "validate_handoff_package_validate_consumer_verifier_acceptance",
@@ -46104,7 +46968,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/validate_handoff_package.py",
+      "source_file": "scripts/overlord/validate_handoff_package.py",
       "source_location": "L249",
       "weight": 0.8,
       "_src": "validate_handoff_package_validate_consumer_verifier_acceptance",
@@ -46116,7 +46980,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/validate_handoff_package.py",
+      "source_file": "scripts/overlord/validate_handoff_package.py",
       "source_location": "L370",
       "weight": 0.8,
       "_src": "validate_handoff_package_validate_package",
@@ -46128,7 +46992,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/validate_handoff_package.py",
+      "source_file": "scripts/overlord/validate_handoff_package.py",
       "source_location": "L398",
       "weight": 0.8,
       "_src": "validate_handoff_package_main",
@@ -46140,7 +47004,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/validate_handoff_package.py",
+      "source_file": "scripts/overlord/validate_handoff_package.py",
       "source_location": "L393",
       "weight": 0.8,
       "_src": "validate_handoff_package_main",
@@ -46704,7 +47568,7 @@
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/validate_session_contract_surfaces.py",
+      "source_file": "scripts/overlord/validate_session_contract_surfaces.py",
       "source_location": "L18",
       "weight": 1.0,
       "_src": "validate_session_contract_surfaces",
@@ -46716,7 +47580,7 @@
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/validate_session_contract_surfaces.py",
+      "source_file": "scripts/overlord/validate_session_contract_surfaces.py",
       "source_location": "L38",
       "weight": 1.0,
       "_src": "validate_session_contract_surfaces",
@@ -46728,7 +47592,7 @@
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/validate_session_contract_surfaces.py",
+      "source_file": "scripts/overlord/validate_session_contract_surfaces.py",
       "source_location": "L77",
       "weight": 1.0,
       "_src": "validate_session_contract_surfaces",
@@ -46740,7 +47604,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/validate_session_contract_surfaces.py",
+      "source_file": "scripts/overlord/validate_session_contract_surfaces.py",
       "source_location": "L56",
       "weight": 0.8,
       "_src": "validate_session_contract_surfaces_validate",
@@ -46752,7 +47616,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/validate_session_contract_surfaces.py",
+      "source_file": "scripts/overlord/validate_session_contract_surfaces.py",
       "source_location": "L83",
       "weight": 0.8,
       "_src": "validate_session_contract_surfaces_main",
@@ -47304,8 +48168,8 @@
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/validate_structured_agent_cycle_plan.py",
-      "source_location": "L54",
+      "source_file": "scripts/overlord/validate_structured_agent_cycle_plan.py",
+      "source_location": "L71",
       "weight": 1.0,
       "_src": "validate_structured_agent_cycle_plan",
       "_tgt": "validate_structured_agent_cycle_plan_display_path",
@@ -47316,8 +48180,8 @@
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/validate_structured_agent_cycle_plan.py",
-      "source_location": "L61",
+      "source_file": "scripts/overlord/validate_structured_agent_cycle_plan.py",
+      "source_location": "L78",
       "weight": 1.0,
       "_src": "validate_structured_agent_cycle_plan",
       "_tgt": "validate_structured_agent_cycle_plan_load_json_safe",
@@ -47328,8 +48192,8 @@
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/validate_structured_agent_cycle_plan.py",
-      "source_location": "L69",
+      "source_file": "scripts/overlord/validate_structured_agent_cycle_plan.py",
+      "source_location": "L86",
       "weight": 1.0,
       "_src": "validate_structured_agent_cycle_plan",
       "_tgt": "validate_structured_agent_cycle_plan_find_plan_files",
@@ -47340,8 +48204,8 @@
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/validate_structured_agent_cycle_plan.py",
-      "source_location": "L73",
+      "source_file": "scripts/overlord/validate_structured_agent_cycle_plan.py",
+      "source_location": "L90",
       "weight": 1.0,
       "_src": "validate_structured_agent_cycle_plan",
       "_tgt": "validate_structured_agent_cycle_plan_require",
@@ -47352,8 +48216,8 @@
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/validate_structured_agent_cycle_plan.py",
-      "source_location": "L78",
+      "source_file": "scripts/overlord/validate_structured_agent_cycle_plan.py",
+      "source_location": "L95",
       "weight": 1.0,
       "_src": "validate_structured_agent_cycle_plan",
       "_tgt": "validate_structured_agent_cycle_plan_branch_issue_number",
@@ -47364,8 +48228,8 @@
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/validate_structured_agent_cycle_plan.py",
-      "source_location": "L83",
+      "source_file": "scripts/overlord/validate_structured_agent_cycle_plan.py",
+      "source_location": "L100",
       "weight": 1.0,
       "_src": "validate_structured_agent_cycle_plan",
       "_tgt": "validate_structured_agent_cycle_plan_is_governance_surface",
@@ -47376,8 +48240,8 @@
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/validate_structured_agent_cycle_plan.py",
-      "source_location": "L92",
+      "source_file": "scripts/overlord/validate_structured_agent_cycle_plan.py",
+      "source_location": "L109",
       "weight": 1.0,
       "_src": "validate_structured_agent_cycle_plan",
       "_tgt": "validate_structured_agent_cycle_plan_read_changed_files",
@@ -47388,8 +48252,20 @@
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/validate_structured_agent_cycle_plan.py",
-      "source_location": "L98",
+      "source_file": "scripts/overlord/validate_structured_agent_cycle_plan.py",
+      "source_location": "L115",
+      "weight": 1.0,
+      "_src": "validate_structured_agent_cycle_plan",
+      "_tgt": "validate_structured_agent_cycle_plan_is_planning_evidence_surface",
+      "source": "validate_structured_agent_cycle_plan",
+      "target": "validate_structured_agent_cycle_plan_is_planning_evidence_surface",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/overlord/validate_structured_agent_cycle_plan.py",
+      "source_location": "L124",
       "weight": 1.0,
       "_src": "validate_structured_agent_cycle_plan",
       "_tgt": "validate_structured_agent_cycle_plan_matching_plan_payloads",
@@ -47400,8 +48276,8 @@
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/validate_structured_agent_cycle_plan.py",
-      "source_location": "L112",
+      "source_file": "scripts/overlord/validate_structured_agent_cycle_plan.py",
+      "source_location": "L138",
       "weight": 1.0,
       "_src": "validate_structured_agent_cycle_plan",
       "_tgt": "validate_structured_agent_cycle_plan_matching_execution_scopes",
@@ -47412,8 +48288,56 @@
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/validate_structured_agent_cycle_plan.py",
-      "source_location": "L121",
+      "source_file": "scripts/overlord/validate_structured_agent_cycle_plan.py",
+      "source_location": "L147",
+      "weight": 1.0,
+      "_src": "validate_structured_agent_cycle_plan",
+      "_tgt": "validate_structured_agent_cycle_plan_require_identity",
+      "source": "validate_structured_agent_cycle_plan",
+      "target": "validate_structured_agent_cycle_plan_require_identity",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/overlord/validate_structured_agent_cycle_plan.py",
+      "source_location": "L169",
+      "weight": 1.0,
+      "_src": "validate_structured_agent_cycle_plan",
+      "_tgt": "validate_structured_agent_cycle_plan_require_repo_ref_array",
+      "source": "validate_structured_agent_cycle_plan",
+      "target": "validate_structured_agent_cycle_plan_require_repo_ref_array",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/overlord/validate_structured_agent_cycle_plan.py",
+      "source_location": "L197",
+      "weight": 1.0,
+      "_src": "validate_structured_agent_cycle_plan",
+      "_tgt": "validate_structured_agent_cycle_plan_validate_alternate_review_exemption",
+      "source": "validate_structured_agent_cycle_plan",
+      "target": "validate_structured_agent_cycle_plan_validate_alternate_review_exemption",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/overlord/validate_structured_agent_cycle_plan.py",
+      "source_location": "L227",
+      "weight": 1.0,
+      "_src": "validate_structured_agent_cycle_plan",
+      "_tgt": "validate_structured_agent_cycle_plan_validate_active_issue_branch_contract",
+      "source": "validate_structured_agent_cycle_plan",
+      "target": "validate_structured_agent_cycle_plan_validate_active_issue_branch_contract",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/overlord/validate_structured_agent_cycle_plan.py",
+      "source_location": "L284",
       "weight": 1.0,
       "_src": "validate_structured_agent_cycle_plan",
       "_tgt": "validate_structured_agent_cycle_plan_validate_planner_boundary_scope_presence",
@@ -47424,8 +48348,8 @@
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/validate_structured_agent_cycle_plan.py",
-      "source_location": "L153",
+      "source_file": "scripts/overlord/validate_structured_agent_cycle_plan.py",
+      "source_location": "L316",
       "weight": 1.0,
       "_src": "validate_structured_agent_cycle_plan",
       "_tgt": "validate_structured_agent_cycle_plan_validate_implementation_ready_plan",
@@ -47436,8 +48360,20 @@
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/validate_structured_agent_cycle_plan.py",
-      "source_location": "L171",
+      "source_file": "scripts/overlord/validate_structured_agent_cycle_plan.py",
+      "source_location": "L334",
+      "weight": 1.0,
+      "_src": "validate_structured_agent_cycle_plan",
+      "_tgt": "validate_structured_agent_cycle_plan_validate_planning_evidence_plan",
+      "source": "validate_structured_agent_cycle_plan",
+      "target": "validate_structured_agent_cycle_plan_validate_planning_evidence_plan",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/overlord/validate_structured_agent_cycle_plan.py",
+      "source_location": "L359",
       "weight": 1.0,
       "_src": "validate_structured_agent_cycle_plan",
       "_tgt": "validate_structured_agent_cycle_plan_validate_implementation_ready_alternate_review",
@@ -47448,8 +48384,8 @@
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/validate_structured_agent_cycle_plan.py",
-      "source_location": "L206",
+      "source_file": "scripts/overlord/validate_structured_agent_cycle_plan.py",
+      "source_location": "L394",
       "weight": 1.0,
       "_src": "validate_structured_agent_cycle_plan",
       "_tgt": "validate_structured_agent_cycle_plan_validate_file",
@@ -47460,8 +48396,8 @@
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/validate_structured_agent_cycle_plan.py",
-      "source_location": "L283",
+      "source_file": "scripts/overlord/validate_structured_agent_cycle_plan.py",
+      "source_location": "L471",
       "weight": 1.0,
       "_src": "validate_structured_agent_cycle_plan",
       "_tgt": "validate_structured_agent_cycle_plan_main",
@@ -47472,8 +48408,8 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/validate_structured_agent_cycle_plan.py",
-      "source_location": "L65",
+      "source_file": "scripts/overlord/validate_structured_agent_cycle_plan.py",
+      "source_location": "L82",
       "weight": 0.8,
       "_src": "validate_structured_agent_cycle_plan_load_json_safe",
       "_tgt": "validate_structured_agent_cycle_plan_display_path",
@@ -47484,8 +48420,8 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/validate_structured_agent_cycle_plan.py",
-      "source_location": "L296",
+      "source_file": "scripts/overlord/validate_structured_agent_cycle_plan.py",
+      "source_location": "L484",
       "weight": 0.8,
       "_src": "validate_structured_agent_cycle_plan_main",
       "_tgt": "validate_structured_agent_cycle_plan_load_json_safe",
@@ -47496,8 +48432,8 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/validate_structured_agent_cycle_plan.py",
-      "source_location": "L294",
+      "source_file": "scripts/overlord/validate_structured_agent_cycle_plan.py",
+      "source_location": "L482",
       "weight": 0.8,
       "_src": "validate_structured_agent_cycle_plan_main",
       "_tgt": "validate_structured_agent_cycle_plan_find_plan_files",
@@ -47508,8 +48444,8 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/validate_structured_agent_cycle_plan.py",
-      "source_location": "L157",
+      "source_file": "scripts/overlord/validate_structured_agent_cycle_plan.py",
+      "source_location": "L320",
       "weight": 0.8,
       "_src": "validate_structured_agent_cycle_plan_validate_implementation_ready_plan",
       "_tgt": "validate_structured_agent_cycle_plan_require",
@@ -47520,8 +48456,20 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/validate_structured_agent_cycle_plan.py",
-      "source_location": "L193",
+      "source_file": "scripts/overlord/validate_structured_agent_cycle_plan.py",
+      "source_location": "L338",
+      "weight": 0.8,
+      "_src": "validate_structured_agent_cycle_plan_validate_planning_evidence_plan",
+      "_tgt": "validate_structured_agent_cycle_plan_require",
+      "source": "validate_structured_agent_cycle_plan_require",
+      "target": "validate_structured_agent_cycle_plan_validate_planning_evidence_plan",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/overlord/validate_structured_agent_cycle_plan.py",
+      "source_location": "L381",
       "weight": 0.8,
       "_src": "validate_structured_agent_cycle_plan_validate_implementation_ready_alternate_review",
       "_tgt": "validate_structured_agent_cycle_plan_require",
@@ -47532,8 +48480,8 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/validate_structured_agent_cycle_plan.py",
-      "source_location": "L230",
+      "source_file": "scripts/overlord/validate_structured_agent_cycle_plan.py",
+      "source_location": "L418",
       "weight": 0.8,
       "_src": "validate_structured_agent_cycle_plan_validate_file",
       "_tgt": "validate_structured_agent_cycle_plan_require",
@@ -47544,8 +48492,8 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/validate_structured_agent_cycle_plan.py",
-      "source_location": "L131",
+      "source_file": "scripts/overlord/validate_structured_agent_cycle_plan.py",
+      "source_location": "L294",
       "weight": 0.8,
       "_src": "validate_structured_agent_cycle_plan_validate_planner_boundary_scope_presence",
       "_tgt": "validate_structured_agent_cycle_plan_branch_issue_number",
@@ -47556,8 +48504,8 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/validate_structured_agent_cycle_plan.py",
-      "source_location": "L306",
+      "source_file": "scripts/overlord/validate_structured_agent_cycle_plan.py",
+      "source_location": "L494",
       "weight": 0.8,
       "_src": "validate_structured_agent_cycle_plan_main",
       "_tgt": "validate_structured_agent_cycle_plan_branch_issue_number",
@@ -47568,8 +48516,8 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/validate_structured_agent_cycle_plan.py",
-      "source_location": "L127",
+      "source_file": "scripts/overlord/validate_structured_agent_cycle_plan.py",
+      "source_location": "L290",
       "weight": 0.8,
       "_src": "validate_structured_agent_cycle_plan_validate_planner_boundary_scope_presence",
       "_tgt": "validate_structured_agent_cycle_plan_is_governance_surface",
@@ -47580,8 +48528,8 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/validate_structured_agent_cycle_plan.py",
-      "source_location": "L305",
+      "source_file": "scripts/overlord/validate_structured_agent_cycle_plan.py",
+      "source_location": "L493",
       "weight": 0.8,
       "_src": "validate_structured_agent_cycle_plan_main",
       "_tgt": "validate_structured_agent_cycle_plan_is_governance_surface",
@@ -47592,8 +48540,8 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/validate_structured_agent_cycle_plan.py",
-      "source_location": "L304",
+      "source_file": "scripts/overlord/validate_structured_agent_cycle_plan.py",
+      "source_location": "L492",
       "weight": 0.8,
       "_src": "validate_structured_agent_cycle_plan_main",
       "_tgt": "validate_structured_agent_cycle_plan_read_changed_files",
@@ -47604,8 +48552,20 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/validate_structured_agent_cycle_plan.py",
-      "source_location": "L314",
+      "source_file": "scripts/overlord/validate_structured_agent_cycle_plan.py",
+      "source_location": "L497",
+      "weight": 0.8,
+      "_src": "validate_structured_agent_cycle_plan_main",
+      "_tgt": "validate_structured_agent_cycle_plan_is_planning_evidence_surface",
+      "source": "validate_structured_agent_cycle_plan_is_planning_evidence_surface",
+      "target": "validate_structured_agent_cycle_plan_main",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/overlord/validate_structured_agent_cycle_plan.py",
+      "source_location": "L503",
       "weight": 0.8,
       "_src": "validate_structured_agent_cycle_plan_main",
       "_tgt": "validate_structured_agent_cycle_plan_matching_plan_payloads",
@@ -47616,8 +48576,8 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/validate_structured_agent_cycle_plan.py",
-      "source_location": "L139",
+      "source_file": "scripts/overlord/validate_structured_agent_cycle_plan.py",
+      "source_location": "L302",
       "weight": 0.8,
       "_src": "validate_structured_agent_cycle_plan_validate_planner_boundary_scope_presence",
       "_tgt": "validate_structured_agent_cycle_plan_matching_execution_scopes",
@@ -47628,8 +48588,56 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/validate_structured_agent_cycle_plan.py",
-      "source_location": "L326",
+      "source_file": "scripts/overlord/validate_structured_agent_cycle_plan.py",
+      "source_location": "L228",
+      "weight": 0.8,
+      "_src": "validate_structured_agent_cycle_plan_validate_active_issue_branch_contract",
+      "_tgt": "validate_structured_agent_cycle_plan_require_identity",
+      "source": "validate_structured_agent_cycle_plan_require_identity",
+      "target": "validate_structured_agent_cycle_plan_validate_active_issue_branch_contract",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/overlord/validate_structured_agent_cycle_plan.py",
+      "source_location": "L274",
+      "weight": 0.8,
+      "_src": "validate_structured_agent_cycle_plan_validate_active_issue_branch_contract",
+      "_tgt": "validate_structured_agent_cycle_plan_require_repo_ref_array",
+      "source": "validate_structured_agent_cycle_plan_require_repo_ref_array",
+      "target": "validate_structured_agent_cycle_plan_validate_active_issue_branch_contract",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/overlord/validate_structured_agent_cycle_plan.py",
+      "source_location": "L260",
+      "weight": 0.8,
+      "_src": "validate_structured_agent_cycle_plan_validate_active_issue_branch_contract",
+      "_tgt": "validate_structured_agent_cycle_plan_validate_alternate_review_exemption",
+      "source": "validate_structured_agent_cycle_plan_validate_alternate_review_exemption",
+      "target": "validate_structured_agent_cycle_plan_validate_active_issue_branch_contract",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/overlord/validate_structured_agent_cycle_plan.py",
+      "source_location": "L527",
+      "weight": 0.8,
+      "_src": "validate_structured_agent_cycle_plan_main",
+      "_tgt": "validate_structured_agent_cycle_plan_validate_active_issue_branch_contract",
+      "source": "validate_structured_agent_cycle_plan_validate_active_issue_branch_contract",
+      "target": "validate_structured_agent_cycle_plan_main",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/overlord/validate_structured_agent_cycle_plan.py",
+      "source_location": "L518",
       "weight": 0.8,
       "_src": "validate_structured_agent_cycle_plan_main",
       "_tgt": "validate_structured_agent_cycle_plan_validate_planner_boundary_scope_presence",
@@ -47640,8 +48648,8 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/validate_structured_agent_cycle_plan.py",
-      "source_location": "L168",
+      "source_file": "scripts/overlord/validate_structured_agent_cycle_plan.py",
+      "source_location": "L331",
       "weight": 0.8,
       "_src": "validate_structured_agent_cycle_plan_validate_implementation_ready_plan",
       "_tgt": "validate_structured_agent_cycle_plan_validate_implementation_ready_alternate_review",
@@ -47652,8 +48660,8 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/validate_structured_agent_cycle_plan.py",
-      "source_location": "L322",
+      "source_file": "scripts/overlord/validate_structured_agent_cycle_plan.py",
+      "source_location": "L514",
       "weight": 0.8,
       "_src": "validate_structured_agent_cycle_plan_main",
       "_tgt": "validate_structured_agent_cycle_plan_validate_implementation_ready_plan",
@@ -47664,8 +48672,20 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/validate_structured_agent_cycle_plan.py",
-      "source_location": "L333",
+      "source_file": "scripts/overlord/validate_structured_agent_cycle_plan.py",
+      "source_location": "L512",
+      "weight": 0.8,
+      "_src": "validate_structured_agent_cycle_plan_main",
+      "_tgt": "validate_structured_agent_cycle_plan_validate_planning_evidence_plan",
+      "source": "validate_structured_agent_cycle_plan_validate_planning_evidence_plan",
+      "target": "validate_structured_agent_cycle_plan_main",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/overlord/validate_structured_agent_cycle_plan.py",
+      "source_location": "L525",
       "weight": 0.8,
       "_src": "validate_structured_agent_cycle_plan_main",
       "_tgt": "validate_structured_agent_cycle_plan_validate_implementation_ready_alternate_review",
@@ -47676,8 +48696,8 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/validate_structured_agent_cycle_plan.py",
-      "source_location": "L337",
+      "source_file": "scripts/overlord/validate_structured_agent_cycle_plan.py",
+      "source_location": "L531",
       "weight": 0.8,
       "_src": "validate_structured_agent_cycle_plan_main",
       "_tgt": "validate_structured_agent_cycle_plan_validate_file",
@@ -47688,7 +48708,7 @@
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/verify_governance_consumer.py",
+      "source_file": "scripts/overlord/verify_governance_consumer.py",
       "source_location": "L76",
       "weight": 1.0,
       "_src": "verify_governance_consumer",
@@ -47700,7 +48720,7 @@
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/verify_governance_consumer.py",
+      "source_file": "scripts/overlord/verify_governance_consumer.py",
       "source_location": "L81",
       "weight": 1.0,
       "_src": "verify_governance_consumer",
@@ -47712,7 +48732,7 @@
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/verify_governance_consumer.py",
+      "source_file": "scripts/overlord/verify_governance_consumer.py",
       "source_location": "L86",
       "weight": 1.0,
       "_src": "verify_governance_consumer",
@@ -47724,7 +48744,7 @@
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/verify_governance_consumer.py",
+      "source_file": "scripts/overlord/verify_governance_consumer.py",
       "source_location": "L90",
       "weight": 1.0,
       "_src": "verify_governance_consumer",
@@ -47736,7 +48756,7 @@
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/verify_governance_consumer.py",
+      "source_file": "scripts/overlord/verify_governance_consumer.py",
       "source_location": "L94",
       "weight": 1.0,
       "_src": "verify_governance_consumer",
@@ -47748,7 +48768,7 @@
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/verify_governance_consumer.py",
+      "source_file": "scripts/overlord/verify_governance_consumer.py",
       "source_location": "L101",
       "weight": 1.0,
       "_src": "verify_governance_consumer",
@@ -47760,7 +48780,7 @@
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/verify_governance_consumer.py",
+      "source_file": "scripts/overlord/verify_governance_consumer.py",
       "source_location": "L113",
       "weight": 1.0,
       "_src": "verify_governance_consumer",
@@ -47772,7 +48792,7 @@
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/verify_governance_consumer.py",
+      "source_file": "scripts/overlord/verify_governance_consumer.py",
       "source_location": "L122",
       "weight": 1.0,
       "_src": "verify_governance_consumer",
@@ -47784,7 +48804,7 @@
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/verify_governance_consumer.py",
+      "source_file": "scripts/overlord/verify_governance_consumer.py",
       "source_location": "L143",
       "weight": 1.0,
       "_src": "verify_governance_consumer",
@@ -47796,7 +48816,7 @@
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/verify_governance_consumer.py",
+      "source_file": "scripts/overlord/verify_governance_consumer.py",
       "source_location": "L152",
       "weight": 1.0,
       "_src": "verify_governance_consumer",
@@ -47808,8 +48828,20 @@
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/verify_governance_consumer.py",
+      "source_file": "scripts/overlord/verify_governance_consumer.py",
       "source_location": "L160",
+      "weight": 1.0,
+      "_src": "verify_governance_consumer",
+      "_tgt": "verify_governance_consumer_profile_package_version",
+      "source": "verify_governance_consumer",
+      "target": "verify_governance_consumer_profile_package_version",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/overlord/verify_governance_consumer.py",
+      "source_location": "L165",
       "weight": 1.0,
       "_src": "verify_governance_consumer",
       "_tgt": "verify_governance_consumer_profile_contract",
@@ -47820,8 +48852,8 @@
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/verify_governance_consumer.py",
-      "source_location": "L165",
+      "source_file": "scripts/overlord/verify_governance_consumer.py",
+      "source_location": "L170",
       "weight": 1.0,
       "_src": "verify_governance_consumer",
       "_tgt": "verify_governance_consumer_manifest_profiles",
@@ -47832,8 +48864,8 @@
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/verify_governance_consumer.py",
-      "source_location": "L170",
+      "source_file": "scripts/overlord/verify_governance_consumer.py",
+      "source_location": "L175",
       "weight": 1.0,
       "_src": "verify_governance_consumer",
       "_tgt": "verify_governance_consumer_known_profiles",
@@ -47844,8 +48876,8 @@
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/verify_governance_consumer.py",
-      "source_location": "L178",
+      "source_file": "scripts/overlord/verify_governance_consumer.py",
+      "source_location": "L183",
       "weight": 1.0,
       "_src": "verify_governance_consumer",
       "_tgt": "verify_governance_consumer_next_package_version",
@@ -47856,8 +48888,8 @@
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/verify_governance_consumer.py",
-      "source_location": "L187",
+      "source_file": "scripts/overlord/verify_governance_consumer.py",
+      "source_location": "L192",
       "weight": 1.0,
       "_src": "verify_governance_consumer",
       "_tgt": "verify_governance_consumer_is_v2_record",
@@ -47868,8 +48900,8 @@
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/verify_governance_consumer.py",
-      "source_location": "L197",
+      "source_file": "scripts/overlord/verify_governance_consumer.py",
+      "source_location": "L202",
       "weight": 1.0,
       "_src": "verify_governance_consumer",
       "_tgt": "verify_governance_consumer_profile_required_constraints",
@@ -47880,8 +48912,8 @@
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/verify_governance_consumer.py",
-      "source_location": "L207",
+      "source_file": "scripts/overlord/verify_governance_consumer.py",
+      "source_location": "L212",
       "weight": 1.0,
       "_src": "verify_governance_consumer",
       "_tgt": "verify_governance_consumer_record_constraints",
@@ -47892,20 +48924,20 @@
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/verify_governance_consumer.py",
-      "source_location": "L219",
+      "source_file": "scripts/overlord/verify_governance_consumer.py",
+      "source_location": "L224",
       "weight": 1.0,
       "_src": "verify_governance_consumer",
-      "_tgt": "verify_governance_consumer_expected_managed_paths",
+      "_tgt": "verify_governance_consumer_expected_managed_entries",
       "source": "verify_governance_consumer",
-      "target": "verify_governance_consumer_expected_managed_paths",
+      "target": "verify_governance_consumer_expected_managed_entries",
       "confidence_score": 1.0
     },
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/verify_governance_consumer.py",
-      "source_location": "L226",
+      "source_file": "scripts/overlord/verify_governance_consumer.py",
+      "source_location": "L245",
       "weight": 1.0,
       "_src": "verify_governance_consumer",
       "_tgt": "verify_governance_consumer_managed_paths",
@@ -47916,8 +48948,20 @@
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/verify_governance_consumer.py",
-      "source_location": "L237",
+      "source_file": "scripts/overlord/verify_governance_consumer.py",
+      "source_location": "L256",
+      "weight": 1.0,
+      "_src": "verify_governance_consumer",
+      "_tgt": "verify_governance_consumer_string_list_or_none",
+      "source": "verify_governance_consumer",
+      "target": "verify_governance_consumer_string_list_or_none",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/overlord/verify_governance_consumer.py",
+      "source_location": "L264",
       "weight": 1.0,
       "_src": "verify_governance_consumer",
       "_tgt": "verify_governance_consumer_managed_file_type",
@@ -47928,8 +48972,8 @@
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/verify_governance_consumer.py",
-      "source_location": "L247",
+      "source_file": "scripts/overlord/verify_governance_consumer.py",
+      "source_location": "L274",
       "weight": 1.0,
       "_src": "verify_governance_consumer",
       "_tgt": "verify_governance_consumer_managed_file_entry",
@@ -47940,8 +48984,20 @@
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/verify_governance_consumer.py",
-      "source_location": "L257",
+      "source_file": "scripts/overlord/verify_governance_consumer.py",
+      "source_location": "L284",
+      "weight": 1.0,
+      "_src": "verify_governance_consumer",
+      "_tgt": "verify_governance_consumer_expected_entry_failures",
+      "source": "verify_governance_consumer",
+      "target": "verify_governance_consumer_expected_entry_failures",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/overlord/verify_governance_consumer.py",
+      "source_location": "L303",
       "weight": 1.0,
       "_src": "verify_governance_consumer",
       "_tgt": "verify_governance_consumer_string_list",
@@ -47952,8 +49008,8 @@
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/verify_governance_consumer.py",
-      "source_location": "L263",
+      "source_file": "scripts/overlord/verify_governance_consumer.py",
+      "source_location": "L309",
       "weight": 1.0,
       "_src": "verify_governance_consumer",
       "_tgt": "verify_governance_consumer_managed_markers",
@@ -47964,8 +49020,8 @@
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/verify_governance_consumer.py",
-      "source_location": "L272",
+      "source_file": "scripts/overlord/verify_governance_consumer.py",
+      "source_location": "L318",
       "weight": 1.0,
       "_src": "verify_governance_consumer",
       "_tgt": "verify_governance_consumer_managed_settings_matchers",
@@ -47976,8 +49032,8 @@
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/verify_governance_consumer.py",
-      "source_location": "L288",
+      "source_file": "scripts/overlord/verify_governance_consumer.py",
+      "source_location": "L334",
       "weight": 1.0,
       "_src": "verify_governance_consumer",
       "_tgt": "verify_governance_consumer_managed_file_content_failures",
@@ -47988,8 +49044,8 @@
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/verify_governance_consumer.py",
-      "source_location": "L317",
+      "source_file": "scripts/overlord/verify_governance_consumer.py",
+      "source_location": "L363",
       "weight": 1.0,
       "_src": "verify_governance_consumer",
       "_tgt": "verify_governance_consumer_expected_checksum",
@@ -48000,8 +49056,8 @@
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/verify_governance_consumer.py",
-      "source_location": "L325",
+      "source_file": "scripts/overlord/verify_governance_consumer.py",
+      "source_location": "L371",
       "weight": 1.0,
       "_src": "verify_governance_consumer",
       "_tgt": "verify_governance_consumer_non_empty_string",
@@ -48012,8 +49068,8 @@
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/verify_governance_consumer.py",
-      "source_location": "L329",
+      "source_file": "scripts/overlord/verify_governance_consumer.py",
+      "source_location": "L375",
       "weight": 1.0,
       "_src": "verify_governance_consumer",
       "_tgt": "verify_governance_consumer_override_text",
@@ -48024,8 +49080,8 @@
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/verify_governance_consumer.py",
-      "source_location": "L333",
+      "source_file": "scripts/overlord/verify_governance_consumer.py",
+      "source_location": "L379",
       "weight": 1.0,
       "_src": "verify_governance_consumer",
       "_tgt": "verify_governance_consumer_contains_negated_forbidden_action",
@@ -48036,8 +49092,8 @@
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/verify_governance_consumer.py",
-      "source_location": "L345",
+      "source_file": "scripts/overlord/verify_governance_consumer.py",
+      "source_location": "L391",
       "weight": 1.0,
       "_src": "verify_governance_consumer",
       "_tgt": "verify_governance_consumer_forbidden_override_failures",
@@ -48048,8 +49104,8 @@
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/verify_governance_consumer.py",
-      "source_location": "L360",
+      "source_file": "scripts/overlord/verify_governance_consumer.py",
+      "source_location": "L406",
       "weight": 1.0,
       "_src": "verify_governance_consumer",
       "_tgt": "verify_governance_consumer_is_relative_to",
@@ -48060,8 +49116,8 @@
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/verify_governance_consumer.py",
-      "source_location": "L368",
+      "source_file": "scripts/overlord/verify_governance_consumer.py",
+      "source_location": "L414",
       "weight": 1.0,
       "_src": "verify_governance_consumer",
       "_tgt": "verify_governance_consumer_load_consumer_record",
@@ -48072,8 +49128,8 @@
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/verify_governance_consumer.py",
-      "source_location": "L377",
+      "source_file": "scripts/overlord/verify_governance_consumer.py",
+      "source_location": "L423",
       "weight": 1.0,
       "_src": "verify_governance_consumer",
       "_tgt": "verify_governance_consumer_override_records",
@@ -48084,8 +49140,8 @@
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/verify_governance_consumer.py",
-      "source_location": "L408",
+      "source_file": "scripts/overlord/verify_governance_consumer.py",
+      "source_location": "L454",
       "weight": 1.0,
       "_src": "verify_governance_consumer",
       "_tgt": "verify_governance_consumer_workflow_ref_failures",
@@ -48096,8 +49152,8 @@
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/verify_governance_consumer.py",
-      "source_location": "L428",
+      "source_file": "scripts/overlord/verify_governance_consumer.py",
+      "source_location": "L474",
       "weight": 1.0,
       "_src": "verify_governance_consumer",
       "_tgt": "verify_governance_consumer_validate_record",
@@ -48108,8 +49164,8 @@
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/verify_governance_consumer.py",
-      "source_location": "L538",
+      "source_file": "scripts/overlord/verify_governance_consumer.py",
+      "source_location": "L592",
       "weight": 1.0,
       "_src": "verify_governance_consumer",
       "_tgt": "verify_governance_consumer_verify",
@@ -48120,8 +49176,8 @@
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/verify_governance_consumer.py",
-      "source_location": "L584",
+      "source_file": "scripts/overlord/verify_governance_consumer.py",
+      "source_location": "L638",
       "weight": 1.0,
       "_src": "verify_governance_consumer",
       "_tgt": "verify_governance_consumer_print_json",
@@ -48132,8 +49188,8 @@
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/verify_governance_consumer.py",
-      "source_location": "L589",
+      "source_file": "scripts/overlord/verify_governance_consumer.py",
+      "source_location": "L643",
       "weight": 1.0,
       "_src": "verify_governance_consumer",
       "_tgt": "verify_governance_consumer_build_parser",
@@ -48144,8 +49200,8 @@
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/verify_governance_consumer.py",
-      "source_location": "L603",
+      "source_file": "scripts/overlord/verify_governance_consumer.py",
+      "source_location": "L657",
       "weight": 1.0,
       "_src": "verify_governance_consumer",
       "_tgt": "verify_governance_consumer_main",
@@ -48156,7 +49212,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/verify_governance_consumer.py",
+      "source_file": "scripts/overlord/verify_governance_consumer.py",
       "source_location": "L87",
       "weight": 0.8,
       "_src": "verify_governance_consumer_fail",
@@ -48168,8 +49224,8 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/verify_governance_consumer.py",
-      "source_location": "L374",
+      "source_file": "scripts/overlord/verify_governance_consumer.py",
+      "source_location": "L420",
       "weight": 0.8,
       "_src": "verify_governance_consumer_load_consumer_record",
       "_tgt": "verify_governance_consumer_consumerrecord",
@@ -48180,7 +49236,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/verify_governance_consumer.py",
+      "source_file": "scripts/overlord/verify_governance_consumer.py",
       "source_location": "L97",
       "weight": 0.8,
       "_src": "verify_governance_consumer_git_root",
@@ -48192,7 +49248,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/verify_governance_consumer.py",
+      "source_file": "scripts/overlord/verify_governance_consumer.py",
       "source_location": "L105",
       "weight": 0.8,
       "_src": "verify_governance_consumer_load_json",
@@ -48204,8 +49260,8 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/verify_governance_consumer.py",
-      "source_location": "L371",
+      "source_file": "scripts/overlord/verify_governance_consumer.py",
+      "source_location": "L417",
       "weight": 0.8,
       "_src": "verify_governance_consumer_load_consumer_record",
       "_tgt": "verify_governance_consumer_fail",
@@ -48216,8 +49272,8 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/verify_governance_consumer.py",
-      "source_location": "L541",
+      "source_file": "scripts/overlord/verify_governance_consumer.py",
+      "source_location": "L595",
       "weight": 0.8,
       "_src": "verify_governance_consumer_verify",
       "_tgt": "verify_governance_consumer_fail",
@@ -48228,7 +49284,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/verify_governance_consumer.py",
+      "source_file": "scripts/overlord/verify_governance_consumer.py",
       "source_location": "L95",
       "weight": 0.8,
       "_src": "verify_governance_consumer_git_root",
@@ -48240,8 +49296,8 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/verify_governance_consumer.py",
-      "source_location": "L552",
+      "source_file": "scripts/overlord/verify_governance_consumer.py",
+      "source_location": "L606",
       "weight": 0.8,
       "_src": "verify_governance_consumer_verify",
       "_tgt": "verify_governance_consumer_git_root",
@@ -48252,8 +49308,8 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/verify_governance_consumer.py",
-      "source_location": "L374",
+      "source_file": "scripts/overlord/verify_governance_consumer.py",
+      "source_location": "L420",
       "weight": 0.8,
       "_src": "verify_governance_consumer_load_consumer_record",
       "_tgt": "verify_governance_consumer_load_json",
@@ -48264,8 +49320,8 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/verify_governance_consumer.py",
-      "source_location": "L554",
+      "source_file": "scripts/overlord/verify_governance_consumer.py",
+      "source_location": "L608",
       "weight": 0.8,
       "_src": "verify_governance_consumer_verify",
       "_tgt": "verify_governance_consumer_load_json",
@@ -48276,8 +49332,8 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/verify_governance_consumer.py",
-      "source_location": "L556",
+      "source_file": "scripts/overlord/verify_governance_consumer.py",
+      "source_location": "L610",
       "weight": 0.8,
       "_src": "verify_governance_consumer_verify",
       "_tgt": "verify_governance_consumer_consumer_record_relpath",
@@ -48288,8 +49344,8 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/verify_governance_consumer.py",
-      "source_location": "L443",
+      "source_file": "scripts/overlord/verify_governance_consumer.py",
+      "source_location": "L489",
       "weight": 0.8,
       "_src": "verify_governance_consumer_validate_record",
       "_tgt": "verify_governance_consumer_required_record_fields",
@@ -48300,8 +49356,8 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/verify_governance_consumer.py",
-      "source_location": "L463",
+      "source_file": "scripts/overlord/verify_governance_consumer.py",
+      "source_location": "L510",
       "weight": 0.8,
       "_src": "verify_governance_consumer_validate_record",
       "_tgt": "verify_governance_consumer_initial_package_version",
@@ -48312,8 +49368,8 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/verify_governance_consumer.py",
-      "source_location": "L480",
+      "source_file": "scripts/overlord/verify_governance_consumer.py",
+      "source_location": "L509",
       "weight": 0.8,
       "_src": "verify_governance_consumer_validate_record",
       "_tgt": "verify_governance_consumer_profile_desired_state",
@@ -48324,8 +49380,20 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/verify_governance_consumer.py",
-      "source_location": "L166",
+      "source_file": "scripts/overlord/verify_governance_consumer.py",
+      "source_location": "L510",
+      "weight": 0.8,
+      "_src": "verify_governance_consumer_validate_record",
+      "_tgt": "verify_governance_consumer_profile_package_version",
+      "source": "verify_governance_consumer_profile_package_version",
+      "target": "verify_governance_consumer_validate_record",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/overlord/verify_governance_consumer.py",
+      "source_location": "L171",
       "weight": 0.8,
       "_src": "verify_governance_consumer_manifest_profiles",
       "_tgt": "verify_governance_consumer_profile_contract",
@@ -48336,8 +49404,8 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/verify_governance_consumer.py",
-      "source_location": "L171",
+      "source_file": "scripts/overlord/verify_governance_consumer.py",
+      "source_location": "L176",
       "weight": 0.8,
       "_src": "verify_governance_consumer_known_profiles",
       "_tgt": "verify_governance_consumer_manifest_profiles",
@@ -48348,8 +49416,8 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/verify_governance_consumer.py",
-      "source_location": "L198",
+      "source_file": "scripts/overlord/verify_governance_consumer.py",
+      "source_location": "L203",
       "weight": 0.8,
       "_src": "verify_governance_consumer_profile_required_constraints",
       "_tgt": "verify_governance_consumer_manifest_profiles",
@@ -48360,8 +49428,8 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/verify_governance_consumer.py",
-      "source_location": "L458",
+      "source_file": "scripts/overlord/verify_governance_consumer.py",
+      "source_location": "L504",
       "weight": 0.8,
       "_src": "verify_governance_consumer_validate_record",
       "_tgt": "verify_governance_consumer_known_profiles",
@@ -48372,8 +49440,8 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/verify_governance_consumer.py",
-      "source_location": "L189",
+      "source_file": "scripts/overlord/verify_governance_consumer.py",
+      "source_location": "L194",
       "weight": 0.8,
       "_src": "verify_governance_consumer_is_v2_record",
       "_tgt": "verify_governance_consumer_next_package_version",
@@ -48384,8 +49452,8 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/verify_governance_consumer.py",
-      "source_location": "L514",
+      "source_file": "scripts/overlord/verify_governance_consumer.py",
+      "source_location": "L568",
       "weight": 0.8,
       "_src": "verify_governance_consumer_validate_record",
       "_tgt": "verify_governance_consumer_is_v2_record",
@@ -48396,8 +49464,8 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/verify_governance_consumer.py",
-      "source_location": "L515",
+      "source_file": "scripts/overlord/verify_governance_consumer.py",
+      "source_location": "L569",
       "weight": 0.8,
       "_src": "verify_governance_consumer_validate_record",
       "_tgt": "verify_governance_consumer_profile_required_constraints",
@@ -48408,8 +49476,8 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/verify_governance_consumer.py",
-      "source_location": "L517",
+      "source_file": "scripts/overlord/verify_governance_consumer.py",
+      "source_location": "L571",
       "weight": 0.8,
       "_src": "verify_governance_consumer_validate_record",
       "_tgt": "verify_governance_consumer_record_constraints",
@@ -48420,20 +49488,20 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/verify_governance_consumer.py",
-      "source_location": "L481",
+      "source_file": "scripts/overlord/verify_governance_consumer.py",
+      "source_location": "L527",
       "weight": 0.8,
       "_src": "verify_governance_consumer_validate_record",
-      "_tgt": "verify_governance_consumer_expected_managed_paths",
-      "source": "verify_governance_consumer_expected_managed_paths",
+      "_tgt": "verify_governance_consumer_expected_managed_entries",
+      "source": "verify_governance_consumer_expected_managed_entries",
       "target": "verify_governance_consumer_validate_record",
       "confidence_score": 0.5
     },
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/verify_governance_consumer.py",
-      "source_location": "L482",
+      "source_file": "scripts/overlord/verify_governance_consumer.py",
+      "source_location": "L529",
       "weight": 0.8,
       "_src": "verify_governance_consumer_validate_record",
       "_tgt": "verify_governance_consumer_managed_paths",
@@ -48444,8 +49512,20 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/verify_governance_consumer.py",
-      "source_location": "L496",
+      "source_file": "scripts/overlord/verify_governance_consumer.py",
+      "source_location": "L292",
+      "weight": 0.8,
+      "_src": "verify_governance_consumer_expected_entry_failures",
+      "_tgt": "verify_governance_consumer_string_list_or_none",
+      "source": "verify_governance_consumer_string_list_or_none",
+      "target": "verify_governance_consumer_expected_entry_failures",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/overlord/verify_governance_consumer.py",
+      "source_location": "L550",
       "weight": 0.8,
       "_src": "verify_governance_consumer_validate_record",
       "_tgt": "verify_governance_consumer_managed_file_type",
@@ -48456,8 +49536,8 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/verify_governance_consumer.py",
-      "source_location": "L495",
+      "source_file": "scripts/overlord/verify_governance_consumer.py",
+      "source_location": "L537",
       "weight": 0.8,
       "_src": "verify_governance_consumer_validate_record",
       "_tgt": "verify_governance_consumer_managed_file_entry",
@@ -48468,8 +49548,32 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/verify_governance_consumer.py",
-      "source_location": "L290",
+      "source_file": "scripts/overlord/verify_governance_consumer.py",
+      "source_location": "L295",
+      "weight": 0.8,
+      "_src": "verify_governance_consumer_expected_entry_failures",
+      "_tgt": "verify_governance_consumer_string_list",
+      "source": "verify_governance_consumer_expected_entry_failures",
+      "target": "verify_governance_consumer_string_list",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/overlord/verify_governance_consumer.py",
+      "source_location": "L539",
+      "weight": 0.8,
+      "_src": "verify_governance_consumer_validate_record",
+      "_tgt": "verify_governance_consumer_expected_entry_failures",
+      "source": "verify_governance_consumer_expected_entry_failures",
+      "target": "verify_governance_consumer_validate_record",
+      "confidence_score": 0.5
+    },
+    {
+      "relation": "calls",
+      "confidence": "INFERRED",
+      "source_file": "scripts/overlord/verify_governance_consumer.py",
+      "source_location": "L336",
       "weight": 0.8,
       "_src": "verify_governance_consumer_managed_file_content_failures",
       "_tgt": "verify_governance_consumer_string_list",
@@ -48480,8 +49584,8 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/verify_governance_consumer.py",
-      "source_location": "L505",
+      "source_file": "scripts/overlord/verify_governance_consumer.py",
+      "source_location": "L559",
       "weight": 0.8,
       "_src": "verify_governance_consumer_validate_record",
       "_tgt": "verify_governance_consumer_managed_markers",
@@ -48492,8 +49596,8 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/verify_governance_consumer.py",
-      "source_location": "L306",
+      "source_file": "scripts/overlord/verify_governance_consumer.py",
+      "source_location": "L352",
       "weight": 0.8,
       "_src": "verify_governance_consumer_managed_file_content_failures",
       "_tgt": "verify_governance_consumer_managed_settings_matchers",
@@ -48504,8 +49608,8 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/verify_governance_consumer.py",
-      "source_location": "L507",
+      "source_file": "scripts/overlord/verify_governance_consumer.py",
+      "source_location": "L561",
       "weight": 0.8,
       "_src": "verify_governance_consumer_validate_record",
       "_tgt": "verify_governance_consumer_managed_file_content_failures",
@@ -48516,8 +49620,8 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/verify_governance_consumer.py",
-      "source_location": "L508",
+      "source_file": "scripts/overlord/verify_governance_consumer.py",
+      "source_location": "L562",
       "weight": 0.8,
       "_src": "verify_governance_consumer_validate_record",
       "_tgt": "verify_governance_consumer_expected_checksum",
@@ -48528,8 +49632,8 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/verify_governance_consumer.py",
-      "source_location": "L395",
+      "source_file": "scripts/overlord/verify_governance_consumer.py",
+      "source_location": "L441",
       "weight": 0.8,
       "_src": "verify_governance_consumer_override_records",
       "_tgt": "verify_governance_consumer_non_empty_string",
@@ -48540,8 +49644,8 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/verify_governance_consumer.py",
-      "source_location": "L348",
+      "source_file": "scripts/overlord/verify_governance_consumer.py",
+      "source_location": "L394",
       "weight": 0.8,
       "_src": "verify_governance_consumer_forbidden_override_failures",
       "_tgt": "verify_governance_consumer_override_text",
@@ -48552,8 +49656,8 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/verify_governance_consumer.py",
-      "source_location": "L353",
+      "source_file": "scripts/overlord/verify_governance_consumer.py",
+      "source_location": "L399",
       "weight": 0.8,
       "_src": "verify_governance_consumer_forbidden_override_failures",
       "_tgt": "verify_governance_consumer_contains_negated_forbidden_action",
@@ -48564,8 +49668,8 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/verify_governance_consumer.py",
-      "source_location": "L528",
+      "source_file": "scripts/overlord/verify_governance_consumer.py",
+      "source_location": "L582",
       "weight": 0.8,
       "_src": "verify_governance_consumer_validate_record",
       "_tgt": "verify_governance_consumer_forbidden_override_failures",
@@ -48576,8 +49680,8 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/verify_governance_consumer.py",
-      "source_location": "L370",
+      "source_file": "scripts/overlord/verify_governance_consumer.py",
+      "source_location": "L416",
       "weight": 0.8,
       "_src": "verify_governance_consumer_load_consumer_record",
       "_tgt": "verify_governance_consumer_is_relative_to",
@@ -48588,8 +49692,8 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/verify_governance_consumer.py",
-      "source_location": "L489",
+      "source_file": "scripts/overlord/verify_governance_consumer.py",
+      "source_location": "L543",
       "weight": 0.8,
       "_src": "verify_governance_consumer_validate_record",
       "_tgt": "verify_governance_consumer_is_relative_to",
@@ -48600,8 +49704,8 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/verify_governance_consumer.py",
-      "source_location": "L548",
+      "source_file": "scripts/overlord/verify_governance_consumer.py",
+      "source_location": "L602",
       "weight": 0.8,
       "_src": "verify_governance_consumer_verify",
       "_tgt": "verify_governance_consumer_is_relative_to",
@@ -48612,8 +49716,8 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/verify_governance_consumer.py",
-      "source_location": "L557",
+      "source_file": "scripts/overlord/verify_governance_consumer.py",
+      "source_location": "L611",
       "weight": 0.8,
       "_src": "verify_governance_consumer_verify",
       "_tgt": "verify_governance_consumer_load_consumer_record",
@@ -48624,8 +49728,8 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/verify_governance_consumer.py",
-      "source_location": "L526",
+      "source_file": "scripts/overlord/verify_governance_consumer.py",
+      "source_location": "L580",
       "weight": 0.8,
       "_src": "verify_governance_consumer_validate_record",
       "_tgt": "verify_governance_consumer_override_records",
@@ -48636,8 +49740,8 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/verify_governance_consumer.py",
-      "source_location": "L529",
+      "source_file": "scripts/overlord/verify_governance_consumer.py",
+      "source_location": "L583",
       "weight": 0.8,
       "_src": "verify_governance_consumer_validate_record",
       "_tgt": "verify_governance_consumer_workflow_ref_failures",
@@ -48648,8 +49752,8 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/verify_governance_consumer.py",
-      "source_location": "L558",
+      "source_file": "scripts/overlord/verify_governance_consumer.py",
+      "source_location": "L612",
       "weight": 0.8,
       "_src": "verify_governance_consumer_verify",
       "_tgt": "verify_governance_consumer_validate_record",
@@ -48660,8 +49764,8 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/verify_governance_consumer.py",
-      "source_location": "L607",
+      "source_file": "scripts/overlord/verify_governance_consumer.py",
+      "source_location": "L661",
       "weight": 0.8,
       "_src": "verify_governance_consumer_main",
       "_tgt": "verify_governance_consumer_verify",
@@ -48672,8 +49776,8 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/verify_governance_consumer.py",
-      "source_location": "L608",
+      "source_file": "scripts/overlord/verify_governance_consumer.py",
+      "source_location": "L662",
       "weight": 0.8,
       "_src": "verify_governance_consumer_main",
       "_tgt": "verify_governance_consumer_print_json",
@@ -48684,8 +49788,8 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/overlord/verify_governance_consumer.py",
-      "source_location": "L604",
+      "source_file": "scripts/overlord/verify_governance_consumer.py",
+      "source_location": "L658",
       "weight": 0.8,
       "_src": "verify_governance_consumer_main",
       "_tgt": "verify_governance_consumer_build_parser",
@@ -58908,7 +60012,7 @@
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/session_bootstrap_contract.py",
+      "source_file": "scripts/session_bootstrap_contract.py",
       "source_location": "L28",
       "weight": 1.0,
       "_src": "session_bootstrap_contract",
@@ -58920,7 +60024,7 @@
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/session_bootstrap_contract.py",
+      "source_file": "scripts/session_bootstrap_contract.py",
       "source_location": "L35",
       "weight": 1.0,
       "_src": "session_bootstrap_contract",
@@ -58932,7 +60036,7 @@
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/session_bootstrap_contract.py",
+      "source_file": "scripts/session_bootstrap_contract.py",
       "source_location": "L44",
       "weight": 1.0,
       "_src": "session_bootstrap_contract",
@@ -58944,7 +60048,7 @@
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/session_bootstrap_contract.py",
+      "source_file": "scripts/session_bootstrap_contract.py",
       "source_location": "L52",
       "weight": 1.0,
       "_src": "session_bootstrap_contract",
@@ -58956,7 +60060,7 @@
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/session_bootstrap_contract.py",
+      "source_file": "scripts/session_bootstrap_contract.py",
       "source_location": "L64",
       "weight": 1.0,
       "_src": "session_bootstrap_contract",
@@ -58968,7 +60072,7 @@
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/session_bootstrap_contract.py",
+      "source_file": "scripts/session_bootstrap_contract.py",
       "source_location": "L75",
       "weight": 1.0,
       "_src": "session_bootstrap_contract",
@@ -58980,7 +60084,7 @@
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/session_bootstrap_contract.py",
+      "source_file": "scripts/session_bootstrap_contract.py",
       "source_location": "L79",
       "weight": 1.0,
       "_src": "session_bootstrap_contract",
@@ -58992,7 +60096,7 @@
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/session_bootstrap_contract.py",
+      "source_file": "scripts/session_bootstrap_contract.py",
       "source_location": "L91",
       "weight": 1.0,
       "_src": "session_bootstrap_contract",
@@ -59004,7 +60108,7 @@
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/session_bootstrap_contract.py",
+      "source_file": "scripts/session_bootstrap_contract.py",
       "source_location": "L110",
       "weight": 1.0,
       "_src": "session_bootstrap_contract",
@@ -59016,7 +60120,7 @@
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/session_bootstrap_contract.py",
+      "source_file": "scripts/session_bootstrap_contract.py",
       "source_location": "L121",
       "weight": 1.0,
       "_src": "session_bootstrap_contract",
@@ -59028,7 +60132,7 @@
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/session_bootstrap_contract.py",
+      "source_file": "scripts/session_bootstrap_contract.py",
       "source_location": "L173",
       "weight": 1.0,
       "_src": "session_bootstrap_contract",
@@ -59040,7 +60144,7 @@
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/session_bootstrap_contract.py",
+      "source_file": "scripts/session_bootstrap_contract.py",
       "source_location": "L186",
       "weight": 1.0,
       "_src": "session_bootstrap_contract",
@@ -59052,7 +60156,7 @@
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/session_bootstrap_contract.py",
+      "source_file": "scripts/session_bootstrap_contract.py",
       "source_location": "L191",
       "weight": 1.0,
       "_src": "session_bootstrap_contract",
@@ -59064,7 +60168,7 @@
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/session_bootstrap_contract.py",
+      "source_file": "scripts/session_bootstrap_contract.py",
       "source_location": "L235",
       "weight": 1.0,
       "_src": "session_bootstrap_contract",
@@ -59076,7 +60180,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/session_bootstrap_contract.py",
+      "source_file": "scripts/session_bootstrap_contract.py",
       "source_location": "L102",
       "weight": 0.8,
       "_src": "session_bootstrap_contract_extract_runbook_paths",
@@ -59088,7 +60192,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/session_bootstrap_contract.py",
+      "source_file": "scripts/session_bootstrap_contract.py",
       "source_location": "L133",
       "weight": 0.8,
       "_src": "session_bootstrap_contract_build_report",
@@ -59100,7 +60204,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/session_bootstrap_contract.py",
+      "source_file": "scripts/session_bootstrap_contract.py",
       "source_location": "L236",
       "weight": 0.8,
       "_src": "session_bootstrap_contract_main",
@@ -59112,7 +60216,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/session_bootstrap_contract.py",
+      "source_file": "scripts/session_bootstrap_contract.py",
       "source_location": "L48",
       "weight": 0.8,
       "_src": "session_bootstrap_contract_resolve_repo_root",
@@ -59124,7 +60228,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/session_bootstrap_contract.py",
+      "source_file": "scripts/session_bootstrap_contract.py",
       "source_location": "L237",
       "weight": 0.8,
       "_src": "session_bootstrap_contract_main",
@@ -59136,7 +60240,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/session_bootstrap_contract.py",
+      "source_file": "scripts/session_bootstrap_contract.py",
       "source_location": "L239",
       "weight": 0.8,
       "_src": "session_bootstrap_contract_main",
@@ -59148,7 +60252,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/session_bootstrap_contract.py",
+      "source_file": "scripts/session_bootstrap_contract.py",
       "source_location": "L129",
       "weight": 0.8,
       "_src": "session_bootstrap_contract_build_report",
@@ -59160,7 +60264,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/session_bootstrap_contract.py",
+      "source_file": "scripts/session_bootstrap_contract.py",
       "source_location": "L166",
       "weight": 0.8,
       "_src": "session_bootstrap_contract_build_report",
@@ -59172,7 +60276,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/session_bootstrap_contract.py",
+      "source_file": "scripts/session_bootstrap_contract.py",
       "source_location": "L133",
       "weight": 0.8,
       "_src": "session_bootstrap_contract_build_report",
@@ -59184,7 +60288,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/session_bootstrap_contract.py",
+      "source_file": "scripts/session_bootstrap_contract.py",
       "source_location": "L134",
       "weight": 0.8,
       "_src": "session_bootstrap_contract_build_report",
@@ -59196,7 +60300,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/session_bootstrap_contract.py",
+      "source_file": "scripts/session_bootstrap_contract.py",
       "source_location": "L135",
       "weight": 0.8,
       "_src": "session_bootstrap_contract_build_report",
@@ -59208,7 +60312,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/session_bootstrap_contract.py",
+      "source_file": "scripts/session_bootstrap_contract.py",
       "source_location": "L238",
       "weight": 0.8,
       "_src": "session_bootstrap_contract_main",
@@ -59220,7 +60324,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/session_bootstrap_contract.py",
+      "source_file": "scripts/session_bootstrap_contract.py",
       "source_location": "L240",
       "weight": 0.8,
       "_src": "session_bootstrap_contract_main",
@@ -59232,7 +60336,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/session_bootstrap_contract.py",
+      "source_file": "scripts/session_bootstrap_contract.py",
       "source_location": "L256",
       "weight": 0.8,
       "_src": "session_bootstrap_contract_main",
@@ -59893,31 +60997,31 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/test_bootstrap_repo_env_contract.py",
-      "source_location": "L168",
+      "source_location": "L172",
       "weight": 1.0,
       "_src": "test_bootstrap_repo_env_contract",
-      "_tgt": "test_bootstrap_repo_env_contract_run_sibling_worktree_lam_bootstrap",
+      "_tgt": "test_bootstrap_repo_env_contract_run_canonical_root_worktree_lam_bootstrap",
       "source": "test_bootstrap_repo_env_contract",
-      "target": "test_bootstrap_repo_env_contract_run_sibling_worktree_lam_bootstrap",
+      "target": "test_bootstrap_repo_env_contract_run_canonical_root_worktree_lam_bootstrap",
       "confidence_score": 1.0
     },
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/test_bootstrap_repo_env_contract.py",
-      "source_location": "L218",
+      "source_location": "L224",
       "weight": 1.0,
       "_src": "test_bootstrap_repo_env_contract",
-      "_tgt": "test_bootstrap_repo_env_contract_run_nested_var_worktree_lam_bootstrap",
+      "_tgt": "test_bootstrap_repo_env_contract_run_noncanonical_root_lam_bootstrap_fails_closed",
       "source": "test_bootstrap_repo_env_contract",
-      "target": "test_bootstrap_repo_env_contract_run_nested_var_worktree_lam_bootstrap",
+      "target": "test_bootstrap_repo_env_contract_run_noncanonical_root_lam_bootstrap_fails_closed",
       "confidence_score": 1.0
     },
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/test_bootstrap_repo_env_contract.py",
-      "source_location": "L263",
+      "source_location": "L254",
       "weight": 1.0,
       "_src": "test_bootstrap_repo_env_contract",
       "_tgt": "test_bootstrap_repo_env_contract_run_synthetic_seek_bootstrap",
@@ -59929,7 +61033,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "scripts/test_bootstrap_repo_env_contract.py",
-      "source_location": "L322",
+      "source_location": "L317",
       "weight": 1.0,
       "_src": "test_bootstrap_repo_env_contract",
       "_tgt": "test_bootstrap_repo_env_contract_run_synthetic_stampede_bootstrap",
@@ -59953,7 +61057,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/test_bootstrap_repo_env_contract.py",
-      "source_location": "L139",
+      "source_location": "L143",
       "weight": 0.8,
       "_src": "test_bootstrap_repo_env_contract_run_synthetic_lam_bootstrap",
       "_tgt": "test_bootstrap_repo_env_contract_check",
@@ -59965,31 +61069,31 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/test_bootstrap_repo_env_contract.py",
-      "source_location": "L213",
+      "source_location": "L219",
       "weight": 0.8,
-      "_src": "test_bootstrap_repo_env_contract_run_sibling_worktree_lam_bootstrap",
+      "_src": "test_bootstrap_repo_env_contract_run_canonical_root_worktree_lam_bootstrap",
       "_tgt": "test_bootstrap_repo_env_contract_check",
       "source": "test_bootstrap_repo_env_contract_check",
-      "target": "test_bootstrap_repo_env_contract_run_sibling_worktree_lam_bootstrap",
+      "target": "test_bootstrap_repo_env_contract_run_canonical_root_worktree_lam_bootstrap",
       "confidence_score": 0.5
     },
     {
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/test_bootstrap_repo_env_contract.py",
-      "source_location": "L259",
+      "source_location": "L247",
       "weight": 0.8,
-      "_src": "test_bootstrap_repo_env_contract_run_nested_var_worktree_lam_bootstrap",
+      "_src": "test_bootstrap_repo_env_contract_run_noncanonical_root_lam_bootstrap_fails_closed",
       "_tgt": "test_bootstrap_repo_env_contract_check",
       "source": "test_bootstrap_repo_env_contract_check",
-      "target": "test_bootstrap_repo_env_contract_run_nested_var_worktree_lam_bootstrap",
+      "target": "test_bootstrap_repo_env_contract_run_noncanonical_root_lam_bootstrap_fails_closed",
       "confidence_score": 0.5
     },
     {
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/test_bootstrap_repo_env_contract.py",
-      "source_location": "L304",
+      "source_location": "L299",
       "weight": 0.8,
       "_src": "test_bootstrap_repo_env_contract_run_synthetic_seek_bootstrap",
       "_tgt": "test_bootstrap_repo_env_contract_check",
@@ -60001,7 +61105,7 @@
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/test_bootstrap_repo_env_contract.py",
-      "source_location": "L361",
+      "source_location": "L360",
       "weight": 0.8,
       "_src": "test_bootstrap_repo_env_contract_run_synthetic_stampede_bootstrap",
       "_tgt": "test_bootstrap_repo_env_contract_check",
@@ -60028,9 +61132,9 @@
       "source_location": "L84",
       "weight": 0.8,
       "_src": "test_bootstrap_repo_env_contract_main",
-      "_tgt": "test_bootstrap_repo_env_contract_run_sibling_worktree_lam_bootstrap",
+      "_tgt": "test_bootstrap_repo_env_contract_run_canonical_root_worktree_lam_bootstrap",
       "source": "test_bootstrap_repo_env_contract_main",
-      "target": "test_bootstrap_repo_env_contract_run_sibling_worktree_lam_bootstrap",
+      "target": "test_bootstrap_repo_env_contract_run_canonical_root_worktree_lam_bootstrap",
       "confidence_score": 0.5
     },
     {
@@ -60040,9 +61144,9 @@
       "source_location": "L85",
       "weight": 0.8,
       "_src": "test_bootstrap_repo_env_contract_main",
-      "_tgt": "test_bootstrap_repo_env_contract_run_nested_var_worktree_lam_bootstrap",
+      "_tgt": "test_bootstrap_repo_env_contract_run_noncanonical_root_lam_bootstrap_fails_closed",
       "source": "test_bootstrap_repo_env_contract_main",
-      "target": "test_bootstrap_repo_env_contract_run_nested_var_worktree_lam_bootstrap",
+      "target": "test_bootstrap_repo_env_contract_run_noncanonical_root_lam_bootstrap_fails_closed",
       "confidence_score": 0.5
     },
     {
@@ -60085,48 +61189,48 @@
       "relation": "rationale_for",
       "confidence": "EXTRACTED",
       "source_file": "scripts/test_bootstrap_repo_env_contract.py",
-      "source_location": "L169",
+      "source_location": "L173",
       "weight": 1.0,
-      "_src": "test_bootstrap_repo_env_contract_rationale_169",
-      "_tgt": "test_bootstrap_repo_env_contract_run_sibling_worktree_lam_bootstrap",
-      "source": "test_bootstrap_repo_env_contract_run_sibling_worktree_lam_bootstrap",
-      "target": "test_bootstrap_repo_env_contract_rationale_169",
+      "_src": "test_bootstrap_repo_env_contract_rationale_173",
+      "_tgt": "test_bootstrap_repo_env_contract_run_canonical_root_worktree_lam_bootstrap",
+      "source": "test_bootstrap_repo_env_contract_run_canonical_root_worktree_lam_bootstrap",
+      "target": "test_bootstrap_repo_env_contract_rationale_173",
       "confidence_score": 1.0
     },
     {
       "relation": "rationale_for",
       "confidence": "EXTRACTED",
       "source_file": "scripts/test_bootstrap_repo_env_contract.py",
-      "source_location": "L219",
+      "source_location": "L225",
       "weight": 1.0,
-      "_src": "test_bootstrap_repo_env_contract_rationale_219",
-      "_tgt": "test_bootstrap_repo_env_contract_run_nested_var_worktree_lam_bootstrap",
-      "source": "test_bootstrap_repo_env_contract_run_nested_var_worktree_lam_bootstrap",
-      "target": "test_bootstrap_repo_env_contract_rationale_219",
+      "_src": "test_bootstrap_repo_env_contract_rationale_225",
+      "_tgt": "test_bootstrap_repo_env_contract_run_noncanonical_root_lam_bootstrap_fails_closed",
+      "source": "test_bootstrap_repo_env_contract_run_noncanonical_root_lam_bootstrap_fails_closed",
+      "target": "test_bootstrap_repo_env_contract_rationale_225",
       "confidence_score": 1.0
     },
     {
       "relation": "rationale_for",
       "confidence": "EXTRACTED",
       "source_file": "scripts/test_bootstrap_repo_env_contract.py",
-      "source_location": "L264",
+      "source_location": "L255",
       "weight": 1.0,
-      "_src": "test_bootstrap_repo_env_contract_rationale_264",
+      "_src": "test_bootstrap_repo_env_contract_rationale_255",
       "_tgt": "test_bootstrap_repo_env_contract_run_synthetic_seek_bootstrap",
       "source": "test_bootstrap_repo_env_contract_run_synthetic_seek_bootstrap",
-      "target": "test_bootstrap_repo_env_contract_rationale_264",
+      "target": "test_bootstrap_repo_env_contract_rationale_255",
       "confidence_score": 1.0
     },
     {
       "relation": "rationale_for",
       "confidence": "EXTRACTED",
       "source_file": "scripts/test_bootstrap_repo_env_contract.py",
-      "source_location": "L323",
+      "source_location": "L318",
       "weight": 1.0,
-      "_src": "test_bootstrap_repo_env_contract_rationale_323",
+      "_src": "test_bootstrap_repo_env_contract_rationale_318",
       "_tgt": "test_bootstrap_repo_env_contract_run_synthetic_stampede_bootstrap",
       "source": "test_bootstrap_repo_env_contract_run_synthetic_stampede_bootstrap",
-      "target": "test_bootstrap_repo_env_contract_rationale_323",
+      "target": "test_bootstrap_repo_env_contract_rationale_318",
       "confidence_score": 1.0
     },
     {
@@ -60646,6 +61750,18 @@
       "confidence_score": 1.0
     },
     {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/test_codex_fire.py",
+      "source_location": "L279",
+      "weight": 1.0,
+      "_src": "test_codex_fire",
+      "_tgt": "test_codex_fire_test_review_template_claude_dry_run_uses_self_contained_packet_contract",
+      "source": "test_codex_fire",
+      "target": "test_codex_fire_test_review_template_claude_dry_run_uses_self_contained_packet_contract",
+      "confidence_score": 1.0
+    },
+    {
       "relation": "calls",
       "confidence": "INFERRED",
       "source_file": "scripts/test_codex_fire.py",
@@ -60768,7 +61884,7 @@
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/test_session_bootstrap_contract.py",
+      "source_file": "scripts/test_session_bootstrap_contract.py",
       "source_location": "L14",
       "weight": 1.0,
       "_src": "test_session_bootstrap_contract",
@@ -60780,7 +61896,7 @@
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/test_session_bootstrap_contract.py",
+      "source_file": "scripts/test_session_bootstrap_contract.py",
       "source_location": "L60",
       "weight": 1.0,
       "_src": "test_session_bootstrap_contract",
@@ -60792,7 +61908,7 @@
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/test_session_bootstrap_contract.py",
+      "source_file": "scripts/test_session_bootstrap_contract.py",
       "source_location": "L69",
       "weight": 1.0,
       "_src": "test_session_bootstrap_contract",
@@ -60804,7 +61920,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/test_session_bootstrap_contract.py",
+      "source_file": "scripts/test_session_bootstrap_contract.py",
       "source_location": "L73",
       "weight": 0.8,
       "_src": "test_session_bootstrap_contract_sessionbootstrapcontracttests_test_emit_hook_note_writes_sentinel_and_surfaces_runbook_paths",
@@ -60816,7 +61932,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/test_session_bootstrap_contract.py",
+      "source_file": "scripts/test_session_bootstrap_contract.py",
       "source_location": "L96",
       "weight": 0.8,
       "_src": "test_session_bootstrap_contract_sessionbootstrapcontracttests_test_missing_required_file_is_recorded_as_warning",
@@ -60828,7 +61944,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/test_session_bootstrap_contract.py",
+      "source_file": "scripts/test_session_bootstrap_contract.py",
       "source_location": "L76",
       "weight": 0.8,
       "_src": "test_session_bootstrap_contract_sessionbootstrapcontracttests_test_emit_hook_note_writes_sentinel_and_surfaces_runbook_paths",
@@ -60840,7 +61956,7 @@
     {
       "relation": "calls",
       "confidence": "INFERRED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/test_session_bootstrap_contract.py",
+      "source_file": "scripts/test_session_bootstrap_contract.py",
       "source_location": "L100",
       "weight": 0.8,
       "_src": "test_session_bootstrap_contract_sessionbootstrapcontracttests_test_missing_required_file_is_recorded_as_warning",
@@ -60852,7 +61968,7 @@
     {
       "relation": "method",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/test_session_bootstrap_contract.py",
+      "source_file": "scripts/test_session_bootstrap_contract.py",
       "source_location": "L70",
       "weight": 1.0,
       "_src": "test_session_bootstrap_contract_sessionbootstrapcontracttests",
@@ -60864,7 +61980,7 @@
     {
       "relation": "method",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/scripts/test_session_bootstrap_contract.py",
+      "source_file": "scripts/test_session_bootstrap_contract.py",
       "source_location": "L93",
       "weight": 1.0,
       "_src": "test_session_bootstrap_contract_sessionbootstrapcontracttests",
@@ -65484,7 +66600,7 @@
     {
       "relation": "imports",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/tools/local-ci-gate/tests/test_local_ci_gate.py",
+      "source_file": "tools/local-ci-gate/tests/test_local_ci_gate.py",
       "source_location": "L12",
       "weight": 1.0,
       "_src": "test_local_ci_gate",
@@ -66096,7 +67212,7 @@
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/tools/local-ci-gate/tests/test_local_ci_gate.py",
+      "source_file": "tools/local-ci-gate/tests/test_local_ci_gate.py",
       "source_location": "L19",
       "weight": 1.0,
       "_src": "test_local_ci_gate",
@@ -66108,7 +67224,7 @@
     {
       "relation": "method",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/tools/local-ci-gate/tests/test_local_ci_gate.py",
+      "source_file": "tools/local-ci-gate/tests/test_local_ci_gate.py",
       "source_location": "L20",
       "weight": 1.0,
       "_src": "test_local_ci_gate_testlocalcigate",
@@ -66120,7 +67236,7 @@
     {
       "relation": "method",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/tools/local-ci-gate/tests/test_local_ci_gate.py",
+      "source_file": "tools/local-ci-gate/tests/test_local_ci_gate.py",
       "source_location": "L68",
       "weight": 1.0,
       "_src": "test_local_ci_gate_testlocalcigate",
@@ -66132,7 +67248,7 @@
     {
       "relation": "method",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/tools/local-ci-gate/tests/test_local_ci_gate.py",
+      "source_file": "tools/local-ci-gate/tests/test_local_ci_gate.py",
       "source_location": "L71",
       "weight": 1.0,
       "_src": "test_local_ci_gate_testlocalcigate",
@@ -66144,7 +67260,7 @@
     {
       "relation": "method",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/tools/local-ci-gate/tests/test_local_ci_gate.py",
+      "source_file": "tools/local-ci-gate/tests/test_local_ci_gate.py",
       "source_location": "L89",
       "weight": 1.0,
       "_src": "test_local_ci_gate_testlocalcigate",
@@ -66156,7 +67272,7 @@
     {
       "relation": "method",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/tools/local-ci-gate/tests/test_local_ci_gate.py",
+      "source_file": "tools/local-ci-gate/tests/test_local_ci_gate.py",
       "source_location": "L96",
       "weight": 1.0,
       "_src": "test_local_ci_gate_testlocalcigate",
@@ -66168,7 +67284,7 @@
     {
       "relation": "method",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/tools/local-ci-gate/tests/test_local_ci_gate.py",
+      "source_file": "tools/local-ci-gate/tests/test_local_ci_gate.py",
       "source_location": "L113",
       "weight": 1.0,
       "_src": "test_local_ci_gate_testlocalcigate",
@@ -66180,7 +67296,7 @@
     {
       "relation": "method",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/tools/local-ci-gate/tests/test_local_ci_gate.py",
+      "source_file": "tools/local-ci-gate/tests/test_local_ci_gate.py",
       "source_location": "L134",
       "weight": 1.0,
       "_src": "test_local_ci_gate_testlocalcigate",
@@ -66192,7 +67308,7 @@
     {
       "relation": "method",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/tools/local-ci-gate/tests/test_local_ci_gate.py",
+      "source_file": "tools/local-ci-gate/tests/test_local_ci_gate.py",
       "source_location": "L156",
       "weight": 1.0,
       "_src": "test_local_ci_gate_testlocalcigate",
@@ -66204,7 +67320,7 @@
     {
       "relation": "method",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/tools/local-ci-gate/tests/test_local_ci_gate.py",
+      "source_file": "tools/local-ci-gate/tests/test_local_ci_gate.py",
       "source_location": "L203",
       "weight": 1.0,
       "_src": "test_local_ci_gate_testlocalcigate",
@@ -66216,7 +67332,7 @@
     {
       "relation": "method",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/tools/local-ci-gate/tests/test_local_ci_gate.py",
+      "source_file": "tools/local-ci-gate/tests/test_local_ci_gate.py",
       "source_location": "L238",
       "weight": 1.0,
       "_src": "test_local_ci_gate_testlocalcigate",
@@ -66228,7 +67344,7 @@
     {
       "relation": "method",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/tools/local-ci-gate/tests/test_local_ci_gate.py",
+      "source_file": "tools/local-ci-gate/tests/test_local_ci_gate.py",
       "source_location": "L268",
       "weight": 1.0,
       "_src": "test_local_ci_gate_testlocalcigate",
@@ -66240,7 +67356,7 @@
     {
       "relation": "method",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/tools/local-ci-gate/tests/test_local_ci_gate.py",
+      "source_file": "tools/local-ci-gate/tests/test_local_ci_gate.py",
       "source_location": "L287",
       "weight": 1.0,
       "_src": "test_local_ci_gate_testlocalcigate",
@@ -66252,7 +67368,7 @@
     {
       "relation": "method",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/tools/local-ci-gate/tests/test_local_ci_gate.py",
+      "source_file": "tools/local-ci-gate/tests/test_local_ci_gate.py",
       "source_location": "L296",
       "weight": 1.0,
       "_src": "test_local_ci_gate_testlocalcigate",
@@ -66264,7 +67380,7 @@
     {
       "relation": "method",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/tools/local-ci-gate/tests/test_local_ci_gate.py",
+      "source_file": "tools/local-ci-gate/tests/test_local_ci_gate.py",
       "source_location": "L313",
       "weight": 1.0,
       "_src": "test_local_ci_gate_testlocalcigate",
@@ -66276,7 +67392,7 @@
     {
       "relation": "method",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/tools/local-ci-gate/tests/test_local_ci_gate.py",
+      "source_file": "tools/local-ci-gate/tests/test_local_ci_gate.py",
       "source_location": "L320",
       "weight": 1.0,
       "_src": "test_local_ci_gate_testlocalcigate",
@@ -66288,7 +67404,7 @@
     {
       "relation": "method",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/tools/local-ci-gate/tests/test_local_ci_gate.py",
+      "source_file": "tools/local-ci-gate/tests/test_local_ci_gate.py",
       "source_location": "L336",
       "weight": 1.0,
       "_src": "test_local_ci_gate_testlocalcigate",
@@ -66300,7 +67416,7 @@
     {
       "relation": "method",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/tools/local-ci-gate/tests/test_local_ci_gate.py",
+      "source_file": "tools/local-ci-gate/tests/test_local_ci_gate.py",
       "source_location": "L349",
       "weight": 1.0,
       "_src": "test_local_ci_gate_testlocalcigate",
@@ -66312,7 +67428,7 @@
     {
       "relation": "method",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/tools/local-ci-gate/tests/test_local_ci_gate.py",
+      "source_file": "tools/local-ci-gate/tests/test_local_ci_gate.py",
       "source_location": "L364",
       "weight": 1.0,
       "_src": "test_local_ci_gate_testlocalcigate",
@@ -66324,7 +67440,7 @@
     {
       "relation": "method",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/tools/local-ci-gate/tests/test_local_ci_gate.py",
+      "source_file": "tools/local-ci-gate/tests/test_local_ci_gate.py",
       "source_location": "L377",
       "weight": 1.0,
       "_src": "test_local_ci_gate_testlocalcigate",
@@ -66336,7 +67452,7 @@
     {
       "relation": "method",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/tools/local-ci-gate/tests/test_local_ci_gate.py",
+      "source_file": "tools/local-ci-gate/tests/test_local_ci_gate.py",
       "source_location": "L391",
       "weight": 1.0,
       "_src": "test_local_ci_gate_testlocalcigate",
@@ -66348,7 +67464,7 @@
     {
       "relation": "method",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/tools/local-ci-gate/tests/test_local_ci_gate.py",
+      "source_file": "tools/local-ci-gate/tests/test_local_ci_gate.py",
       "source_location": "L403",
       "weight": 1.0,
       "_src": "test_local_ci_gate_testlocalcigate",
@@ -66360,7 +67476,7 @@
     {
       "relation": "method",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/tools/local-ci-gate/tests/test_local_ci_gate.py",
+      "source_file": "tools/local-ci-gate/tests/test_local_ci_gate.py",
       "source_location": "L414",
       "weight": 1.0,
       "_src": "test_local_ci_gate_testlocalcigate",
@@ -66372,7 +67488,7 @@
     {
       "relation": "method",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/tools/local-ci-gate/tests/test_local_ci_gate.py",
+      "source_file": "tools/local-ci-gate/tests/test_local_ci_gate.py",
       "source_location": "L436",
       "weight": 1.0,
       "_src": "test_local_ci_gate_testlocalcigate",
@@ -66384,7 +67500,7 @@
     {
       "relation": "method",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/bennibarger/Developer/HLDPRO/_worktrees/gov-issue-573-session-waterfall-runbook/tools/local-ci-gate/tests/test_local_ci_gate.py",
+      "source_file": "tools/local-ci-gate/tests/test_local_ci_gate.py",
       "source_location": "L457",
       "weight": 1.0,
       "_src": "test_local_ci_gate_testlocalcigate",

--- a/raw/closeouts/2026-04-29-issue-583-hard-gated-som-enforcement.md
+++ b/raw/closeouts/2026-04-29-issue-583-hard-gated-som-enforcement.md
@@ -1,0 +1,140 @@
+# Stage 6 Closeout
+Date: 2026-04-29
+Repo: hldpro-governance
+Task ID: GitHub issue #583
+Six-Stage Cycle: Stage 6 / Audit + Closeout
+Completed By: Codex orchestrator with governed Claude review
+
+## Decision Made
+
+Hardened issue-level Society of Minds enforcement so governed issue packets and
+consumer-repo governance wiring fail closed instead of relying on adapter
+presence or self-attestation.
+
+## Pattern Identified
+
+The earlier rollout fixed entrypoint surfaces but left two opt-in gaps: issue
+packets could still self-approve without independent evidence, and consumer
+repos could claim governance-package compliance without declaring the thin
+tracked session-contract files the org rules actually rely on.
+
+## Contradicts Existing
+
+This closes the drift where the source standards described orchestrator-only
+authority and thin session adapters, but the source validators and reusable
+workflow still allowed downstream packets and consumer records to bypass that
+contract.
+
+## Files Changed
+
+- `.github/workflows/governance-check.yml`
+- `STANDARDS.md`
+- `docs/EXTERNAL_SERVICES_RUNBOOK.md`
+- `docs/governance-consumer-pull-state.json`
+- `docs/governance-tooling-package.json`
+- `docs/schemas/structured-agent-cycle-plan.schema.json`
+- `scripts/overlord/deploy_governance_tooling.py`
+- `scripts/overlord/test_deploy_governance_tooling.py`
+- `scripts/overlord/test_validate_structured_agent_cycle_plan.py`
+- `scripts/overlord/test_verify_governance_consumer.py`
+- `scripts/overlord/validate_structured_agent_cycle_plan.py`
+- `scripts/overlord/verify_governance_consumer.py`
+- `docs/plans/issue-583-hard-gated-som-enforcement-structured-agent-cycle-plan.json`
+- `raw/handoffs/2026-04-29-issue-583-hard-gated-som-enforcement.json`
+- `raw/validation/2026-04-29-issue-583-hard-gated-som-enforcement.md`
+
+## Issue Links
+
+- Issue: https://github.com/NIBARGERB-HLDPRO/hldpro-governance/issues/583
+- Parent epic: https://github.com/NIBARGERB-HLDPRO/hldpro-governance/issues/579
+- Downstream repair lane: https://github.com/NIBARGERB-HLDPRO/Stampede/issues/197
+
+## Schema / Artifact Version
+
+- Structured plan schema: `docs/schemas/structured-agent-cycle-plan.schema.json`
+- Handoff schema: `docs/schemas/package-handoff.schema.json`
+- Cross-review schema: `raw/cross-review` schema v2
+
+## Model Identity
+
+- Codex orchestrator: `gpt-5.4` (`openai`)
+- Alternate-family reviewer: `claude-opus-4-6` (`anthropic`)
+- Deterministic gate: `hldpro-local-ci`
+
+## Review And Gate Identity
+
+- Review artifact refs:
+  - `raw/cross-review/2026-04-29-issue-583-hard-gated-som-enforcement.md`
+  - `docs/codex-reviews/2026-04-29-claude.md`
+- Gate artifact refs:
+  - `cache/local-ci-gate/reports/20260429T160006Z-hldpro-governance-git/local-ci-20260429T160012Z.json`
+- Handoff lifecycle: accepted
+
+## Wired Checks Run
+
+- `python3 scripts/overlord/validate_structured_agent_cycle_plan.py --root . --branch-name issue-583-hard-gated-som-enforcement --require-if-issue-branch`
+- `python3 scripts/overlord/validate_handoff_package.py --root . raw/handoffs/2026-04-29-issue-583-hard-gated-som-enforcement.json`
+- `python3 scripts/overlord/verify_governance_consumer.py --governance-root . --target-repo /Users/bennibarger/Developer/HLDPRO/Stampede`
+- `bash scripts/cross-review/require-dual-signature.sh raw/cross-review/2026-04-29-issue-583-hard-gated-som-enforcement.md`
+- `python3 -m unittest scripts.overlord.test_validate_structured_agent_cycle_plan scripts.overlord.test_validate_handoff_package scripts.overlord.test_verify_governance_consumer scripts.overlord.test_deploy_governance_tooling`
+- `python3 tools/local-ci-gate/bin/hldpro-local-ci run --profile hldpro-governance --json`
+- `git diff --check`
+
+## Execution Scope / Write Boundary
+
+Structured plan:
+- `docs/plans/issue-583-hard-gated-som-enforcement-structured-agent-cycle-plan.json`
+
+Execution scope:
+- `raw/execution-scopes/2026-04-29-issue-583-hard-gated-som-enforcement-implementation.json`
+
+Handoff package:
+- `raw/handoffs/2026-04-29-issue-583-hard-gated-som-enforcement.json`
+
+Handoff lifecycle:
+- `Handoff lifecycle: accepted`
+
+## Validation Commands
+
+Validation artifact:
+- `raw/validation/2026-04-29-issue-583-hard-gated-som-enforcement.md`
+
+- PASS `python3 scripts/overlord/validate_structured_agent_cycle_plan.py --root . --branch-name issue-583-hard-gated-som-enforcement --require-if-issue-branch`
+- PASS `python3 scripts/overlord/validate_handoff_package.py --root . raw/handoffs/2026-04-29-issue-583-hard-gated-som-enforcement.json`
+- PASS `python3 scripts/overlord/verify_governance_consumer.py --governance-root . --target-repo /Users/bennibarger/Developer/HLDPRO/Stampede`
+  - expected failure proof on current Stampede consumer record: stale package version and missing `CLAUDE.md`, `CODEX.md`, `docs/EXTERNAL_SERVICES_RUNBOOK.md`, and `scripts/codex-review.sh` consumer-record entries
+- PASS `bash scripts/cross-review/require-dual-signature.sh raw/cross-review/2026-04-29-issue-583-hard-gated-som-enforcement.md`
+- PASS `python3 -m unittest scripts.overlord.test_validate_structured_agent_cycle_plan scripts.overlord.test_validate_handoff_package scripts.overlord.test_verify_governance_consumer scripts.overlord.test_deploy_governance_tooling`
+- PASS `python3 tools/local-ci-gate/bin/hldpro-local-ci run --profile hldpro-governance --json`
+- PASS `git diff --check`
+
+## Tier Evidence Used
+
+- `raw/cross-review/2026-04-29-issue-583-hard-gated-som-enforcement.md`
+
+## Residual Risks / Follow-Up
+
+- GitHub issue: https://github.com/NIBARGERB-HLDPRO/Stampede/issues/197
+  The downstream Stampede lane still needs its repo branch and consumer record
+  upgraded to the hard-gated session-contract package.
+- GitHub issue: https://github.com/NIBARGERB-HLDPRO/hldpro-governance/issues/579
+  The remaining rollout child lanes need the same consumer-record contract
+  upgrade before the org-wide rollout can be called complete.
+
+## Wiki Pages Updated
+
+- None. The governance SSOT is carried in `STANDARDS.md` and
+  `docs/EXTERNAL_SERVICES_RUNBOOK.md` for this slice.
+
+## operator_context Written
+
+[ ] Yes — row ID: [id]
+[x] No — reason: governance-source standards slice; no separate operator-context write required
+
+## Links To
+
+- `docs/plans/issue-583-hard-gated-som-enforcement-pdcar.md`
+- `docs/plans/issue-583-hard-gated-som-enforcement-structured-agent-cycle-plan.json`
+- `raw/handoffs/2026-04-29-issue-583-hard-gated-som-enforcement.json`
+- `raw/cross-review/2026-04-29-issue-583-hard-gated-som-enforcement.md`
+- `raw/validation/2026-04-29-issue-583-hard-gated-som-enforcement.md`

--- a/raw/closeouts/2026-04-29-issue-583-hard-gated-som-enforcement.md
+++ b/raw/closeouts/2026-04-29-issue-583-hard-gated-som-enforcement.md
@@ -69,7 +69,7 @@ contract.
   - `raw/cross-review/2026-04-29-issue-583-hard-gated-som-enforcement.md`
   - `docs/codex-reviews/2026-04-29-claude.md`
 - Gate artifact refs:
-  - `cache/local-ci-gate/reports/20260429T160159Z-hldpro-governance-git/local-ci-20260429T160205Z.json`
+  - command result PASS from `python3 tools/local-ci-gate/bin/hldpro-local-ci run --profile hldpro-governance --json`
 - Handoff lifecycle: accepted
 
 ## Wired Checks Run

--- a/raw/closeouts/2026-04-29-issue-583-hard-gated-som-enforcement.md
+++ b/raw/closeouts/2026-04-29-issue-583-hard-gated-som-enforcement.md
@@ -40,6 +40,8 @@ contract.
 - `scripts/overlord/validate_structured_agent_cycle_plan.py`
 - `scripts/overlord/verify_governance_consumer.py`
 - `docs/plans/issue-583-hard-gated-som-enforcement-structured-agent-cycle-plan.json`
+- `graphify-out/GRAPH_REPORT.md`
+- `graphify-out/graph.json`
 - `raw/handoffs/2026-04-29-issue-583-hard-gated-som-enforcement.json`
 - `raw/validation/2026-04-29-issue-583-hard-gated-som-enforcement.md`
 
@@ -67,7 +69,7 @@ contract.
   - `raw/cross-review/2026-04-29-issue-583-hard-gated-som-enforcement.md`
   - `docs/codex-reviews/2026-04-29-claude.md`
 - Gate artifact refs:
-  - `cache/local-ci-gate/reports/20260429T160006Z-hldpro-governance-git/local-ci-20260429T160012Z.json`
+  - `cache/local-ci-gate/reports/20260429T160159Z-hldpro-governance-git/local-ci-20260429T160205Z.json`
 - Handoff lifecycle: accepted
 
 ## Wired Checks Run

--- a/raw/cross-review/2026-04-29-issue-583-hard-gated-som-enforcement.md
+++ b/raw/cross-review/2026-04-29-issue-583-hard-gated-som-enforcement.md
@@ -1,0 +1,62 @@
+---
+schema_version: v2
+pr_number: pre-pr
+pr_scope: standards
+drafter:
+  role: architect-codex
+  model_id: gpt-5.4
+  model_family: openai
+  signature_date: 2026-04-29
+reviewer:
+  role: architect-claude
+  model_id: claude-opus-4-6
+  model_family: anthropic
+  signature_date: 2026-04-29
+  verdict: APPROVED_WITH_CHANGES
+gate_identity:
+  role: deterministic-local-gate
+  model_id: hldpro-local-ci
+  model_family: deterministic
+  signature_date: 2026-04-29
+invariants_checked:
+  dual_planner_pairing: true
+  no_self_approval: true
+  planning_floor: true
+  pii_floor: true
+  cross_family_independence: true
+---
+
+# Cross-Review — Issue #583 Hard-Gated Issue-Level SoM Enforcement
+
+Source artifact: `docs/codex-reviews/2026-04-29-claude.md`
+
+## Verdict
+
+**APPROVED_WITH_CHANGES**
+
+## Blocking findings
+
+1. The planning packet originally lacked an explicit lifecycle-transition rule
+   explaining when empty review/handoff refs are legal in `planning_only` and
+   when they must become blocking failures.
+2. The planning execution scope originally omitted the `raw/cross-review/...`
+   path needed to capture the review artifact that unblocks implementation.
+
+## Required follow-ups folded into the packet
+
+- Added lifecycle-gated acceptance criteria that distinguish `planning_only`
+  from `implementation_ready` and later states.
+- Added the `raw/cross-review/...` and `docs/codex-reviews/...` artifact paths
+  to the planning execution scope.
+- Clarified that governance CI and the managed consumer-governance contract are
+  both in scope, while direct downstream repo repair remains separate issue
+  `#197`.
+- Recorded the need for bounded exemption schema and structured reviewer
+  identity fields before implementation-ready promotion.
+
+## Remaining conditions before implementation
+
+- Promote the lane to `implementation_ready` only after the implementation scope
+  names the exact schema, validator, test, and CI surfaces to be changed.
+- Keep the replay proof against Stampede issue `#184` as a required validation
+  artifact before calling the source fix complete.

--- a/raw/execution-scopes/2026-04-29-issue-583-hard-gated-som-enforcement-implementation.json
+++ b/raw/execution-scopes/2026-04-29-issue-583-hard-gated-som-enforcement-implementation.json
@@ -6,6 +6,8 @@
     "docs/PROGRESS.md",
     "docs/governance-consumer-pull-state.json",
     "docs/governance-tooling-package.json",
+    "graphify-out/GRAPH_REPORT.md",
+    "graphify-out/graph.json",
     "docs/plans/issue-583-hard-gated-som-enforcement-pdcar.md",
     "docs/plans/issue-583-hard-gated-som-enforcement-structured-agent-cycle-plan.json",
     "raw/execution-scopes/2026-04-29-issue-583-hard-gated-som-enforcement-planning.json",

--- a/raw/execution-scopes/2026-04-29-issue-583-hard-gated-som-enforcement-implementation.json
+++ b/raw/execution-scopes/2026-04-29-issue-583-hard-gated-som-enforcement-implementation.json
@@ -1,0 +1,66 @@
+{
+  "expected_execution_root": ".",
+  "expected_branch": "issue-583-hard-gated-som-enforcement",
+  "execution_mode": "implementation_ready",
+  "allowed_write_paths": [
+    "docs/PROGRESS.md",
+    "docs/governance-consumer-pull-state.json",
+    "docs/governance-tooling-package.json",
+    "docs/plans/issue-583-hard-gated-som-enforcement-pdcar.md",
+    "docs/plans/issue-583-hard-gated-som-enforcement-structured-agent-cycle-plan.json",
+    "raw/execution-scopes/2026-04-29-issue-583-hard-gated-som-enforcement-planning.json",
+    "raw/execution-scopes/2026-04-29-issue-583-hard-gated-som-enforcement-implementation.json",
+    "raw/handoffs/2026-04-29-issue-583-hard-gated-som-enforcement.json",
+    "raw/cross-review/2026-04-29-issue-583-hard-gated-som-enforcement.md",
+    "raw/validation/2026-04-29-issue-583-hard-gated-som-enforcement.md",
+    "raw/closeouts/2026-04-29-issue-583-hard-gated-som-enforcement.md",
+    "docs/codex-reviews/2026-04-29-claude.md",
+    "docs/schemas/structured-agent-cycle-plan.schema.json",
+    "docs/schemas/package-handoff.schema.json",
+    "scripts/overlord/validate_structured_agent_cycle_plan.py",
+    "scripts/overlord/validate_handoff_package.py",
+    "scripts/overlord/test_validate_structured_agent_cycle_plan.py",
+    "scripts/overlord/test_validate_handoff_package.py",
+    "scripts/overlord/deploy_governance_tooling.py",
+    "scripts/overlord/test_deploy_governance_tooling.py",
+    "scripts/overlord/verify_governance_consumer.py",
+    "scripts/overlord/test_verify_governance_consumer.py",
+    ".github/workflows/governance-check.yml",
+    "tools/local-ci-gate/profiles/hldpro-governance.yml",
+    "STANDARDS.md",
+    "docs/EXTERNAL_SERVICES_RUNBOOK.md"
+  ],
+  "forbidden_roots": [
+    "/Users/bennibarger/Developer/HLDPRO/hldpro-governance",
+    "/Users/bennibarger/Developer/HLDPRO/Stampede"
+  ],
+  "active_parallel_roots": [
+    {
+      "path": "/Users/bennibarger/Developer/HLDPRO/hldpro-governance",
+      "reason": "Primary governance checkout remains dirty in unrelated files; issue-583 implementation stays isolated in this clean worktree."
+    },
+    {
+      "path": "/Users/bennibarger/Developer/HLDPRO/Stampede",
+      "reason": "Stampede repair remains separate issue #197 and serves only as downstream replay proof during this source-fix lane."
+    }
+  ],
+  "lane_claim": {
+    "issue_number": 583,
+    "claim_ref": "https://github.com/NIBARGERB-HLDPRO/hldpro-governance/issues/583",
+    "claimed_by": "codex",
+    "claimed_at": "2026-04-29T13:05:00Z"
+  },
+  "handoff_evidence": {
+    "status": "accepted",
+    "planner_model": "gpt-5.4",
+    "implementer_model": "gpt-5.4",
+    "accepted_at": "2026-04-29T13:05:00Z",
+    "evidence_paths": [
+      "docs/plans/issue-583-hard-gated-som-enforcement-structured-agent-cycle-plan.json",
+      "docs/plans/issue-583-hard-gated-som-enforcement-pdcar.md",
+      "raw/cross-review/2026-04-29-issue-583-hard-gated-som-enforcement.md"
+    ],
+    "active_exception_ref": "docs/plans/issue-583-hard-gated-som-enforcement-pdcar.md",
+    "active_exception_expires_at": "2026-04-30T13:05:00Z"
+  }
+}

--- a/raw/execution-scopes/2026-04-29-issue-583-hard-gated-som-enforcement-planning.json
+++ b/raw/execution-scopes/2026-04-29-issue-583-hard-gated-som-enforcement-planning.json
@@ -1,0 +1,47 @@
+{
+  "expected_execution_root": ".",
+  "expected_branch": "issue-583-hard-gated-som-enforcement",
+  "execution_mode": "planning_only",
+  "allowed_write_paths": [
+    "docs/PROGRESS.md",
+    "docs/plans/issue-583-hard-gated-som-enforcement-pdcar.md",
+    "docs/plans/issue-583-hard-gated-som-enforcement-structured-agent-cycle-plan.json",
+    "raw/execution-scopes/2026-04-29-issue-583-hard-gated-som-enforcement-planning.json",
+    "raw/handoffs/2026-04-29-issue-583-hard-gated-som-enforcement.json",
+    "raw/cross-review/2026-04-29-issue-583-hard-gated-som-enforcement.md",
+    "docs/codex-reviews/2026-04-29-claude.md",
+    "raw/validation/2026-04-29-issue-583-hard-gated-som-enforcement.md"
+  ],
+  "forbidden_roots": [
+    "/Users/bennibarger/Developer/HLDPRO/hldpro-governance",
+    "/Users/bennibarger/Developer/HLDPRO/Stampede"
+  ],
+  "active_parallel_roots": [
+    {
+      "path": "/Users/bennibarger/Developer/HLDPRO/hldpro-governance",
+      "reason": "Primary governance checkout remains dirty in unrelated files; issue-583 work is isolated in this clean worktree."
+    },
+    {
+      "path": "/Users/bennibarger/Developer/HLDPRO/Stampede",
+      "reason": "Stampede issue #184 repair is routed to separate issue #197 after the governance source fix lands."
+    }
+  ],
+  "lane_claim": {
+    "issue_number": 583,
+    "claim_ref": "https://github.com/NIBARGERB-HLDPRO/hldpro-governance/issues/583",
+    "claimed_by": "codex",
+    "claimed_at": "2026-04-29T12:10:00Z"
+  },
+  "handoff_evidence": {
+    "status": "accepted",
+    "planner_model": "gpt-5.4",
+    "implementer_model": "gpt-5.4",
+    "accepted_at": "2026-04-29T12:10:00Z",
+    "evidence_paths": [
+      "docs/plans/issue-583-hard-gated-som-enforcement-structured-agent-cycle-plan.json",
+      "docs/plans/issue-583-hard-gated-som-enforcement-pdcar.md"
+    ],
+    "active_exception_ref": "docs/plans/issue-583-hard-gated-som-enforcement-pdcar.md",
+    "active_exception_expires_at": "2026-04-30T12:10:00Z"
+  }
+}

--- a/raw/handoffs/2026-04-29-issue-583-hard-gated-som-enforcement.json
+++ b/raw/handoffs/2026-04-29-issue-583-hard-gated-som-enforcement.json
@@ -1,0 +1,108 @@
+{
+  "schema_version": "v1",
+  "handoff_id": "issue-583-hard-gated-som-enforcement",
+  "issue_number": 583,
+  "parent_epic_number": 579,
+  "lifecycle_state": "implementation_ready",
+  "from_role": "codex-orchestrator",
+  "to_role": "codex-orchestrator",
+  "structured_plan_ref": "docs/plans/issue-583-hard-gated-som-enforcement-structured-agent-cycle-plan.json",
+  "execution_scope_ref": "raw/execution-scopes/2026-04-29-issue-583-hard-gated-som-enforcement-implementation.json",
+  "packet_ref": null,
+  "package_manifest_ref": null,
+  "acceptance_criteria": [
+    {
+      "id": "AC1",
+      "statement": "Governed plans record enough identity metadata to prove reviewer independence, and self-reviewed governed plans fail the structured-plan validator.",
+      "verification_refs": [
+        "docs/plans/issue-583-hard-gated-som-enforcement-pdcar.md",
+        "docs/plans/issue-583-hard-gated-som-enforcement-structured-agent-cycle-plan.json",
+        "docs/schemas/structured-agent-cycle-plan.schema.json",
+        "scripts/overlord/validate_structured_agent_cycle_plan.py"
+      ]
+    },
+    {
+      "id": "AC2",
+      "statement": "alternate_model_review may be bypassed only with a bounded legal exemption that the validator recognizes and rejects otherwise.",
+      "verification_refs": [
+        "STANDARDS.md",
+        "docs/EXTERNAL_SERVICES_RUNBOOK.md",
+        "docs/schemas/structured-agent-cycle-plan.schema.json",
+        "scripts/overlord/validate_structured_agent_cycle_plan.py"
+      ]
+    },
+    {
+      "id": "AC3",
+      "statement": "Lifecycle gates are explicit and enforced: planning_only lanes may defer populated review refs only until alternate-family review is complete, promotion to implementation_ready requires accepted review evidence plus non-empty review refs, and continuing governed handoffs from implementation_ready onward require non-null handoff evidence and fail closed when missing.",
+      "verification_refs": [
+        "docs/plans/issue-583-hard-gated-som-enforcement-pdcar.md",
+        "docs/schemas/package-handoff.schema.json",
+        "scripts/overlord/validate_structured_agent_cycle_plan.py",
+        "scripts/overlord/validate_handoff_package.py"
+      ]
+    },
+    {
+      "id": "AC4",
+      "statement": "Governance CI and the managed consumer-governance contract run the structured-plan and handoff validators as blocking checks, and proof shows the old Stampede issue-184 packet shape would now fail.",
+      "verification_refs": [
+        ".github/workflows/governance-check.yml",
+        "tools/local-ci-gate/profiles/hldpro-governance.yml",
+        "raw/validation/2026-04-29-issue-583-hard-gated-som-enforcement.md",
+        "https://github.com/NIBARGERB-HLDPRO/Stampede/issues/184"
+      ]
+    },
+    {
+      "id": "AC5",
+      "statement": "Alternate-review exemptions, if allowed at all, use a bounded schema with explicit type, grant authority, and expiry; free-text bypasses do not satisfy the validator.",
+      "verification_refs": [
+        "docs/plans/issue-583-hard-gated-som-enforcement-pdcar.md",
+        "docs/schemas/structured-agent-cycle-plan.schema.json",
+        "scripts/overlord/validate_structured_agent_cycle_plan.py",
+        "STANDARDS.md"
+      ]
+    }
+  ],
+  "validation_commands": [
+    "python3 scripts/overlord/validate_structured_agent_cycle_plan.py --root . --branch-name issue-583-hard-gated-som-enforcement --require-if-issue-branch",
+    "python3 scripts/overlord/validate_handoff_package.py --root . raw/handoffs/2026-04-29-issue-583-hard-gated-som-enforcement.json",
+    "python3 scripts/overlord/verify_governance_consumer.py --governance-root . --target-repo /Users/bennibarger/Developer/HLDPRO/Stampede",
+    "bash scripts/cross-review/require-dual-signature.sh raw/cross-review/2026-04-29-issue-583-hard-gated-som-enforcement.md",
+    "python3 -m unittest scripts.overlord.test_validate_structured_agent_cycle_plan scripts.overlord.test_validate_handoff_package scripts.overlord.test_verify_governance_consumer scripts.overlord.test_deploy_governance_tooling",
+    "git diff --check"
+  ],
+  "review_artifact_refs": [
+    "raw/cross-review/2026-04-29-issue-583-hard-gated-som-enforcement.md"
+  ],
+  "validation_artifact_refs": [
+    "raw/validation/2026-04-29-issue-583-hard-gated-som-enforcement.md"
+  ],
+  "gate_artifact_refs": [
+    "cache/local-ci-gate/reports/20260429T155625Z-hldpro-governance-git/local-ci-20260429T155632Z.json"
+  ],
+  "artifact_refs": [
+    "docs/PROGRESS.md",
+    "docs/plans/issue-583-hard-gated-som-enforcement-pdcar.md",
+    "docs/plans/issue-583-hard-gated-som-enforcement-structured-agent-cycle-plan.json",
+    "raw/execution-scopes/2026-04-29-issue-583-hard-gated-som-enforcement-planning.json",
+    "raw/execution-scopes/2026-04-29-issue-583-hard-gated-som-enforcement-implementation.json",
+    "docs/codex-reviews/2026-04-29-claude.md",
+    "docs/schemas/structured-agent-cycle-plan.schema.json",
+    "docs/schemas/package-handoff.schema.json",
+    "scripts/overlord/validate_structured_agent_cycle_plan.py",
+    "scripts/overlord/validate_handoff_package.py",
+    ".github/workflows/governance-check.yml",
+    "tools/local-ci-gate/profiles/hldpro-governance.yml",
+    "docs/governance-consumer-pull-state.json",
+    "docs/governance-tooling-package.json",
+    "scripts/overlord/verify_governance_consumer.py",
+    "scripts/overlord/test_verify_governance_consumer.py",
+    "scripts/overlord/deploy_governance_tooling.py",
+    "scripts/overlord/test_deploy_governance_tooling.py"
+  ],
+  "audit_refs": [],
+  "closeout_ref": "raw/closeouts/2026-04-29-issue-583-hard-gated-som-enforcement.md",
+  "blocked_on": [],
+  "handoff_decision": "accepted",
+  "created_at": "2026-04-29T12:10:00Z",
+  "notes": "Promoted to implementation-ready after the alternate-family review conditions were folded into the planning packet, the cross-review artifact was recorded, and the bounded implementation execution scope was declared."
+}

--- a/raw/handoffs/2026-04-29-issue-583-hard-gated-som-enforcement.json
+++ b/raw/handoffs/2026-04-29-issue-583-hard-gated-som-enforcement.json
@@ -77,7 +77,7 @@
     "raw/validation/2026-04-29-issue-583-hard-gated-som-enforcement.md"
   ],
   "gate_artifact_refs": [
-    "cache/local-ci-gate/reports/20260429T155625Z-hldpro-governance-git/local-ci-20260429T155632Z.json"
+    "raw/validation/2026-04-29-issue-583-hard-gated-som-enforcement.md"
   ],
   "artifact_refs": [
     "docs/PROGRESS.md",

--- a/raw/validation/2026-04-29-issue-583-hard-gated-som-enforcement.md
+++ b/raw/validation/2026-04-29-issue-583-hard-gated-som-enforcement.md
@@ -1,0 +1,47 @@
+# Issue #583 Implementation Validation
+
+Date: `2026-04-29`
+Issue: `#583`
+Branch: `issue-583-hard-gated-som-enforcement`
+
+## Scope
+
+Validate the implementation-ready packet and bounded governance-source changes
+for the hard-gated issue-level Society of Minds enforcement fix, including the
+consumer-verifier and reusable-workflow wiring that make the stronger contract
+blocking instead of advisory.
+
+## Commands
+
+- `python3 scripts/overlord/validate_structured_agent_cycle_plan.py --root . --branch-name issue-583-hard-gated-som-enforcement --require-if-issue-branch`
+- `python3 scripts/overlord/validate_handoff_package.py --root . raw/handoffs/2026-04-29-issue-583-hard-gated-som-enforcement.json`
+- `python3 scripts/overlord/verify_governance_consumer.py --governance-root . --target-repo /Users/bennibarger/Developer/HLDPRO/Stampede`
+- `bash scripts/cross-review/require-dual-signature.sh raw/cross-review/2026-04-29-issue-583-hard-gated-som-enforcement.md`
+- `python3 -m unittest scripts.overlord.test_validate_structured_agent_cycle_plan scripts.overlord.test_validate_handoff_package scripts.overlord.test_verify_governance_consumer scripts.overlord.test_deploy_governance_tooling`
+- `tmp=$(mktemp -d) && mkdir -p "$tmp/docs/plans" && cp /Users/bennibarger/Developer/HLDPRO/Stampede/docs/plans/issue-184-structured-agent-cycle-plan.json "$tmp/docs/plans/issue-184-structured-agent-cycle-plan.json" && python3 scripts/overlord/validate_structured_agent_cycle_plan.py --root "$tmp" --branch-name feat/issue-184-offline-research-staging-20260426 --require-if-issue-branch`
+- `git diff --check`
+
+## Results
+
+- PASS: structured-plan validator accepts the issue-583 implementation-ready packet.
+- PASS: handoff validator accepts the issue-583 implementation-ready handoff.
+- PASS: cross-review dual-signature gate accepts the issue-583 alternate-family review artifact.
+- PASS: focused unittest coverage is green, including verifier and deployer contract coverage.
+- PASS: downstream replay of the live Stampede issue-184 plan shape now fails closed with the hardened validator.
+- PASS: consumer verification now fails closed when a governed repo claims package consumption without the required thin tracked session-contract entries.
+- PASS: `git diff --check`.
+- PASS WITH CONDITIONS: alternate-family review accepted the hard-gated
+  direction and the packet now reflects the required lifecycle-transition and
+  writable cross-review changes before implementation.
+
+## Notes
+
+- The packet is promoted to `implementation_ready` after the governed
+  alternate-family review was recorded through `scripts/codex-review.sh claude`
+  and the implementation execution scope was declared.
+- The downstream replay currently fails on the exact missing surfaces we expect:
+  missing `plan_author`, missing specialist-review identity metadata, and null
+  `execution_handoff.handoff_package_ref` on the live Stampede issue-184 plan.
+- Consumer verification remains a migration gate for downstream repos: once the
+  issue-583 contract is merged, repos with legacy consumer records will fail
+  until their records declare the required thin session-contract surfaces.

--- a/scripts/overlord/deploy_governance_tooling.py
+++ b/scripts/overlord/deploy_governance_tooling.py
@@ -14,6 +14,7 @@ import deploy_local_ci_gate
 
 GOVERNANCE_ROOT = Path(__file__).resolve().parents[2]
 PACKAGE_MANIFEST = GOVERNANCE_ROOT / "docs" / "governance-tooling-package.json"
+DESIRED_STATE = GOVERNANCE_ROOT / "docs" / "governance-consumer-pull-state.json"
 CONSUMER_RECORD_PATH = ".hldpro/governance-tooling.json"
 DEFAULT_PROFILE = "hldpro-governance"
 DEFAULT_SHIM_PATH = ".hldpro/local-ci.sh"
@@ -37,19 +38,17 @@ class ToolingPlan:
     existing_shim_state: str
     existing_record_state: str
 
-    def managed_files(self) -> list[dict[str, str]]:
-        return [
-            {
-                "path": self.shim_path.relative_to(self.target_repo).as_posix(),
-                "type": "local_ci_shim",
-                "state": self.existing_shim_state,
-            },
-            {
-                "path": self.record_path.relative_to(self.target_repo).as_posix(),
-                "type": "consumer_record",
-                "state": self.existing_record_state,
-            },
-        ]
+    def managed_files(self) -> list[dict[str, object]]:
+        desired_state = _load_json(self.governance_root / "docs" / "governance-consumer-pull-state.json", "consumer pull desired state")
+        return _managed_file_contract_entries(
+            desired_state,
+            self.profile,
+            self.target_repo,
+            self.shim_path,
+            self.record_path,
+            self.existing_shim_state,
+            self.existing_record_state,
+        )
 
     def planned_write_set(self) -> list[str]:
         return [str(self.shim_path), str(self.record_path)]
@@ -115,6 +114,16 @@ def _load_manifest(path: Path) -> dict[str, object]:
     return payload
 
 
+def _load_json(path: Path, label: str) -> dict[str, object]:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        _fail(f"could not load {label} {path}: {exc}")
+    if not isinstance(payload, dict):
+        _fail(f"{label} must be a JSON object: {path}")
+    return payload
+
+
 def _consumer_record_relpath(manifest: dict[str, object]) -> str:
     versioning = manifest.get("versioning")
     if isinstance(versioning, dict):
@@ -124,15 +133,83 @@ def _consumer_record_relpath(manifest: dict[str, object]) -> str:
     return CONSUMER_RECORD_PATH
 
 
-def _package_version(manifest: dict[str, object], override: str | None) -> str:
+def _profile_desired_state(desired_state: dict[str, object], profile: str) -> dict[str, object]:
+    profiles = desired_state.get("profiles")
+    if not isinstance(profiles, dict):
+        return {}
+    state = profiles.get(profile)
+    return state if isinstance(state, dict) else {}
+
+
+def _package_version(
+    manifest: dict[str, object],
+    desired_state: dict[str, object],
+    profile: str,
+    override: str | None,
+) -> str:
     if override:
         return override
+    profile_state = _profile_desired_state(desired_state, profile)
+    profile_version = profile_state.get("package_version")
+    if isinstance(profile_version, str) and profile_version:
+        return profile_version
     versioning = manifest.get("versioning")
     if isinstance(versioning, dict):
         raw = versioning.get("initial_version")
         if isinstance(raw, str) and raw:
             return raw
     return "0.0.0-unknown"
+
+
+def _managed_file_contract_entries(
+    desired_state: dict[str, object],
+    profile: str,
+    target_repo: Path,
+    shim_path: Path,
+    record_path: Path,
+    existing_shim_state: str,
+    existing_record_state: str,
+) -> list[dict[str, object]]:
+    profile_state = _profile_desired_state(desired_state, profile)
+    raw = profile_state.get("managed_files")
+    if not isinstance(raw, list):
+        raw = [".hldpro/local-ci.sh", ".hldpro/governance-tooling.json"]
+    shim_rel = shim_path.relative_to(target_repo).as_posix()
+    record_rel = record_path.relative_to(target_repo).as_posix()
+    entries: list[dict[str, object]] = []
+    for item in raw:
+        if isinstance(item, str):
+            relpath = item
+            entry: dict[str, object] = {"path": relpath}
+        elif isinstance(item, dict) and isinstance(item.get("path"), str) and item["path"]:
+            relpath = item["path"]
+            entry = {"path": relpath}
+            for key in ("type", "required_strings", "required_pre_tool_use_matchers", "required_post_tool_use_matchers"):
+                value = item.get(key)
+                if isinstance(value, str):
+                    entry[key] = value
+                elif isinstance(value, list) and all(isinstance(member, str) for member in value):
+                    entry[key] = list(value)
+        else:
+            continue
+        if relpath == shim_rel:
+            entry["type"] = "local_ci_shim"
+            entry["state"] = existing_shim_state
+        elif relpath == record_rel:
+            entry["type"] = "consumer_record"
+            entry["state"] = existing_record_state
+        else:
+            entry["state"] = "present" if (target_repo / relpath).exists() else "missing"
+        entries.append(entry)
+    return entries
+
+
+def _profile_constraints(desired_state: dict[str, object], profile: str) -> list[str]:
+    profile_state = _profile_desired_state(desired_state, profile)
+    raw = profile_state.get("profile_constraints")
+    if isinstance(raw, list) and all(isinstance(item, str) for item in raw):
+        return list(raw)
+    return []
 
 
 def _record_state(path: Path) -> str:
@@ -173,11 +250,12 @@ def build_plan(args: argparse.Namespace) -> ToolingPlan:
         _fail(f"governance root must exist and be a directory: {governance_root}")
     manifest_path = Path(args.manifest).resolve() if args.manifest else governance_root / "docs" / "governance-tooling-package.json"
     manifest = _load_manifest(manifest_path)
+    desired_state = _load_json(governance_root / "docs" / "governance-consumer-pull-state.json", "consumer pull desired state")
 
     target_repo = _git_root(Path(args.target_repo).resolve())
     governance_ref = args.governance_ref or _git_head(governance_root)
-    package_version = _package_version(manifest, args.package_version)
     profile = args.profile or DEFAULT_PROFILE
+    package_version = _package_version(manifest, desired_state, profile, args.package_version)
 
     shim_path = deploy_local_ci_gate._resolve_shim_path(target_repo, args.shim_path or DEFAULT_SHIM_PATH)
     record_path = (target_repo / _consumer_record_relpath(manifest)).resolve()
@@ -209,8 +287,11 @@ def _refuse_unmanaged_record(plan: ToolingPlan, force: bool) -> None:
 
 
 def _consumer_record(plan: ToolingPlan) -> dict[str, object]:
-    return {
-        "schema_version": 1,
+    desired_state = _load_json(plan.governance_root / "docs" / "governance-consumer-pull-state.json", "consumer pull desired state")
+    profile_constraints = _profile_constraints(desired_state, plan.profile)
+    schema_version = 2 if plan.package_version == "0.3.0-hard-gated-som" or profile_constraints else 1
+    record = {
+        "schema_version": schema_version,
         "consumer_repo": str(plan.target_repo),
         "governance_repo": "NIBARGERB-HLDPRO/hldpro-governance",
         "governance_root": str(plan.governance_root),
@@ -233,6 +314,9 @@ def _consumer_record(plan: ToolingPlan) -> dict[str, object]:
         ],
         "overrides": [],
     }
+    if profile_constraints:
+        record["profile_constraints"] = profile_constraints
+    return record
 
 
 def apply(plan: ToolingPlan, *, allow_dirty_target: bool, force: bool) -> dict[str, object]:

--- a/scripts/overlord/test_deploy_governance_tooling.py
+++ b/scripts/overlord/test_deploy_governance_tooling.py
@@ -96,6 +96,45 @@ class TestDeployGovernanceTooling(unittest.TestCase):
         self.assertEqual(record["overrides"], [])
         self.assertEqual({item["path"] for item in record["managed_files"]}, {".hldpro/local-ci.sh", ".hldpro/governance-tooling.json"})
 
+    def test_apply_consumer_profile_records_required_session_contract_surfaces(self) -> None:
+        (self.product / "CLAUDE.md").write_text("thin pointer\n", encoding="utf-8")
+        (self.product / "CODEX.md").write_text("thin pointer\n", encoding="utf-8")
+        runbook = self.product / "docs" / "EXTERNAL_SERVICES_RUNBOOK.md"
+        runbook.parent.mkdir(parents=True, exist_ok=True)
+        runbook.write_text("governance pointer\n", encoding="utf-8")
+        review = self.product / "scripts" / "codex-review.sh"
+        review.parent.mkdir(parents=True, exist_ok=True)
+        review.write_text("#!/usr/bin/env bash\n# claude\n", encoding="utf-8")
+
+        code, stdout, stderr = self._invoke(
+            "apply",
+            "--governance-root",
+            str(REPO_ROOT),
+            "--target-repo",
+            str(self.product),
+            "--governance-ref",
+            self.ref,
+            "--profile",
+            "stampede",
+            "--allow-dirty-target",
+        )
+
+        self.assertEqual(code, 0, stderr)
+        record = json.loads(self._record().read_text(encoding="utf-8"))
+        self.assertEqual(record["schema_version"], 2)
+        self.assertEqual(record["package_version"], "0.3.0-hard-gated-som")
+        self.assertEqual(
+            {item["path"] for item in record["managed_files"]},
+            {
+                ".hldpro/local-ci.sh",
+                ".hldpro/governance-tooling.json",
+                "CLAUDE.md",
+                "CODEX.md",
+                "docs/EXTERNAL_SERVICES_RUNBOOK.md",
+                "scripts/codex-review.sh",
+            },
+        )
+
     def test_verify_passes_after_apply(self) -> None:
         apply_code, _, apply_err = self._invoke("apply", *self._base_args())
         self.assertEqual(apply_code, 0, apply_err)

--- a/scripts/overlord/test_validate_structured_agent_cycle_plan.py
+++ b/scripts/overlord/test_validate_structured_agent_cycle_plan.py
@@ -20,8 +20,42 @@ def _plan(
     review_status: str = "accepted",
     review_required: bool = True,
     approved_at: str = "2026-04-28T19:00:00Z",
+    include_plan_author: bool = True,
+    include_reviewer_identity: bool = True,
+    same_model_self_review: bool = False,
+    include_review_artifact_refs: bool = True,
+    include_handoff_package_ref: bool = True,
+    review_exemption: dict | None = None,
 ) -> dict:
-    return {
+    review: dict[str, object] = {
+        "reviewer": "test",
+        "role": "test",
+        "focus": "test",
+        "status": "accepted",
+        "summary": "test",
+        "evidence": ["test"],
+    }
+    if include_reviewer_identity:
+        review["reviewer_model_id"] = "gpt-5.4" if same_model_self_review else "claude-opus-4-6"
+        review["reviewer_model_family"] = "openai" if same_model_self_review else "anthropic"
+
+    execution_handoff: dict[str, object] = {
+        "session_agent": "codex",
+        "execution_mode": mode,
+        "approved_scope_summary": "test",
+        "next_execution_step": "test",
+        "blocked_on": [],
+    }
+    if include_handoff_package_ref:
+        execution_handoff["handoff_package_ref"] = f"raw/handoffs/2026-04-17-issue-{issue_number}.json"
+    else:
+        execution_handoff["handoff_package_ref"] = None
+    if include_review_artifact_refs:
+        execution_handoff["review_artifact_refs"] = ["raw/cross-review/example.md"]
+    else:
+        execution_handoff["review_artifact_refs"] = []
+
+    payload = {
         "session_id": f"test-{issue_number}",
         "issue_number": issue_number,
         "objective": "test",
@@ -40,14 +74,7 @@ def _plan(
             }
         ],
         "specialist_reviews": [
-            {
-                "reviewer": "test",
-                "role": "test",
-                "focus": "test",
-                "status": "accepted",
-                "summary": "test",
-                "evidence": ["test"],
-            }
+            review
         ],
         "alternate_model_review": {
             "required": review_required,
@@ -56,19 +83,21 @@ def _plan(
             "status": review_status,
             "summary": "test",
             "evidence": ["test"],
+            **({"exemption": review_exemption} if review_exemption is not None else {}),
         },
-        "execution_handoff": {
-            "session_agent": "codex",
-            "execution_mode": mode,
-            "approved_scope_summary": "test",
-            "next_execution_step": "test",
-            "blocked_on": [],
-        },
+        "execution_handoff": execution_handoff,
         "material_deviation_rules": ["test"],
         "approved": approved,
         "approved_by": ["test"],
         "approved_at": approved_at,
     }
+    if include_plan_author:
+        payload["plan_author"] = {
+            "role": "codex-orchestrator",
+            "model_id": "gpt-5.4",
+            "model_family": "openai",
+        }
+    return payload
 
 
 class TestGovernanceSurfacePlanGate(unittest.TestCase):
@@ -361,6 +390,224 @@ class TestGovernanceSurfacePlanGate(unittest.TestCase):
         self.assertEqual(result.returncode, 1)
         self.assertIn("alternate_model_review.required` to true", result.stdout)
 
+    def test_active_issue_branch_requires_plan_author_identity(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            root = Path(raw)
+            plan_path = root / "docs" / "plans" / "issue-226-structured-agent-cycle-plan.json"
+            plan_path.parent.mkdir(parents=True)
+            plan_path.write_text(
+                json.dumps(_plan(226, approved_at="2026-04-29T13:10:00Z", include_plan_author=False)),
+                encoding="utf-8",
+            )
+            result = subprocess.run(
+                [
+                    "python3",
+                    str(VALIDATOR),
+                    "--root",
+                    str(root),
+                    "--branch-name",
+                    "issue-226-test",
+                    "--require-if-issue-branch",
+                ],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("`plan_author` must be an object", result.stdout)
+
+    def test_active_issue_branch_rejects_same_model_self_review(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            root = Path(raw)
+            plan_path = root / "docs" / "plans" / "issue-226-structured-agent-cycle-plan.json"
+            plan_path.parent.mkdir(parents=True)
+            plan_path.write_text(
+                json.dumps(_plan(226, approved_at="2026-04-29T13:10:00Z", same_model_self_review=True)),
+                encoding="utf-8",
+            )
+            result = subprocess.run(
+                [
+                    "python3",
+                    str(VALIDATOR),
+                    "--root",
+                    str(root),
+                    "--branch-name",
+                    "issue-226-test",
+                    "--require-if-issue-branch",
+                ],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("cannot self-approve with the same model identity as `plan_author`", result.stdout)
+
+    def test_active_issue_branch_requires_review_refs_once_specialist_review_is_accepted(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            root = Path(raw)
+            plan_path = root / "docs" / "plans" / "issue-226-structured-agent-cycle-plan.json"
+            plan_path.parent.mkdir(parents=True)
+            plan_path.write_text(
+                json.dumps(_plan(226, approved_at="2026-04-29T13:10:00Z", include_review_artifact_refs=False)),
+                encoding="utf-8",
+            )
+            result = subprocess.run(
+                [
+                    "python3",
+                    str(VALIDATOR),
+                    "--root",
+                    str(root),
+                    "--branch-name",
+                    "issue-226-test",
+                    "--require-if-issue-branch",
+                ],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("requires non-empty `execution_handoff.review_artifact_refs`", result.stdout)
+
+    def test_active_issue_branch_requires_handoff_package_ref(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            root = Path(raw)
+            plan_path = root / "docs" / "plans" / "issue-226-structured-agent-cycle-plan.json"
+            plan_path.parent.mkdir(parents=True)
+            plan_path.write_text(
+                json.dumps(_plan(226, approved_at="2026-04-29T13:10:00Z", include_handoff_package_ref=False)),
+                encoding="utf-8",
+            )
+            result = subprocess.run(
+                [
+                    "python3",
+                    str(VALIDATOR),
+                    "--root",
+                    str(root),
+                    "--branch-name",
+                    "issue-226-test",
+                    "--require-if-issue-branch",
+                ],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("require a non-null `execution_handoff.handoff_package_ref`", result.stdout)
+
+    def test_planning_only_active_issue_branch_requires_legal_alternate_review_exemption(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            root = Path(raw)
+            plan_path = root / "docs" / "plans" / "issue-226-structured-agent-cycle-plan.json"
+            plan_path.parent.mkdir(parents=True)
+            plan_path.write_text(
+                json.dumps(
+                    _plan(
+                        226,
+                        mode="planning_only",
+                        review_required=False,
+                        review_status="not_requested",
+                        approved_at="2026-04-29T13:10:00Z",
+                    )
+                ),
+                encoding="utf-8",
+            )
+            result = subprocess.run(
+                [
+                    "python3",
+                    str(VALIDATOR),
+                    "--root",
+                    str(root),
+                    "--branch-name",
+                    "issue-226-test",
+                    "--require-if-issue-branch",
+                ],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("alternate_model_review.exemption` must be present", result.stdout)
+
+    def test_planning_only_active_issue_branch_accepts_bounded_historical_exemption(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            root = Path(raw)
+            plan_path = root / "docs" / "plans" / "issue-226-structured-agent-cycle-plan.json"
+            plan_path.parent.mkdir(parents=True)
+            plan_path.write_text(
+                json.dumps(
+                    _plan(
+                        226,
+                        mode="planning_only",
+                        review_required=False,
+                        review_status="not_requested",
+                        approved_at="2026-04-29T13:10:00Z",
+                        review_exemption={
+                            "exemption_type": "historical_grandfathered",
+                            "granted_by": "governance-board",
+                            "expires_at": "2026-05-01T00:00:00Z",
+                            "rationale": "historical carry-forward",
+                        },
+                    )
+                ),
+                encoding="utf-8",
+            )
+            result = subprocess.run(
+                [
+                    "python3",
+                    str(VALIDATOR),
+                    "--root",
+                    str(root),
+                    "--branch-name",
+                    "issue-226-test",
+                    "--require-if-issue-branch",
+                ],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+
+    def test_stampede_issue_184_failure_shape_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            root = Path(raw)
+            plan_path = root / "docs" / "plans" / "issue-184-structured-agent-cycle-plan.json"
+            plan_path.parent.mkdir(parents=True)
+            payload = _plan(
+                184,
+                mode="planning_only",
+                review_required=False,
+                review_status="not_requested",
+                approved_at="2026-04-29T14:00:00Z",
+                include_plan_author=False,
+                include_reviewer_identity=False,
+                include_review_artifact_refs=False,
+                include_handoff_package_ref=False,
+            )
+            payload["specialist_reviews"][0]["reviewer"] = "Codex orchestrator"
+            payload["specialist_reviews"][0]["role"] = "repo-governance and Path A planning reviewer"
+            payload["execution_handoff"]["review_artifact_refs"] = []
+            payload["execution_handoff"]["handoff_package_ref"] = None
+            plan_path.write_text(json.dumps(payload), encoding="utf-8")
+            result = subprocess.run(
+                [
+                    "python3",
+                    str(VALIDATOR),
+                    "--root",
+                    str(root),
+                    "--branch-name",
+                    "feat/issue-184-offline-research-staging",
+                    "--require-if-issue-branch",
+                ],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("`plan_author` must be an object", result.stdout)
+        self.assertIn("alternate_model_review.exemption` must be present", result.stdout)
+        self.assertIn("requires non-empty `execution_handoff.review_artifact_refs`", result.stdout)
+        self.assertIn("require a non-null `execution_handoff.handoff_package_ref`", result.stdout)
+
     def test_historical_implementation_ready_plan_does_not_fail_without_matching_issue_branch(self) -> None:
         with tempfile.TemporaryDirectory() as raw:
             root = Path(raw)
@@ -381,7 +628,7 @@ class TestGovernanceSurfacePlanGate(unittest.TestCase):
         self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
         self.assertIn("PASS validated 1 structured agent cycle plan file", result.stdout)
 
-    def test_historical_issue_branch_plan_is_grandfathered_before_review_gate_cutover(self) -> None:
+    def test_active_issue_branch_is_not_grandfathered_out_of_new_identity_gate(self) -> None:
         with tempfile.TemporaryDirectory() as raw:
             root = Path(raw)
             plan_path = root / "docs" / "plans" / "issue-109-structured-agent-cycle-plan.json"
@@ -393,6 +640,10 @@ class TestGovernanceSurfacePlanGate(unittest.TestCase):
                         review_status="accepted_with_followup",
                         review_required=False,
                         approved_at="2026-04-19T19:25:00Z",
+                        include_plan_author=False,
+                        include_reviewer_identity=False,
+                        include_review_artifact_refs=False,
+                        include_handoff_package_ref=False,
                     )
                 ),
                 encoding="utf-8",
@@ -411,7 +662,8 @@ class TestGovernanceSurfacePlanGate(unittest.TestCase):
                 capture_output=True,
                 text=True,
             )
-        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("`plan_author` must be an object", result.stdout)
 
     def test_malformed_json_reports_structured_fail_without_traceback(self) -> None:
         with tempfile.TemporaryDirectory() as raw:

--- a/scripts/overlord/test_verify_governance_consumer.py
+++ b/scripts/overlord/test_verify_governance_consumer.py
@@ -567,6 +567,14 @@ class TestVerifyGovernanceConsumer(unittest.TestCase):
         hook = self.product / ".claude" / "hooks" / "pre-tool-use.sh"
         hook.parent.mkdir(parents=True)
         hook.write_text("# hldpro-governance managed\necho ok\n", encoding="utf-8")
+        (self.product / "CLAUDE.md").write_text("See hldpro-governance STANDARDS.md\n", encoding="utf-8")
+        (self.product / "CODEX.md").write_text("Codex is the supervisor/orchestrator in hldpro-governance.\n", encoding="utf-8")
+        runbook = self.product / "docs" / "EXTERNAL_SERVICES_RUNBOOK.md"
+        runbook.parent.mkdir(parents=True, exist_ok=True)
+        runbook.write_text("See hldpro-governance EXTERNAL_SERVICES_RUNBOOK.md\n", encoding="utf-8")
+        review = self.product / "scripts" / "codex-review.sh"
+        review.parent.mkdir(parents=True, exist_ok=True)
+        review.write_text("#!/usr/bin/env bash\n# claude\n", encoding="utf-8")
         record = self._read_record()
         record["schema_version"] = 2
         record["profile_constraints"] = self._required_constraints("healthcareplatform")
@@ -611,6 +619,60 @@ class TestVerifyGovernanceConsumer(unittest.TestCase):
         self.assertEqual(payload["status"], "passed")
         self.assertEqual(payload["failures"], [])
         self.assertEqual(payload["observed_overrides"][0]["owner"], "governance")
+
+    def test_verify_fails_when_consumer_profile_omits_required_session_contract_entries(self) -> None:
+        self._deploy(profile="stampede", package_version=self._next_package_version())
+
+        code, stdout, stderr = self._invoke(
+            "--governance-root",
+            str(REPO_ROOT),
+            "--target-repo",
+            str(self.product),
+            "--profile",
+            "stampede",
+            "--governance-ref",
+            self.ref,
+        )
+
+        self.assertEqual(code, 1, stderr)
+        payload = json.loads(stdout)
+        joined = "\n".join(payload["failures"])
+        self.assertIn("managed file missing on disk", joined)
+        self.assertIn("CLAUDE.md", joined)
+        self.assertIn("CODEX.md", joined)
+        self.assertIn("docs/EXTERNAL_SERVICES_RUNBOOK.md", joined)
+        self.assertIn("scripts/codex-review.sh", joined)
+
+    def test_verify_fails_when_consumer_profile_session_contract_content_is_stale(self) -> None:
+        next_version = self._next_package_version()
+        self._deploy(profile="stampede", package_version=next_version)
+        (self.product / "CLAUDE.md").write_text("Thin pointer only\n", encoding="utf-8")
+        (self.product / "CODEX.md").write_text("Orchestrator only\n", encoding="utf-8")
+        runbook = self.product / "docs" / "EXTERNAL_SERVICES_RUNBOOK.md"
+        runbook.parent.mkdir(parents=True, exist_ok=True)
+        runbook.write_text("Local note only\n", encoding="utf-8")
+        review = self.product / "scripts" / "codex-review.sh"
+        review.parent.mkdir(parents=True, exist_ok=True)
+        review.write_text("#!/usr/bin/env bash\n# claude\n", encoding="utf-8")
+
+        code, stdout, stderr = self._invoke(
+            "--governance-root",
+            str(REPO_ROOT),
+            "--target-repo",
+            str(self.product),
+            "--profile",
+            "stampede",
+            "--governance-ref",
+            self.ref,
+        )
+
+        self.assertEqual(code, 1, stderr)
+        payload = json.loads(stdout)
+        joined = "\n".join(payload["failures"])
+        self.assertIn("managed file missing required content", joined)
+        self.assertIn("CLAUDE.md", joined)
+        self.assertIn("CODEX.md", joined)
+        self.assertIn("docs/EXTERNAL_SERVICES_RUNBOOK.md", joined)
 
     def test_verify_fails_for_tracked_session_contract_missing_required_content(self) -> None:
         self._deploy()
@@ -673,8 +735,16 @@ class TestVerifyGovernanceConsumer(unittest.TestCase):
         hook = self.product / ".claude" / "hooks" / "pre-tool-use.sh"
         hook.parent.mkdir(parents=True)
         hook.write_text("# hldpro-governance managed\necho ok\n", encoding="utf-8")
+        claude_md = self.product / "CLAUDE.md"
+        claude_md.write_text("Thin governance pointer to hldpro-governance STANDARDS.md.\n", encoding="utf-8")
         codex = self.product / "CODEX.md"
-        codex.write_text("Codex is the supervisor/orchestrator.\n", encoding="utf-8")
+        codex.write_text("Codex is the supervisor/orchestrator in hldpro-governance.\n", encoding="utf-8")
+        runbook = self.product / "docs" / "EXTERNAL_SERVICES_RUNBOOK.md"
+        runbook.parent.mkdir(parents=True, exist_ok=True)
+        runbook.write_text("See ../hldpro-governance/docs/EXTERNAL_SERVICES_RUNBOOK.md\n", encoding="utf-8")
+        review = self.product / "scripts" / "codex-review.sh"
+        review.parent.mkdir(parents=True, exist_ok=True)
+        review.write_text("#!/usr/bin/env bash\n# claude\n", encoding="utf-8")
         settings = self.product / ".claude" / "settings.json"
         settings.parent.mkdir(parents=True, exist_ok=True)
         settings.write_text(
@@ -700,10 +770,34 @@ class TestVerifyGovernanceConsumer(unittest.TestCase):
         )
         record["managed_files"].append(
             {
+                "path": "CLAUDE.md",
+                "type": "tracked_session_contract",
+                "required_strings": ["hldpro-governance", "STANDARDS.md"],
+                "sha256": hashlib.sha256(claude_md.read_bytes()).hexdigest(),
+            }
+        )
+        record["managed_files"].append(
+            {
                 "path": "CODEX.md",
                 "type": "tracked_session_contract",
-                "required_strings": ["supervisor/orchestrator"],
+                "required_strings": ["hldpro-governance", "supervisor/orchestrator"],
                 "sha256": hashlib.sha256(codex.read_bytes()).hexdigest(),
+            }
+        )
+        record["managed_files"].append(
+            {
+                "path": "docs/EXTERNAL_SERVICES_RUNBOOK.md",
+                "type": "tracked_session_contract",
+                "required_strings": ["hldpro-governance", "EXTERNAL_SERVICES_RUNBOOK.md"],
+                "sha256": hashlib.sha256(runbook.read_bytes()).hexdigest(),
+            }
+        )
+        record["managed_files"].append(
+            {
+                "path": "scripts/codex-review.sh",
+                "type": "tracked_session_contract",
+                "required_strings": ["claude"],
+                "sha256": hashlib.sha256(review.read_bytes()).hexdigest(),
             }
         )
         record["managed_files"].append(

--- a/scripts/overlord/validate_structured_agent_cycle_plan.py
+++ b/scripts/overlord/validate_structured_agent_cycle_plan.py
@@ -49,6 +49,10 @@ GOVERNANCE_SURFACE_FILES = {
 IMPLEMENTATION_READY_MODES = {"implementation_ready", "implementation_complete"}
 ACCEPTED_REVIEW_STATES = {"accepted", "accepted_with_followup"}
 IMPLEMENTATION_READY_REVIEW_GATE_APPROVED_AT = "2026-04-28T19:00:00Z"
+ALTERNATE_REVIEW_EXEMPTION_TYPES = {
+    "historical_grandfathered",
+    "alternate_service_outage",
+}
 PLANNING_EVIDENCE_PREFIXES = (
     "docs/plans/",
     "raw/closeouts/",
@@ -138,6 +142,143 @@ def _matching_execution_scopes(root: Path, issue_number: int | None, mode: str) 
     if not scope_root.is_dir():
         return []
     return sorted(scope_root.glob(f"*issue-{issue_number}*{mode}*.json"))
+
+
+def _require_identity(
+    value: object,
+    path: Path,
+    field_name: str,
+    failures: list[str],
+) -> dict[str, str] | None:
+    if not isinstance(value, dict):
+        failures.append(f"{path}: `{field_name}` must be an object")
+        return None
+    required_keys = ("role", "model_id", "model_family")
+    for key in required_keys:
+        raw = value.get(key)
+        if not isinstance(raw, str) or not raw.strip():
+            failures.append(f"{path}: `{field_name}.{key}` must be a non-empty string")
+            return None
+    return {
+        "role": str(value["role"]).strip(),
+        "model_id": str(value["model_id"]).strip(),
+        "model_family": str(value["model_family"]).strip(),
+    }
+
+
+def _require_repo_ref_array(
+    value: object,
+    path: Path,
+    field_name: str,
+    failures: list[str],
+    *,
+    allow_empty: bool,
+    required_prefix: str | None = None,
+) -> list[str]:
+    if not isinstance(value, list):
+        failures.append(f"{path}: `{field_name}` must be an array")
+        return []
+    refs = [item for item in value if isinstance(item, str) and item.strip()]
+    if len(refs) != len(value):
+        failures.append(f"{path}: `{field_name}` entries must be non-empty strings")
+        return []
+    if not allow_empty and not refs:
+        failures.append(f"{path}: requires non-empty `{field_name}`")
+        return []
+    if required_prefix is not None:
+        invalid = [ref for ref in refs if not ref.startswith(required_prefix)]
+        if invalid:
+            failures.append(
+                f"{path}: `{field_name}` must reference `{required_prefix}...`, got {', '.join(invalid)}"
+            )
+    return refs
+
+
+def _validate_alternate_review_exemption(path: Path, review: dict[str, object], failures: list[str]) -> None:
+    exemption = review.get("exemption")
+    if not isinstance(exemption, dict):
+        failures.append(f"{path}: `alternate_model_review.exemption` must be present when `required` is false")
+        return
+    exemption_type = exemption.get("exemption_type")
+    if exemption_type not in ALTERNATE_REVIEW_EXEMPTION_TYPES:
+        failures.append(
+            f"{path}: `alternate_model_review.exemption.exemption_type` must be one of {sorted(ALTERNATE_REVIEW_EXEMPTION_TYPES)}"
+        )
+    granted_by = exemption.get("granted_by")
+    if not isinstance(granted_by, str) or not granted_by.strip():
+        failures.append(f"{path}: `alternate_model_review.exemption.granted_by` must be a non-empty string")
+    expires_at = exemption.get("expires_at")
+    if not isinstance(expires_at, str) or not expires_at.strip():
+        failures.append(f"{path}: `alternate_model_review.exemption.expires_at` must be a non-empty RFC3339 timestamp")
+    rationale = exemption.get("rationale")
+    if not isinstance(rationale, str) or not rationale.strip():
+        failures.append(f"{path}: `alternate_model_review.exemption.rationale` must be a non-empty string")
+    status = review.get("status")
+    if exemption_type == "alternate_service_outage" and status != "unavailable":
+        failures.append(
+            f"{path}: `alternate_model_review.status` must be 'unavailable' when exemption_type is 'alternate_service_outage'"
+        )
+    if exemption_type == "historical_grandfathered" and status != "not_requested":
+        failures.append(
+            f"{path}: `alternate_model_review.status` must be 'not_requested' when exemption_type is 'historical_grandfathered'"
+        )
+
+
+def _validate_active_issue_branch_contract(path: Path, payload: dict[str, object], failures: list[str]) -> None:
+    plan_author = _require_identity(payload.get("plan_author"), path, "plan_author", failures)
+
+    specialist_reviews = payload.get("specialist_reviews")
+    accepted_specialist_reviews = 0
+    if isinstance(specialist_reviews, list):
+        for index, review in enumerate(specialist_reviews, start=1):
+            if not isinstance(review, dict):
+                continue
+            if review.get("status") not in ACCEPTED_REVIEW_STATES:
+                continue
+            accepted_specialist_reviews += 1
+            identity = _require_identity(
+                {
+                    "role": review.get("role"),
+                    "model_id": review.get("reviewer_model_id"),
+                    "model_family": review.get("reviewer_model_family"),
+                },
+                path,
+                f"specialist_reviews[{index}] reviewer identity",
+                failures,
+            )
+            if plan_author and identity:
+                if (
+                    identity["model_id"] == plan_author["model_id"]
+                    and identity["model_family"] == plan_author["model_family"]
+                ):
+                    failures.append(
+                        f"{path}: specialist_reviews[{index}] cannot self-approve with the same model identity as `plan_author`"
+                    )
+
+    alternate_review = payload.get("alternate_model_review")
+    if isinstance(alternate_review, dict) and alternate_review.get("required") is False:
+        _validate_alternate_review_exemption(path, alternate_review, failures)
+
+    execution_handoff = payload.get("execution_handoff")
+    if not isinstance(execution_handoff, dict):
+        return
+    handoff_ref = execution_handoff.get("handoff_package_ref")
+    if not isinstance(handoff_ref, str) or not handoff_ref.strip():
+        failures.append(f"{path}: active issue-branch plans require a non-null `execution_handoff.handoff_package_ref`")
+
+    accepted_alternate_review = (
+        isinstance(alternate_review, dict) and alternate_review.get("status") in ACCEPTED_REVIEW_STATES
+    )
+    mode = execution_handoff.get("execution_mode")
+    review_refs_required = accepted_specialist_reviews > 0 or accepted_alternate_review or mode in IMPLEMENTATION_READY_MODES
+    _require_repo_ref_array(
+        execution_handoff.get("review_artifact_refs"),
+        path,
+        "execution_handoff.review_artifact_refs",
+        failures,
+        allow_empty=not review_refs_required,
+        required_prefix="raw/cross-review/",
+    )
 
 
 def _validate_planner_boundary_scope_presence(
@@ -382,6 +523,8 @@ def main() -> int:
             if rel_path in governance_validated_paths:
                 continue
             _validate_implementation_ready_alternate_review(rel_path, payload, failures, scope="implementation")
+            if isinstance(payload, dict):
+                _validate_active_issue_branch_contract(rel_path, payload, failures)
 
     for file_path, payload in loaded_plans:
         if payload is not None:

--- a/scripts/overlord/verify_governance_consumer.py
+++ b/scripts/overlord/verify_governance_consumer.py
@@ -157,6 +157,11 @@ def _profile_desired_state(desired_state: dict[str, Any], profile: str) -> dict[
     return profile_state if isinstance(profile_state, dict) else {}
 
 
+def _profile_package_version(profile_state: dict[str, Any]) -> str:
+    value = profile_state.get("package_version")
+    return value if isinstance(value, str) and value else ""
+
+
 def _profile_contract(manifest: dict[str, Any]) -> dict[str, Any]:
     contract = manifest.get("profile_contract")
     return contract if isinstance(contract, dict) else {}
@@ -216,11 +221,25 @@ def _record_constraints(payload: dict[str, Any]) -> set[str]:
     return set()
 
 
-def _expected_managed_paths(profile_state: dict[str, Any]) -> set[str]:
+def _expected_managed_entries(profile_state: dict[str, Any]) -> list[dict[str, Any]]:
     raw = profile_state.get("managed_files")
-    if isinstance(raw, list) and all(isinstance(item, str) for item in raw):
-        return set(raw)
-    return {".hldpro/local-ci.sh", ".hldpro/governance-tooling.json"}
+    if not isinstance(raw, list):
+        return [
+            {"path": ".hldpro/local-ci.sh", "type": "local_ci_shim"},
+            {"path": ".hldpro/governance-tooling.json", "type": "consumer_record"},
+        ]
+    entries: list[dict[str, Any]] = []
+    for item in raw:
+        if isinstance(item, str) and item:
+            entries.append({"path": item})
+        elif isinstance(item, dict) and isinstance(item.get("path"), str) and item["path"]:
+            entries.append(dict(item))
+    if entries:
+        return entries
+    return [
+        {"path": ".hldpro/local-ci.sh", "type": "local_ci_shim"},
+        {"path": ".hldpro/governance-tooling.json", "type": "consumer_record"},
+    ]
 
 
 def _managed_paths(record: dict[str, Any]) -> set[str]:
@@ -232,6 +251,14 @@ def _managed_paths(record: dict[str, Any]) -> set[str]:
         if isinstance(item, dict) and isinstance(item.get("path"), str):
             paths.add(item["path"])
     return paths
+
+
+def _string_list_or_none(value: Any) -> list[str] | None:
+    if value is None:
+        return None
+    if isinstance(value, list) and all(isinstance(item, str) for item in value):
+        return value
+    return []
 
 
 def _managed_file_type(record: dict[str, Any], relpath: str) -> str:
@@ -252,6 +279,25 @@ def _managed_file_entry(record: dict[str, Any], relpath: str) -> dict[str, Any]:
         if isinstance(item, dict) and item.get("path") == relpath:
             return item
     return {}
+
+
+def _expected_entry_failures(expected: dict[str, Any], actual: dict[str, Any], relpath: str) -> list[str]:
+    failures: list[str] = []
+    expected_type = expected.get("type")
+    if isinstance(expected_type, str) and expected_type:
+        actual_type = actual.get("type")
+        if actual_type != expected_type:
+            failures.append(f"managed file type mismatch for {relpath}: expected {expected_type}, got {actual_type}")
+    for field in ("required_strings", "required_pre_tool_use_matchers", "required_post_tool_use_matchers"):
+        expected_values = _string_list_or_none(expected.get(field))
+        if expected_values is None:
+            continue
+        actual_values = _string_list(actual.get(field))
+        if actual_values != expected_values:
+            failures.append(
+                f"managed file metadata mismatch for {relpath}: expected {field}={expected_values}, got {actual_values}"
+            )
+    return failures
 
 
 def _string_list(value: Any) -> list[str]:
@@ -460,7 +506,8 @@ def _validate_record(
         failures.append(f"unknown profile: {profile}")
 
     package_version = payload.get("package_version")
-    expected_version = expected_package_version or _initial_package_version(manifest)
+    profile_state = _profile_desired_state(desired_state, profile)
+    expected_version = expected_package_version or _profile_package_version(profile_state) or _initial_package_version(manifest)
     if package_version != expected_version:
         failures.append(f"package_version mismatch: expected {expected_version}, got {package_version}")
 
@@ -477,12 +524,19 @@ def _validate_record(
     if isinstance(consumer_repo, str) and Path(consumer_repo).resolve(strict=False) != target_repo:
         warnings.append(f"consumer_repo path differs from target repo: {consumer_repo}")
 
-    profile_state = _profile_desired_state(desired_state, profile)
-    expected_paths = _expected_managed_paths(profile_state)
+    expected_entries = _expected_managed_entries(profile_state)
+    expected_paths = {entry["path"] for entry in expected_entries if isinstance(entry.get("path"), str)}
     actual_paths = _managed_paths(payload)
     missing_paths = sorted(expected_paths - actual_paths)
     if missing_paths:
         failures.append(f"managed_files missing expected path(s): {', '.join(missing_paths)}")
+    expected_by_path = {
+        entry["path"]: entry for entry in expected_entries if isinstance(entry.get("path"), str)
+    }
+    for relpath, expected_entry in expected_by_path.items():
+        actual_entry = _managed_file_entry(payload, relpath)
+        if actual_entry:
+            failures.extend(_expected_entry_failures(expected_entry, actual_entry, relpath))
 
     for relpath in sorted(actual_paths):
         candidate = (target_repo / relpath).resolve()


### PR DESCRIPTION
## Summary
- hard-gate issue-level SoM packet validation against self-review, illegal alternate-review bypass, and missing review/handoff evidence
- hard-gate governed consumer records and reusable CI on thin session-contract surfaces instead of adapter presence alone
- record issue-583 packet, cross-review, validation, closeout, and graphify writeback evidence

## Proof
- `python3 -m unittest scripts.overlord.test_validate_structured_agent_cycle_plan scripts.overlord.test_validate_handoff_package scripts.overlord.test_verify_governance_consumer scripts.overlord.test_deploy_governance_tooling`
- `python3 tools/local-ci-gate/bin/hldpro-local-ci run --profile hldpro-governance --json`
- `python3 scripts/overlord/verify_governance_consumer.py --governance-root . --target-repo /Users/bennibarger/Developer/HLDPRO/Stampede`
- `python3 scripts/overlord/validate_structured_agent_cycle_plan.py --root . --branch-name issue-583-hard-gated-som-enforcement --require-if-issue-branch`
- `python3 scripts/overlord/validate_handoff_package.py --root . raw/handoffs/2026-04-29-issue-583-hard-gated-som-enforcement.json`
- `python3 scripts/overlord/validate_closeout.py --root . raw/closeouts/2026-04-29-issue-583-hard-gated-som-enforcement.md`
- `bash scripts/cross-review/require-dual-signature.sh raw/cross-review/2026-04-29-issue-583-hard-gated-som-enforcement.md`
- `git diff --check`

## Key downstream replay
- Live Stampede issue-184 packet shape now fails the hardened structured-plan validator.
- Live Stampede consumer record now fails the hardened consumer verifier on stale package version and missing `CLAUDE.md`, `CODEX.md`, `docs/EXTERNAL_SERVICES_RUNBOOK.md`, and `scripts/codex-review.sh` entries.
